### PR TITLE
Add formatted display for WebSearch tool results

### DIFF
--- a/src/components/messages/MessageBubble.tsx
+++ b/src/components/messages/MessageBubble.tsx
@@ -10,6 +10,7 @@ import { RawJsonDisplay } from './RawJsonDisplay';
 import { EditDisplay } from './EditDisplay';
 import { TodoWriteDisplay } from './TodoWriteDisplay';
 import { GlobDisplay } from './GlobDisplay';
+import { WebSearchDisplay } from './WebSearchDisplay';
 import { ToolCallDisplay } from './ToolCallDisplay';
 import { ToolResultDisplay } from './ToolResultDisplay';
 import { SystemInitDisplay } from './SystemInitDisplay';
@@ -107,6 +108,10 @@ function renderContentBlocks(
 
             if (block.name === 'Edit') {
               return <EditDisplay key={block.id} tool={tool} />;
+            }
+
+            if (block.name === 'WebSearch') {
+              return <WebSearchDisplay key={block.id} tool={tool} />;
             }
 
             return <ToolCallDisplay key={block.id} tool={tool} />;

--- a/src/components/messages/WebSearchDisplay.tsx
+++ b/src/components/messages/WebSearchDisplay.tsx
@@ -1,0 +1,258 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import { cn } from '@/lib/utils';
+import { Card, CardContent } from '@/components/ui/card';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import { Badge } from '@/components/ui/badge';
+import type { ToolCall } from './types';
+
+interface WebSearchInput {
+  query: string;
+}
+
+interface SearchLink {
+  title: string;
+  url: string;
+}
+
+interface ParsedWebSearchOutput {
+  query: string;
+  links: SearchLink[];
+  summary: string;
+}
+
+/**
+ * Parse WebSearch output into structured components.
+ * The output format is:
+ * - First line: "Web search results for query: \"...\""
+ * - Links line: "Links: [{...}, ...]"
+ * - Rest: Summary text
+ */
+function parseWebSearchOutput(output: string): ParsedWebSearchOutput | null {
+  if (!output || typeof output !== 'string') {
+    return null;
+  }
+
+  const result: ParsedWebSearchOutput = {
+    query: '',
+    links: [],
+    summary: '',
+  };
+
+  // Split by newlines and process
+  const lines = output.split('\n');
+  let summaryStartIndex = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    // Parse query from first line
+    const queryMatch = line.match(/^Web search results for query: "(.+)"$/);
+    if (queryMatch) {
+      result.query = queryMatch[1];
+      summaryStartIndex = i + 1;
+      continue;
+    }
+
+    // Parse links JSON
+    if (line.startsWith('Links: ')) {
+      try {
+        const jsonStr = line.substring('Links: '.length);
+        const parsed = JSON.parse(jsonStr);
+        if (Array.isArray(parsed)) {
+          result.links = parsed.filter(
+            (item): item is SearchLink =>
+              typeof item === 'object' &&
+              item !== null &&
+              typeof item.title === 'string' &&
+              typeof item.url === 'string'
+          );
+        }
+      } catch {
+        // If parsing fails, just skip the links
+      }
+      summaryStartIndex = i + 1;
+      continue;
+    }
+  }
+
+  // Everything after the links line is the summary
+  const summaryLines = lines.slice(summaryStartIndex);
+  result.summary = summaryLines.join('\n').trim();
+
+  return result;
+}
+
+// Search/globe icon component
+const SearchIcon = () => (
+  <svg
+    className="w-4 h-4 text-blue-600 dark:text-blue-400 flex-shrink-0"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke="currentColor"
+    strokeWidth={1.5}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
+    />
+  </svg>
+);
+
+// External link icon component
+const ExternalLinkIcon = () => (
+  <svg
+    className="w-3 h-3 text-muted-foreground flex-shrink-0 opacity-0 group-hover/link:opacity-100 transition-opacity"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke="currentColor"
+    strokeWidth={2}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25"
+    />
+  </svg>
+);
+
+/**
+ * Specialized display for WebSearch tool calls.
+ * Shows the search query, clickable source links, and a formatted summary.
+ */
+export function WebSearchDisplay({ tool }: { tool: ToolCall }) {
+  const [expanded, setExpanded] = useState(false);
+  const hasOutput = tool.output !== undefined;
+  const isPending = !hasOutput;
+
+  const inputObj = tool.input as WebSearchInput | undefined;
+  const query = inputObj?.query ?? '';
+
+  const parsed = useMemo(() => {
+    if (typeof tool.output !== 'string') {
+      return null;
+    }
+    return parseWebSearchOutput(tool.output);
+  }, [tool.output]);
+
+  return (
+    <div className="group">
+      <Collapsible open={expanded} onOpenChange={setExpanded}>
+        <Card
+          className={cn(
+            'mt-2',
+            tool.is_error && 'border-red-300 dark:border-red-700',
+            isPending && 'border-yellow-300 dark:border-yellow-700'
+          )}
+        >
+          <CollapsibleTrigger className="w-full px-3 py-2 text-left flex items-center justify-between text-sm hover:bg-muted/50 rounded-t-xl">
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2">
+                <SearchIcon />
+                <span className="font-mono text-primary">WebSearch</span>
+                {isPending && (
+                  <Badge
+                    variant="outline"
+                    className="text-xs border-yellow-500 text-yellow-700 dark:text-yellow-400"
+                  >
+                    Searching...
+                  </Badge>
+                )}
+                {tool.is_error && (
+                  <Badge variant="destructive" className="text-xs">
+                    Error
+                  </Badge>
+                )}
+                {hasOutput && !tool.is_error && parsed && (
+                  <Badge
+                    variant="outline"
+                    className="text-xs border-blue-500 text-blue-700 dark:text-blue-400"
+                  >
+                    {parsed.links.length} {parsed.links.length === 1 ? 'source' : 'sources'}
+                  </Badge>
+                )}
+              </div>
+              <div className="text-muted-foreground text-xs mt-1 truncate">{query}</div>
+            </div>
+            <span className="text-muted-foreground ml-2 flex-shrink-0">{expanded ? '−' : '+'}</span>
+          </CollapsibleTrigger>
+
+          <CollapsibleContent>
+            <CardContent className="p-3 space-y-3 text-sm">
+              {/* Query section */}
+              <div>
+                <div className="text-muted-foreground text-xs mb-1">Query:</div>
+                <code className="bg-muted px-2 py-1 rounded text-sm">{query}</code>
+              </div>
+
+              {/* Error display */}
+              {tool.is_error && hasOutput && (
+                <div>
+                  <div className="text-muted-foreground text-xs mb-1">Error:</div>
+                  <pre className="bg-red-50 dark:bg-red-950 text-red-800 dark:text-red-200 p-2 rounded overflow-x-auto max-h-48 overflow-y-auto text-xs">
+                    {typeof tool.output === 'string'
+                      ? tool.output
+                      : JSON.stringify(tool.output, null, 2)}
+                  </pre>
+                </div>
+              )}
+
+              {/* Sources section */}
+              {hasOutput && !tool.is_error && parsed && parsed.links.length > 0 && (
+                <div>
+                  <div className="text-muted-foreground text-xs mb-1">Sources:</div>
+                  <div className="bg-muted rounded p-2 max-h-48 overflow-y-auto space-y-1">
+                    {parsed.links.map((link, index) => (
+                      <a
+                        key={index}
+                        href={link.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="group/link flex items-start gap-2 py-1.5 px-2 -mx-2 hover:bg-background/50 rounded text-xs"
+                      >
+                        <span className="text-muted-foreground flex-shrink-0 mt-0.5">
+                          {index + 1}.
+                        </span>
+                        <div className="flex-1 min-w-0">
+                          <div className="text-blue-600 dark:text-blue-400 hover:underline font-medium truncate">
+                            {link.title}
+                          </div>
+                          <div className="text-muted-foreground truncate text-xs">{link.url}</div>
+                        </div>
+                        <ExternalLinkIcon />
+                      </a>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Summary section */}
+              {hasOutput && !tool.is_error && parsed && parsed.summary && (
+                <div>
+                  <div className="text-muted-foreground text-xs mb-1">Summary:</div>
+                  <div className="bg-muted rounded p-3 max-h-64 overflow-y-auto text-sm whitespace-pre-wrap">
+                    {parsed.summary}
+                  </div>
+                </div>
+              )}
+
+              {/* Fallback if parsing failed */}
+              {hasOutput && !tool.is_error && !parsed && (
+                <div>
+                  <div className="text-muted-foreground text-xs mb-1">Result:</div>
+                  <pre className="bg-muted p-2 rounded overflow-x-auto max-h-48 overflow-y-auto text-xs font-mono">
+                    {typeof tool.output === 'string'
+                      ? tool.output
+                      : JSON.stringify(tool.output, null, 2)}
+                  </pre>
+                </div>
+              )}
+            </CardContent>
+          </CollapsibleContent>
+        </Card>
+      </Collapsible>
+    </div>
+  );
+}

--- a/src/components/messages/index.ts
+++ b/src/components/messages/index.ts
@@ -4,6 +4,7 @@
 export { MessageBubble } from './MessageBubble';
 export { CopyButton } from './CopyButton';
 export { EditDisplay } from './EditDisplay';
+export { GlobDisplay } from './GlobDisplay';
 export { RawJsonDisplay } from './RawJsonDisplay';
 export { TodoWriteDisplay } from './TodoWriteDisplay';
 export { ToolCallDisplay } from './ToolCallDisplay';
@@ -11,6 +12,7 @@ export { ToolResultDisplay } from './ToolResultDisplay';
 export { SystemInitDisplay } from './SystemInitDisplay';
 export { ResultDisplay } from './ResultDisplay';
 export { HookResponseDisplay } from './HookResponseDisplay';
+export { WebSearchDisplay } from './WebSearchDisplay';
 
 export type { ToolResultMap, ToolCall, ContentBlock, MessageContent, TodoItem } from './types';
 export { formatAsJson } from './types';


### PR DESCRIPTION
## Summary
- Adds a new `WebSearchDisplay` component that nicely formats WebSearch tool results
- Displays the search query, numbered clickable source links with titles and URLs, and formatted summary text
- Follows the same UI pattern as existing specialized tool displays (GlobDisplay, EditDisplay)

Fixes #19

## Test plan
- [x] Build passes (`pnpm build`)
- [x] Lint passes (`pnpm lint`)
- [x] TypeScript type check passes
- [x] Tests pass (`pnpm test`)
- [ ] Manual testing: run a session that uses WebSearch and verify the display looks good

🤖 Generated with [Claude Code](https://claude.com/claude-code)