### PR TITLE
Add common development tools to Docker image

### DIFF
--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -281,11 +281,13 @@ This ensures users can see all changes through GitHub, which is their only way t
 ```dockerfile
 FROM nvidia/cuda:12.1.0-base-ubuntu22.04
 
-# Install dependencies including Python, pip, and JDK
+# Install dependencies including Python, pip, JDK, and common dev tools
 RUN apt-get update && apt-get install -y \
     curl git docker.io ca-certificates gnupg \
     python3 python3-pip python3-venv \
     openjdk-17-jdk-headless \
+    build-essential coreutils unzip zip tar \
+    file tree jq less vim wget openssh-client \
     && rm -rf /var/lib/apt/lists/* \
     && ln -sf /usr/bin/python3 /usr/bin/python
 

--- a/docker/Dockerfile.claude-code
+++ b/docker/Dockerfile.claude-code
@@ -3,7 +3,7 @@ FROM nvidia/cuda:12.1.0-base-ubuntu22.04
 # Avoid prompts from apt
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install dependencies including Python, pip, and JDK
+# Install dependencies including Python, pip, JDK, and common development tools
 RUN apt-get update && apt-get install -y \
     curl \
     git \
@@ -14,6 +14,24 @@ RUN apt-get update && apt-get install -y \
     python3-pip \
     python3-venv \
     openjdk-17-jdk-headless \
+    # Standard development tools
+    build-essential \
+    # Common utilities (includes yes, head, tail, etc.)
+    coreutils \
+    # Archive tools
+    unzip \
+    zip \
+    tar \
+    # File inspection tools
+    file \
+    tree \
+    # Text processing tools
+    jq \
+    less \
+    vim \
+    # Network tools
+    wget \
+    openssh-client \
     && rm -rf /var/lib/apt/lists/* \
     && ln -sf /usr/bin/python3 /usr/bin/python
 


### PR DESCRIPTION
## Summary

- Adds standard development tools (`build-essential`) including `make`, `gcc`, etc.
- Adds `coreutils` for common utilities like `yes`, `head`, `tail`
- Adds archive tools: `unzip`, `zip`, `tar`
- Adds file inspection tools: `file`, `tree`
- Adds text processing tools: `jq`, `less`, `vim`
- Adds network tools: `wget`, `openssh-client`

Fixes #36
Fixes #38

## Test plan

- [ ] Rebuild the Docker image and verify new tools are available
- [ ] Test `unzip`, `yes`, `tail`, `head` commands work
- [ ] Test `make`, `gcc` from build-essential work
- [ ] Test `file`, `tree`, `jq` commands work

🤖 Generated with [Claude Code](https://claude.com/claude-code)