### PR TITLE
Consolidate copy buttons for tool messages

### DIFF
--- a/src/components/messages/EditDisplay.tsx
+++ b/src/components/messages/EditDisplay.tsx
@@ -1,12 +1,10 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState } from 'react';
 import { cn } from '@/lib/utils';
 import { Card, CardContent } from '@/components/ui/card';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { Badge } from '@/components/ui/badge';
-import { CopyButton } from './CopyButton';
-import { formatAsJson, buildToolMessages } from './types';
 import type { ToolCall } from './types';
 
 interface EditInput {
@@ -33,12 +31,6 @@ export function EditDisplay({ tool }: { tool: ToolCall }) {
 
   // Extract just the filename for the header
   const fileName = filePath.split('/').pop() ?? filePath;
-
-  // Build copy text with both tool call and result as an array of messages
-  const getCopyText = useCallback(() => {
-    const messages = buildToolMessages(tool);
-    return formatAsJson(messages);
-  }, [tool]);
 
   return (
     <div className="group">
@@ -133,9 +125,6 @@ export function EditDisplay({ tool }: { tool: ToolCall }) {
           </CollapsibleContent>
         </Card>
       </Collapsible>
-      <div className="mt-1">
-        <CopyButton getText={getCopyText} />
-      </div>
     </div>
   );
 }

--- a/src/components/messages/GlobDisplay.tsx
+++ b/src/components/messages/GlobDisplay.tsx
@@ -1,12 +1,10 @@
 'use client';
 
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import { cn } from '@/lib/utils';
 import { Card, CardContent } from '@/components/ui/card';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { Badge } from '@/components/ui/badge';
-import { CopyButton } from './CopyButton';
-import { formatAsJson, buildToolMessages } from './types';
 import type { ToolCall } from './types';
 
 interface GlobInput {
@@ -77,12 +75,6 @@ export function GlobDisplay({ tool }: { tool: ToolCall }) {
   }, [tool.output]);
 
   const groupedFiles = useMemo(() => groupByDirectory(files), [files]);
-
-  // Build copy text with both tool call and result as an array of messages
-  const getCopyText = useCallback(() => {
-    const messages = buildToolMessages(tool);
-    return formatAsJson(messages);
-  }, [tool]);
 
   // File icon component
   const FileIcon = () => (
@@ -215,9 +207,6 @@ export function GlobDisplay({ tool }: { tool: ToolCall }) {
           </CollapsibleContent>
         </Card>
       </Collapsible>
-      <div className="mt-1">
-        <CopyButton getText={getCopyText} />
-      </div>
     </div>
   );
 }

--- a/src/components/messages/TodoWriteDisplay.tsx
+++ b/src/components/messages/TodoWriteDisplay.tsx
@@ -1,12 +1,10 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState } from 'react';
 import { cn } from '@/lib/utils';
 import { Card, CardContent } from '@/components/ui/card';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { Badge } from '@/components/ui/badge';
-import { CopyButton } from './CopyButton';
-import { formatAsJson, buildToolMessages } from './types';
 import type { ToolCall, TodoItem } from './types';
 
 interface TodoWriteDisplayProps {
@@ -99,12 +97,6 @@ export function TodoWriteDisplay({
     setManualExpandedState(open);
   };
 
-  // Build copy text with both tool call and result as an array of messages
-  const getCopyText = useCallback(() => {
-    const messages = buildToolMessages(tool);
-    return formatAsJson(messages);
-  }, [tool]);
-
   return (
     <div className="group">
       <Collapsible open={expanded} onOpenChange={handleOpenChange}>
@@ -152,9 +144,6 @@ export function TodoWriteDisplay({
           </CollapsibleContent>
         </Card>
       </Collapsible>
-      <div className="mt-1">
-        <CopyButton getText={getCopyText} />
-      </div>
     </div>
   );
 }

--- a/src/components/messages/ToolCallDisplay.tsx
+++ b/src/components/messages/ToolCallDisplay.tsx
@@ -1,12 +1,10 @@
 'use client';
 
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import { cn } from '@/lib/utils';
 import { Card, CardContent } from '@/components/ui/card';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { Badge } from '@/components/ui/badge';
-import { CopyButton } from './CopyButton';
-import { formatAsJson, buildToolMessages } from './types';
 import { processTerminalOutput, isTerminalOutput } from '@/lib/terminal-output';
 import type { ToolCall } from './types';
 
@@ -22,12 +20,6 @@ export function ToolCallDisplay({ tool }: { tool: ToolCall }) {
   // Extract description from input if present (e.g., Bash tool)
   const inputObj = tool.input as Record<string, unknown> | undefined;
   const description = inputObj?.description as string | undefined;
-
-  // Build copy text with both tool call and result as an array of messages
-  const getCopyText = useCallback(() => {
-    const messages = buildToolMessages(tool);
-    return formatAsJson(messages);
-  }, [tool]);
 
   // Process terminal output (ANSI codes, progress bars) for Bash commands
   const processedOutput = useMemo(() => {
@@ -117,9 +109,6 @@ export function ToolCallDisplay({ tool }: { tool: ToolCall }) {
           </CollapsibleContent>
         </Card>
       </Collapsible>
-      <div className="mt-1">
-        <CopyButton getText={getCopyText} />
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Removes duplicate copy buttons from individual tool display components (ToolCallDisplay, TodoWriteDisplay, EditDisplay, GlobDisplay)
- Consolidates copy functionality in MessageBubble so the outer copy button now copies both text content and all tool calls with their results

## Test plan
- [ ] Verify tool messages show only one copy button (outside the bubble)
- [ ] Verify copying a message with tool calls includes both the text and tool call/result JSON
- [ ] Verify copying a message without tool calls still works as before

Fixes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)