### PR TITLE
Add Android SDK to Docker image

### DIFF
--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -320,6 +320,17 @@ USER claudeuser
 ENV HOME=/home/claudeuser
 ENV PATH="/home/claudeuser/.local/bin:${PATH}"
 
+# Install Android SDK
+ENV ANDROID_HOME=/home/claudeuser/Android/Sdk
+ENV PATH="${ANDROID_HOME}/cmdline-tools/latest/bin:${ANDROID_HOME}/platform-tools:${PATH}"
+
+RUN mkdir -p ${ANDROID_HOME}/cmdline-tools && \
+    cd ${ANDROID_HOME}/cmdline-tools && \
+    curl -sSL "https://dl.google.com/android/repository/commandlinetools-linux-13114758_latest.zip" -o cmdline-tools.zip && \
+    unzip -q cmdline-tools.zip && mv cmdline-tools latest && rm cmdline-tools.zip && \
+    yes | sdkmanager --licenses > /dev/null 2>&1 && \
+    sdkmanager "platform-tools" "platforms;android-35" "build-tools;35.0.0"
+
 # Configure git identity for commits
 RUN git config --global user.email "claude@anthropic.com" && \
     git config --global user.name "Claude"

--- a/docker/Dockerfile.claude-code
+++ b/docker/Dockerfile.claude-code
@@ -72,6 +72,23 @@ USER claudeuser
 ENV HOME=/home/claudeuser
 ENV PATH="/home/claudeuser/.local/bin:${PATH}"
 
+# Install Android SDK
+ENV ANDROID_HOME=/home/claudeuser/Android/Sdk
+ENV PATH="${ANDROID_HOME}/cmdline-tools/latest/bin:${ANDROID_HOME}/platform-tools:${PATH}"
+
+# Download and install Android command-line tools
+RUN mkdir -p ${ANDROID_HOME}/cmdline-tools && \
+    cd ${ANDROID_HOME}/cmdline-tools && \
+    curl -sSL "https://dl.google.com/android/repository/commandlinetools-linux-13114758_latest.zip" -o cmdline-tools.zip && \
+    unzip -q cmdline-tools.zip && \
+    mv cmdline-tools latest && \
+    rm cmdline-tools.zip && \
+    chmod +x ${ANDROID_HOME}/cmdline-tools/latest/bin/*
+
+# Accept Android SDK licenses and install common components
+RUN yes | sdkmanager --licenses > /dev/null 2>&1 && \
+    sdkmanager "platform-tools" "platforms;android-35" "build-tools;35.0.0"
+
 # Configure pnpm to use shared store if mounted at /pnpm-store
 # The store supports concurrent access with atomic operations
 ENV PNPM_HOME="/home/claudeuser/.local/share/pnpm"


### PR DESCRIPTION
Pre-install Android SDK with command-line tools, platform-tools, Android 35 platform, and build-tools 35.0.0. Set ANDROID_HOME environment variable and add SDK binaries to PATH.

This allows Android projects to build without manual SDK installation.

Fixes #37