### PR TITLE
Add system prompt for commit/push/PR workflow

### DIFF
--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -228,12 +228,26 @@ claude.getHistory({
    claude -p "<prompt>" \
      --session-id <sessionId> \      # or --resume on subsequent
      --output-format stream-json \
-     --dangerously-skip-permissions
+     --dangerously-skip-permissions \
+     --append-system-prompt "<system-prompt>"
    ```
 3. Server reads stdout line by line, parses JSON
 4. Each line saved to database with incrementing sequence number
 5. Lines streamed to client via SSE/WebSocket
 6. On completion, `result` message marks end of turn
+
+### System Prompt
+
+A system prompt is appended to all Claude sessions to ensure proper workflow. Since users interact through the web interface and have no local access to files, Claude must always commit, push, and open PRs for changes to be visible.
+
+The system prompt instructs Claude to:
+
+1. Always commit changes with clear, descriptive commit messages
+2. Always push commits to the remote repository
+3. Open a Pull Request (using `gh pr create`) for new branches or changes that benefit from review
+4. If a PR already exists, just push to update it
+
+This ensures users can see all changes through GitHub, which is their only way to access the codebase.
 
 ### Interruption Flow
 

--- a/src/server/services/claude-runner.ts
+++ b/src/server/services/claude-runner.ts
@@ -29,6 +29,18 @@ const OUTPUT_FILE_PREFIX = '.claude-output-';
 // Using /usr/bin/claude because that's the installed path and won't match other processes
 const CLAUDE_PROCESS_PATTERN = '/usr/bin/claude';
 
+// System prompt appended to all Claude sessions to ensure proper workflow
+// Since users interact through GitHub PRs (no local access), Claude must always
+// commit, push, and open PRs for any changes to be visible
+const SYSTEM_PROMPT = `IMPORTANT: The user is accessing this session remotely through a web interface and has no local access to the files. They can only see your changes through GitHub. Therefore, you MUST follow this workflow for ANY code changes:
+
+1. Always commit your changes with clear, descriptive commit messages
+2. Always push your commits to the remote repository
+3. If you're working on a new branch or the changes would benefit from review, open a Pull Request using the GitHub CLI (gh pr create)
+4. If a PR already exists for the current branch, just push to update it
+
+Never leave uncommitted or unpushed changes - the user cannot see them otherwise.`;
+
 // Logging helper for debugging
 function log(context: string, message: string, data?: Record<string, unknown>): void {
   const timestamp = new Date().toISOString();
@@ -106,6 +118,8 @@ export async function runClaudeCommand(
     'stream-json',
     '--verbose',
     '--dangerously-skip-permissions',
+    '--append-system-prompt',
+    SYSTEM_PROMPT,
   ];
 
   const outputFile = getOutputFilePath(sessionId);


### PR DESCRIPTION
## Summary

- Adds a system prompt that is appended to all Claude sessions via `--append-system-prompt`
- The prompt instructs Claude to always commit, push, and open PRs since users access sessions remotely and have no local file access
- Updates DESIGN.md to document the system prompt behavior

## Test plan

- [ ] Start a new session and verify Claude commits and pushes changes
- [ ] Verify Claude opens a PR when appropriate

🤖 Generated with [Claude Code](https://claude.com/claude-code)