### PR TITLE
Open links in chat messages in new windows

### DIFF
--- a/src/components/MarkdownContent.tsx
+++ b/src/components/MarkdownContent.tsx
@@ -1,17 +1,25 @@
 'use client';
 
 import { useMemo } from 'react';
-import { marked } from 'marked';
+import { marked, Renderer } from 'marked';
 
 interface MarkdownContentProps {
   content: string;
   className?: string;
 }
 
+// Create custom renderer that opens links in new windows
+const renderer = new Renderer();
+renderer.link = ({ href, title, text }) => {
+  const titleAttr = title ? ` title="${title}"` : '';
+  return `<a href="${href}"${titleAttr} target="_blank" rel="noopener noreferrer">${text}</a>`;
+};
+
 // Configure marked options
 marked.setOptions({
   gfm: true, // GitHub Flavored Markdown
   breaks: true, // Convert \n to <br>
+  renderer,
 });
 
 export function MarkdownContent({ content, className = '' }: MarkdownContentProps) {


### PR DESCRIPTION
## Summary
- Configure a custom marked renderer in `MarkdownContent` component to add `target="_blank"` and `rel="noopener noreferrer"` to all links
- Links in chat messages now open in new browser windows/tabs instead of navigating away from the app

## Test plan
- [ ] Send a message containing a markdown link and verify it opens in a new tab
- [ ] Verify existing markdown rendering still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)