### PR TITLE
Replace polling with SSE for real-time updates

### DIFF
--- a/src/components/SessionList.tsx
+++ b/src/components/SessionList.tsx
@@ -7,6 +7,15 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Spinner } from '@/components/ui/spinner';
 import { SessionListItem } from '@/components/SessionListItem';
 
+interface Session {
+  id: string;
+  name: string;
+  repoUrl: string;
+  branch: string;
+  status: string;
+  updatedAt: Date;
+}
+
 export function SessionList() {
   const { data, isLoading, refetch } = trpc.sessions.list.useQuery();
 
@@ -18,7 +27,7 @@ export function SessionList() {
     );
   }
 
-  const sessions = data?.sessions || [];
+  const sessions: Session[] = data?.sessions || [];
 
   if (sessions.length === 0) {
     return (

--- a/src/server/routers/index.ts
+++ b/src/server/routers/index.ts
@@ -3,12 +3,14 @@ import { authRouter } from './auth';
 import { sessionsRouter } from './sessions';
 import { claudeRouter } from './claude';
 import { githubRouter } from './github';
+import { sseRouter } from './sse';
 
 export const appRouter = router({
   auth: authRouter,
   sessions: sessionsRouter,
   claude: claudeRouter,
   github: githubRouter,
+  sse: sseRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/src/server/routers/sse.ts
+++ b/src/server/routers/sse.ts
@@ -1,0 +1,124 @@
+import { z } from 'zod';
+import { router, protectedProcedure } from '../trpc';
+import { sseEvents } from '../services/events';
+import { tracked } from '@trpc/server';
+
+export const sseRouter = router({
+  // Subscribe to session updates (status changes, etc.)
+  onSessionUpdate: protectedProcedure
+    .input(z.object({ sessionId: z.string().uuid() }))
+    .subscription(async function* ({ input, signal }) {
+      // Create an async iterator from event emitter
+      const events: Array<{ type: 'session_update'; sessionId: string; session: unknown }> = [];
+      let resolveWait: (() => void) | null = null;
+
+      const unsubscribe = sseEvents.onSessionUpdate(input.sessionId, (event) => {
+        events.push(event);
+        resolveWait?.();
+      });
+
+      // Clean up on abort
+      signal?.addEventListener('abort', () => {
+        unsubscribe();
+      });
+
+      try {
+        while (!signal?.aborted) {
+          if (events.length > 0) {
+            const event = events.shift()!;
+            yield tracked(event.sessionId, event);
+          } else {
+            // Wait for next event or abort
+            await new Promise<void>((resolve) => {
+              resolveWait = resolve;
+              const onAbort = () => resolve();
+              signal?.addEventListener('abort', onAbort, { once: true });
+            });
+          }
+        }
+      } finally {
+        unsubscribe();
+      }
+    }),
+
+  // Subscribe to new messages for a session
+  onNewMessage: protectedProcedure
+    .input(z.object({ sessionId: z.string().uuid() }))
+    .subscription(async function* ({ input, signal }) {
+      const events: Array<{
+        type: 'new_message';
+        sessionId: string;
+        message: { id: string; sequence: number; type: string };
+      }> = [];
+      let resolveWait: (() => void) | null = null;
+
+      const unsubscribe = sseEvents.onNewMessage(input.sessionId, (event) => {
+        // Only send minimal data needed to trigger a refetch
+        events.push({
+          type: 'new_message',
+          sessionId: event.sessionId,
+          message: {
+            id: event.message.id,
+            sequence: event.message.sequence,
+            type: event.message.type,
+          },
+        });
+        resolveWait?.();
+      });
+
+      signal?.addEventListener('abort', () => {
+        unsubscribe();
+      });
+
+      try {
+        while (!signal?.aborted) {
+          if (events.length > 0) {
+            const event = events.shift()!;
+            yield tracked(event.message.id, event);
+          } else {
+            await new Promise<void>((resolve) => {
+              resolveWait = resolve;
+              const onAbort = () => resolve();
+              signal?.addEventListener('abort', onAbort, { once: true });
+            });
+          }
+        }
+      } finally {
+        unsubscribe();
+      }
+    }),
+
+  // Subscribe to Claude running state changes
+  onClaudeRunning: protectedProcedure
+    .input(z.object({ sessionId: z.string().uuid() }))
+    .subscription(async function* ({ input, signal }) {
+      const events: Array<{ type: 'claude_running'; sessionId: string; running: boolean }> = [];
+      let resolveWait: (() => void) | null = null;
+
+      const unsubscribe = sseEvents.onClaudeRunning(input.sessionId, (event) => {
+        events.push(event);
+        resolveWait?.();
+      });
+
+      signal?.addEventListener('abort', () => {
+        unsubscribe();
+      });
+
+      try {
+        while (!signal?.aborted) {
+          if (events.length > 0) {
+            const event = events.shift()!;
+            yield tracked(`${event.sessionId}-${event.running}`, event);
+          } else {
+            await new Promise<void>((resolve) => {
+              resolveWait = resolve;
+              const onAbort = () => resolve();
+              signal?.addEventListener('abort', onAbort, { once: true });
+            });
+          }
+        }
+      } finally {
+        unsubscribe();
+      }
+    }),
+});

--- a/src/server/services/events.ts
+++ b/src/server/services/events.ts
@@ -1,0 +1,80 @@
+import { EventEmitter } from 'events';
+import type { Message, Session } from '@prisma/client';
+
+// Message with parsed content (for SSE events)
+export type ParsedMessage = Omit<Message, 'content'> & { content: unknown };
+
+// Event types for type-safe event handling
+export interface SessionUpdateEvent {
+  type: 'session_update';
+  sessionId: string;
+  session: Session;
+}
+
+export interface MessageEvent {
+  type: 'new_message';
+  sessionId: string;
+  message: ParsedMessage;
+}
+
+export interface ClaudeRunningEvent {
+  type: 'claude_running';
+  sessionId: string;
+  running: boolean;
+}
+
+export type SSEEvent = SessionUpdateEvent | MessageEvent | ClaudeRunningEvent;
+
+// Create a typed event emitter
+class SSEEventEmitter extends EventEmitter {
+  emitSessionUpdate(sessionId: string, session: Session): void {
+    this.emit(`session:${sessionId}`, {
+      type: 'session_update',
+      sessionId,
+      session,
+    } satisfies SessionUpdateEvent);
+  }
+
+  emitNewMessage(sessionId: string, message: ParsedMessage): void {
+    this.emit(`messages:${sessionId}`, {
+      type: 'new_message',
+      sessionId,
+      message,
+    } satisfies MessageEvent);
+  }
+
+  emitClaudeRunning(sessionId: string, running: boolean): void {
+    this.emit(`claude:${sessionId}`, {
+      type: 'claude_running',
+      sessionId,
+      running,
+    } satisfies ClaudeRunningEvent);
+  }
+
+  // Subscribe to session updates for a specific session
+  onSessionUpdate(sessionId: string, callback: (event: SessionUpdateEvent) => void): () => void {
+    const eventName = `session:${sessionId}`;
+    this.on(eventName, callback);
+    return () => this.off(eventName, callback);
+  }
+
+  // Subscribe to new messages for a specific session
+  onNewMessage(sessionId: string, callback: (event: MessageEvent) => void): () => void {
+    const eventName = `messages:${sessionId}`;
+    this.on(eventName, callback);
+    return () => this.off(eventName, callback);
+  }
+
+  // Subscribe to Claude running state changes for a specific session
+  onClaudeRunning(sessionId: string, callback: (event: ClaudeRunningEvent) => void): () => void {
+    const eventName = `claude:${sessionId}`;
+    this.on(eventName, callback);
+    return () => this.off(eventName, callback);
+  }
+}
+
+// Singleton instance for the application
+export const sseEvents = new SSEEventEmitter();
+
+// Increase max listeners to handle many concurrent sessions
+sseEvents.setMaxListeners(1000);


### PR DESCRIPTION
## Summary
- Adds SSE (Server-Sent Events) channels to replace polling for session updates, new messages, and Claude running state changes
- Creates a new event emitter service that allows server-side code to publish events
- Adds tRPC subscription endpoints for clients to receive real-time updates
- Updates the session page to use SSE subscriptions instead of polling intervals

## Changes
- **New file: `src/server/services/events.ts`** - SSE event emitter service for publishing session updates, new messages, and Claude running state
- **New file: `src/server/routers/sse.ts`** - tRPC subscriptions router with three endpoints: `onSessionUpdate`, `onNewMessage`, `onClaudeRunning`
- **Modified: `src/server/routers/sessions.ts`** - Emits session update events when session status changes
- **Modified: `src/server/services/claude-runner.ts`** - Emits new message events and Claude running state events
- **Modified: `src/app/session/[id]/page.tsx`** - Uses SSE subscriptions instead of polling, triggers refetches only when events are received

## Benefits
- More efficient: No unnecessary network requests when nothing has changed
- Lower latency: Updates appear immediately rather than waiting for next poll interval
- Better scalability: Reduced server load from polling requests

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)