### PR TITLE
Remove user logic, use password environment variable

### DIFF
--- a/doc/architecture.d2
+++ b/doc/architecture.d2
@@ -47,7 +47,7 @@ server: Home Server {
     sqlite: SQLite {
       sessions: Sessions
       messages: Messages
-      users: Users
+      authSessions: AuthSessions
     }
 
     filesystem: Filesystem {
@@ -92,12 +92,14 @@ data_model: Data Model {
     createdAt: timestamp
   }
 
-  user: User {
+  authSession: AuthSession {
     shape: sql_table
     id: string {constraint: primary_key}
-    username: string
-    passwordHash: string
-    totpSecret: string | null
+    token: string
+    expiresAt: timestamp
+    createdAt: timestamp
+    ipAddress: string | null
+    userAgent: string | null
   }
 
   session.id <- message.sessionId
@@ -109,8 +111,10 @@ api: tRPC API {
 
   auth_routes: auth {
     login: login()
-    verify: verifyTwoFactor()
     logout: logout()
+    logoutAll: logoutAll()
+    listSessions: listSessions()
+    deleteSession: deleteSession()
   }
 
   session_routes: sessions {

--- a/prisma/migrations/20260120023808_remove_user_model_simplify_auth/migration.sql
+++ b/prisma/migrations/20260120023808_remove_user_model_simplify_auth/migration.sql
@@ -1,0 +1,34 @@
+/*
+  Warnings:
+
+  - You are about to drop the `User` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the column `userId` on the `AuthSession` table. All the data in the column will be lost.
+
+*/
+-- DropIndex
+DROP INDEX "User_username_key";
+
+-- DropTable
+PRAGMA foreign_keys=off;
+DROP TABLE "User";
+PRAGMA foreign_keys=on;
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_AuthSession" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "token" TEXT NOT NULL,
+    "expiresAt" DATETIME NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "ipAddress" TEXT,
+    "userAgent" TEXT
+);
+INSERT INTO "new_AuthSession" ("createdAt", "expiresAt", "id", "token") SELECT "createdAt", "expiresAt", "id", "token" FROM "AuthSession";
+DROP TABLE "AuthSession";
+ALTER TABLE "new_AuthSession" RENAME TO "AuthSession";
+CREATE UNIQUE INDEX "AuthSession_token_key" ON "AuthSession"("token");
+CREATE INDEX "AuthSession_token_idx" ON "AuthSession"("token");
+CREATE INDEX "AuthSession_expiresAt_idx" ON "AuthSession"("expiresAt");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,23 +7,13 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-model User {
-  id           String        @id @default(uuid())
-  username     String        @unique
-  passwordHash String
-  createdAt    DateTime      @default(now())
-  updatedAt    DateTime      @updatedAt
-  authSessions AuthSession[]
-}
-
 model AuthSession {
   id        String   @id @default(uuid())
   token     String   @unique
-  userId    String
   expiresAt DateTime
   createdAt DateTime @default(now())
-
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  ipAddress String?
+  userAgent String?
 
   @@index([token])
   @@index([expiresAt])

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,41 +1,25 @@
 'use client';
 
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { trpc } from '@/lib/trpc';
 import { useAuth } from '@/lib/auth-context';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Spinner } from '@/components/ui/spinner';
 
 export default function LoginPage() {
   const router = useRouter();
-  const { login, user } = useAuth();
-  const [username, setUsername] = useState('');
+  const { login, isAuthenticated } = useAuth();
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
 
-  const { data: setupData, isLoading: setupLoading } = trpc.auth.needsSetup.useQuery();
-
-  // If no users exist yet, show registration form
-  const isRegistering = useMemo(() => setupData?.needsSetup ?? false, [setupData]);
-
   const loginMutation = trpc.auth.login.useMutation({
     onSuccess: (data) => {
-      login(data.token, data.user);
-      router.push('/');
-    },
-    onError: (err) => {
-      setError(err.message);
-    },
-  });
-
-  const registerMutation = trpc.auth.register.useMutation({
-    onSuccess: (data) => {
-      login(data.token, data.user);
+      login(data.token);
       router.push('/');
     },
     onError: (err) => {
@@ -44,31 +28,16 @@ export default function LoginPage() {
   });
 
   useEffect(() => {
-    if (user) {
+    if (isAuthenticated) {
       router.push('/');
     }
-  }, [user, router]);
+  }, [isAuthenticated, router]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
-
-    if (isRegistering) {
-      registerMutation.mutate({ username, password });
-    } else {
-      loginMutation.mutate({ username, password });
-    }
+    loginMutation.mutate({ password });
   };
-
-  const isSubmitting = loginMutation.isPending || registerMutation.isPending;
-
-  if (setupLoading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <Spinner size="lg" />
-      </div>
-    );
-  }
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-background py-12 px-4 sm:px-6 lg:px-8">
@@ -79,10 +48,7 @@ export default function LoginPage() {
 
         <Card>
           <CardHeader>
-            <CardTitle>{isRegistering ? 'Create your account' : 'Sign in'}</CardTitle>
-            {setupData?.needsSetup && (
-              <CardDescription>No users exist yet. Create the first admin account.</CardDescription>
-            )}
+            <CardTitle>Sign in</CardTitle>
           </CardHeader>
           <CardContent>
             <form onSubmit={handleSubmit} className="space-y-4">
@@ -93,42 +59,25 @@ export default function LoginPage() {
               )}
 
               <div className="space-y-2">
-                <Label htmlFor="username">Username</Label>
-                <Input
-                  id="username"
-                  name="username"
-                  type="text"
-                  autoComplete="username"
-                  required
-                  value={username}
-                  onChange={(e) => setUsername(e.target.value)}
-                  placeholder="Enter your username"
-                />
-              </div>
-
-              <div className="space-y-2">
                 <Label htmlFor="password">Password</Label>
                 <Input
                   id="password"
                   name="password"
                   type="password"
-                  autoComplete={isRegistering ? 'new-password' : 'current-password'}
+                  autoComplete="current-password"
                   required
-                  minLength={isRegistering ? 8 : undefined}
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
-                  placeholder={isRegistering ? 'At least 8 characters' : 'Enter your password'}
+                  placeholder="Enter your password"
                 />
               </div>
 
-              <Button type="submit" className="w-full" disabled={isSubmitting}>
-                {isSubmitting ? (
+              <Button type="submit" className="w-full" disabled={loginMutation.isPending}>
+                {loginMutation.isPending ? (
                   <span className="flex items-center gap-2">
                     <Spinner size="sm" className="text-primary-foreground" />
-                    {isRegistering ? 'Creating account...' : 'Signing in...'}
+                    Signing in...
                   </span>
-                ) : isRegistering ? (
-                  'Create account'
                 ) : (
                   'Sign in'
                 )}

--- a/src/components/AuthGuard.tsx
+++ b/src/components/AuthGuard.tsx
@@ -6,14 +6,14 @@ import { useAuth } from '@/lib/auth-context';
 import { Spinner } from '@/components/ui/spinner';
 
 export function AuthGuard({ children }: { children: React.ReactNode }) {
-  const { user, isLoading } = useAuth();
+  const { isAuthenticated, isLoading } = useAuth();
   const router = useRouter();
 
   useEffect(() => {
-    if (!isLoading && !user) {
+    if (!isLoading && !isAuthenticated) {
       router.push('/login');
     }
-  }, [user, isLoading, router]);
+  }, [isAuthenticated, isLoading, router]);
 
   if (isLoading) {
     return (
@@ -23,7 +23,7 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
     );
   }
 
-  if (!user) {
+  if (!isAuthenticated) {
     return null;
   }
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,7 +5,7 @@ import { useAuth } from '@/lib/auth-context';
 import { Button } from '@/components/ui/button';
 
 export function Header() {
-  const { user, logout } = useAuth();
+  const { isAuthenticated, logout } = useAuth();
 
   return (
     <header className="bg-background border-b">
@@ -15,13 +15,10 @@ export function Header() {
             <span className="text-xl font-bold">Claude Code Local Web</span>
           </Link>
 
-          {user && (
-            <div className="flex items-center space-x-4">
-              <span className="text-sm text-muted-foreground">{user.username}</span>
-              <Button variant="ghost" size="sm" onClick={logout}>
-                Sign out
-              </Button>
-            </div>
+          {isAuthenticated && (
+            <Button variant="ghost" size="sm" onClick={logout}>
+              Sign out
+            </Button>
           )}
         </div>
       </div>

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -6,7 +6,6 @@ const TOKEN_LENGTH = 32; // 256 bits of entropy
 export const SESSION_DURATION_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 export const loginSchema = z.object({
-  username: z.string().min(1, 'Username is required'),
   password: z.string().min(1, 'Password is required'),
 });
 

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -13,6 +13,9 @@ const envSchema = z.object({
   NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
   // Prefix for session branches in worktrees (e.g., "claude/" creates "claude/{sessionId}")
   SESSION_BRANCH_PREFIX: z.string().default('claude/'),
+  // Argon2-hashed password for authentication (generate with: node -e "require('argon2').hash('yourpassword').then(console.log)")
+  // No default - logins will fail if not set
+  PASSWORD_HASH: z.string().optional(),
 });
 
 export type Env = z.infer<typeof envSchema>;


### PR DESCRIPTION
Since this is a single-user app (owner of local machine), remove the User model and use PASSWORD_HASH environment variable for authentication.

Changes:
- Remove User model from Prisma schema
- Add PASSWORD_HASH env var (Argon2-hashed, no default - logins fail if unset)
- Update AuthSession to track IP address and user agent for audit logging
- Simplify login to just password (no username)
- Add listSessions/deleteSession endpoints for session management
- Remove registration flow entirely
- Update README with password hash generation instructions
- Update design docs to reflect new auth model