### PR TITLE
Use corepack for pnpm installation in container

### DIFF
--- a/docker/Dockerfile.claude-code
+++ b/docker/Dockerfile.claude-code
@@ -33,8 +33,10 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
     apt-get install -y gh && \
     rm -rf /var/lib/apt/lists/*
 
-# Install pnpm and Claude Code
-RUN npm install -g pnpm @anthropic-ai/claude-code
+# Enable corepack for pnpm (built into Node.js) and install Claude Code
+RUN corepack enable && \
+    corepack prepare pnpm@latest --activate && \
+    npm install -g @anthropic-ai/claude-code
 
 # Create a non-root user with UID 1000 (common default for host user)
 # Add to docker group for docker-in-docker capability


### PR DESCRIPTION
## Summary
- Switch from `npm install -g pnpm` to corepack, the recommended way to manage pnpm in Node.js 20.x
- Uses `corepack enable` and `corepack prepare pnpm@latest --activate` for proper pnpm installation

## Test plan
- [ ] Rebuild the Docker image
- [ ] Verify `pnpm --version` works in a container

🤖 Generated with [Claude Code](https://claude.com/claude-code)