### PR TITLE
Add HookResponseDisplay component for nicely formatted hook messages

### DIFF
--- a/src/components/messages/HookResponseDisplay.tsx
+++ b/src/components/messages/HookResponseDisplay.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import { Badge } from '@/components/ui/badge';
+import { CopyButton } from './CopyButton';
+import { formatAsJson } from './types';
+import type { MessageContent } from './types';
+
+interface HookResponseContent extends MessageContent {
+  hook_name?: string;
+  hook_event?: string;
+  stdout?: string;
+  stderr?: string;
+  exit_code?: number;
+}
+
+/**
+ * Display for hook response messages showing hook execution results.
+ */
+export function HookResponseDisplay({ content }: { content: HookResponseContent }) {
+  const [expanded, setExpanded] = useState(false);
+  const getJsonText = useCallback(() => formatAsJson(content), [content]);
+
+  const hasError = content.exit_code !== 0;
+  const hasOutput = content.stdout || content.stderr;
+
+  // Extract a readable hook name (e.g., "SessionStart:resume" -> "Session Start (resume)")
+  const formatHookName = (name?: string) => {
+    if (!name) return 'Unknown Hook';
+    // Split on colon for event:action format
+    const [event, action] = name.split(':');
+    // Add spaces before capitals (e.g., SessionStart -> Session Start)
+    const formattedEvent = event.replace(/([a-z])([A-Z])/g, '$1 $2');
+    return action ? `${formattedEvent} (${action})` : formattedEvent;
+  };
+
+  return (
+    <div className="group">
+      <Collapsible open={expanded} onOpenChange={setExpanded}>
+        <CollapsibleTrigger className="w-full text-left flex items-center gap-2 text-sm hover:bg-muted/50 rounded p-2">
+          <Badge variant={hasError ? 'destructive' : 'secondary'}>
+            {hasError ? 'Hook Failed' : 'Hook'}
+          </Badge>
+          <span className="text-muted-foreground text-xs">{formatHookName(content.hook_name)}</span>
+          {hasError && (
+            <span className="text-xs text-red-500 dark:text-red-400">
+              Exit code: {content.exit_code}
+            </span>
+          )}
+          {hasOutput && (
+            <span className="text-muted-foreground ml-auto">{expanded ? '−' : '+'}</span>
+          )}
+        </CollapsibleTrigger>
+
+        {hasOutput && (
+          <CollapsibleContent>
+            <div className="p-3 space-y-2 text-xs bg-muted/50 rounded mt-1">
+              {content.stdout && (
+                <div>
+                  <span className="text-muted-foreground font-medium">stdout:</span>
+                  <pre className="mt-1 p-2 bg-background rounded font-mono text-xs whitespace-pre-wrap break-all">
+                    {content.stdout}
+                  </pre>
+                </div>
+              )}
+              {content.stderr && (
+                <div>
+                  <span className="text-red-500 dark:text-red-400 font-medium">stderr:</span>
+                  <pre className="mt-1 p-2 bg-red-50 dark:bg-red-950 rounded font-mono text-xs whitespace-pre-wrap break-all text-red-700 dark:text-red-300">
+                    {content.stderr}
+                  </pre>
+                </div>
+              )}
+            </div>
+          </CollapsibleContent>
+        )}
+      </Collapsible>
+      <div className="mt-1">
+        <CopyButton getText={getJsonText} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/messages/MessageBubble.tsx
+++ b/src/components/messages/MessageBubble.tsx
@@ -12,6 +12,7 @@ import { ToolCallDisplay } from './ToolCallDisplay';
 import { ToolResultDisplay } from './ToolResultDisplay';
 import { SystemInitDisplay } from './SystemInitDisplay';
 import { ResultDisplay } from './ResultDisplay';
+import { HookResponseDisplay } from './HookResponseDisplay';
 import { formatAsJson } from './types';
 import type { ToolResultMap, ContentBlock, MessageContent } from './types';
 
@@ -157,6 +158,7 @@ function isRecognizedMessage(
         | 'system'
         | 'systemInit'
         | 'systemError'
+        | 'hookResponse'
         | 'result';
     }
   | { recognized: false } {
@@ -200,6 +202,11 @@ function isRecognizedMessage(
       return { recognized: true, category: 'systemError' };
     }
     return { recognized: false };
+  }
+
+  // Hook response messages
+  if (type === 'system' && content.subtype === 'hook_response') {
+    return { recognized: true, category: 'hookResponse' };
   }
 
   // Other system messages
@@ -276,6 +283,15 @@ export function MessageBubble({
     return (
       <div className="w-full max-w-[85%]">
         <SystemInitDisplay content={content} />
+      </div>
+    );
+  }
+
+  // Hook response messages get their own compact display
+  if (category === 'hookResponse') {
+    return (
+      <div className="w-full max-w-[85%]">
+        <HookResponseDisplay content={content} />
       </div>
     );
   }

--- a/src/components/messages/index.ts
+++ b/src/components/messages/index.ts
@@ -9,6 +9,7 @@ export { ToolCallDisplay } from './ToolCallDisplay';
 export { ToolResultDisplay } from './ToolResultDisplay';
 export { SystemInitDisplay } from './SystemInitDisplay';
 export { ResultDisplay } from './ResultDisplay';
+export { HookResponseDisplay } from './HookResponseDisplay';
 
 export type { ToolResultMap, ToolCall, ContentBlock, MessageContent, TodoItem } from './types';
 export { formatAsJson } from './types';


### PR DESCRIPTION
## Summary
- Adds a new `HookResponseDisplay` component to nicely format hook response messages
- Shows hook name (e.g., "Session Start (resume)") and exit code in a compact collapsible format
- Displays stderr in red styling for failed hooks
- Both stdout and stderr can be expanded when present

Fixes #11

## Test plan
- [ ] Create a session with a hook configured that produces output
- [ ] Verify hook response messages display with the new compact format
- [ ] Verify failed hooks show red "Hook Failed" badge and exit code
- [ ] Verify stdout/stderr can be expanded and display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)