### PR TITLE
Add GitHub issues integration for session creation

### DIFF
--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -49,6 +49,7 @@ interface Session {
   containerId: string | null; // Docker container ID when running
   status: 'creating' | 'running' | 'stopped' | 'error';
   statusMessage: string | null; // Progress message during creation or error details
+  initialPrompt: string | null; // Optional prompt to auto-send when session starts (e.g., from GitHub issue)
   createdAt: Date;
   updatedAt: Date;
 }
@@ -77,6 +78,22 @@ interface AuthSession {
   createdAt: Date;
   ipAddress: string | null; // For audit logging
   userAgent: string | null; // For audit logging
+}
+```
+
+### Issue
+
+```typescript
+interface Issue {
+  id: number;
+  number: number;
+  title: string;
+  body: string | null;
+  state: 'open' | 'closed';
+  author: string;
+  labels: Array<{ name: string; color: string }>;
+  createdAt: string;
+  updatedAt: string;
 }
 ```
 
@@ -114,6 +131,20 @@ github.listRepos({ search?: string, cursor?: string })
 
 github.listBranches({ repoFullName: string })
   → { branches: Branch[], defaultBranch: string }
+
+github.listIssues({
+  repoFullName: string,
+  search?: string,
+  state?: 'open' | 'closed' | 'all',  // default: 'open'
+  cursor?: string,
+  perPage?: number
+})
+  → { issues: Issue[], nextCursor?: string }
+  // Lists issues for a repository with optional search and pagination
+
+github.getIssue({ repoFullName: string, issueNumber: number })
+  → { issue: Issue }
+  // Get full details of a specific issue
 ```
 
 ### Session Management
@@ -122,12 +153,14 @@ github.listBranches({ repoFullName: string })
 sessions.create({
   name: string,
   repoFullName: string,    // e.g., "brendanlong/math-llm"
-  branch: string
+  branch: string,
+  initialPrompt?: string   // Optional prompt to auto-send when session starts
 })
   → { session: Session }
   // Returns immediately with session in "creating" status
   // Cloning and container setup continues in background
   // UI polls session.get() to track progress via statusMessage
+  // If initialPrompt is provided, it will be sent automatically when session becomes running
 
 sessions.list({ status?: SessionStatus })
   → { sessions: Session[] }
@@ -398,7 +431,11 @@ ORDER BY sequence ASC;
 
 - Search/select GitHub repo
 - Select branch (defaults to default branch)
-- Name the session
+- Optional: Select a GitHub issue to work on
+  - Searchable dropdown with open issues
+  - When selected, auto-fills session name with issue title
+  - Generates initial prompt asking Claude to fix the issue
+- Name the session (auto-filled from issue if selected)
 - Create button
 
 ### Session View (Chat)

--- a/prisma/migrations/20260120061932_add_initial_prompt/migration.sql
+++ b/prisma/migrations/20260120061932_add_initial_prompt/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Session" ADD COLUMN "initialPrompt" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,6 +28,7 @@ model Session {
   containerId   String?
   status        String         @default("creating") // creating, running, stopped, error
   statusMessage String?        // Human-readable progress message during creation
+  initialPrompt String?        // Optional prompt to send when session starts (e.g., from GitHub issue)
   createdAt     DateTime       @default(now())
   updatedAt     DateTime       @updatedAt
   messages      Message[]

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -28,6 +28,7 @@ export interface Session {
   containerId: string | null;
   status: SessionStatus;
   statusMessage: string | null;
+  initialPrompt: string | null;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -40,4 +41,17 @@ export interface Message {
   type: MessageType;
   content: string;
   createdAt: Date;
+}
+
+// GitHub Issue interface
+export interface Issue {
+  id: number;
+  number: number;
+  title: string;
+  body: string | null;
+  state: 'open' | 'closed';
+  author: string;
+  labels: Array<{ name: string; color: string }>;
+  createdAt: string;
+  updatedAt: string;
 }

--- a/src/server/routers/sessions.ts
+++ b/src/server/routers/sessions.ts
@@ -71,6 +71,7 @@ export const sessionsRouter = router({
         name: z.string().min(1).max(100),
         repoFullName: z.string().regex(/^[\w-]+\/[\w.-]+$/),
         branch: z.string().min(1),
+        initialPrompt: z.string().max(100000).optional(),
       })
     )
     .mutation(async ({ input }) => {
@@ -85,6 +86,7 @@ export const sessionsRouter = router({
           workspacePath: '', // Will be updated after clone
           status: 'creating',
           statusMessage: 'Cloning repository...',
+          initialPrompt: input.initialPrompt || null,
         },
       });
 


### PR DESCRIPTION
## Summary

- Add ability to select a GitHub issue when creating a new session
- When an issue is selected, the session name is auto-filled with the issue title
- An initial prompt is automatically generated and sent to Claude when the session starts
- The prompt includes full issue context (title, body, labels, URL) and instructions to fix, commit, and push

## Changes

- **New API endpoints**: `github.listIssues` and `github.getIssue` for fetching repository issues with search and pagination
- **New `IssueSelector` component**: Searchable dropdown showing open issues with labels
- **Session `initialPrompt` field**: Stores the prompt to auto-send when session becomes running
- **Auto-send logic**: Session page detects transition from "creating" to "running" and sends the initial prompt

## Test plan

- [ ] Create a new session without selecting an issue - should work as before
- [ ] Create a new session and select an issue - session name should auto-fill
- [ ] Verify the initial prompt is sent automatically when the session starts
- [ ] Test issue search functionality
- [ ] Test "Load more" pagination for issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)