### PR TITLE
Add support for shared Gradle cache across sessions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,7 @@ PASSWORD_HASH="JGFyZ29uMmlkJHY9MTkkbT02NTUzNix0PTMscD00JHlvdXJfc2FsdF9oZXJlJHlvd
 # The store is safe for concurrent access (atomic operations)
 # Find your store path with: pnpm store path
 # PNPM_STORE_PATH="$HOME/.local/share/pnpm/store"
+
+# Optional: Shared Gradle user home for faster builds across sessions
+# The cache is safe for concurrent access (Gradle uses file locking)
+# GRADLE_USER_HOME="$HOME/.gradle"

--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -474,6 +474,13 @@ ORDER BY sequence ASC;
 - pnpm's store is safe for concurrent access (atomic operations)
 - Only `pnpm store prune` should not run while installs are in progress
 
+### Shared Gradle Cache
+
+- Set `GRADLE_USER_HOME` to the host's Gradle user home (e.g., `/home/user/.gradle`)
+- The cache is mounted at `/gradle-cache` in containers and `GRADLE_USER_HOME` env var is set
+- Gradle's cache is safe for concurrent access (uses file locking)
+- Includes downloaded dependencies, wrapper distributions, and build caches
+
 ## UI Screens
 
 ### Session List (Home)

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -24,6 +24,10 @@ const envSchema = z.object({
   // pnpm's store is safe for concurrent access (atomic operations)
   // Example: /home/user/.local/share/pnpm/store
   PNPM_STORE_PATH: z.string().optional(),
+  // Optional path to host Gradle user home for sharing caches across sessions
+  // Gradle's cache is safe for concurrent access (file locking)
+  // Example: /home/user/.gradle
+  GRADLE_USER_HOME: z.string().optional(),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/src/server/services/docker.ts
+++ b/src/server/services/docker.ts
@@ -48,6 +48,10 @@ export async function createAndStartContainer(config: ContainerConfig): Promise<
     if (config.githubToken) {
       envVars.push(`GITHUB_TOKEN=${config.githubToken}`);
     }
+    // Set Gradle user home if shared cache is configured
+    if (env.GRADLE_USER_HOME) {
+      envVars.push('GRADLE_USER_HOME=/gradle-cache');
+    }
 
     // Build volume binds
     const binds = [
@@ -60,6 +64,12 @@ export async function createAndStartContainer(config: ContainerConfig): Promise<
     // pnpm's store is safe for concurrent access (atomic operations)
     if (env.PNPM_STORE_PATH) {
       binds.push(`${env.PNPM_STORE_PATH}:/pnpm-store`);
+    }
+
+    // Mount shared Gradle cache if configured
+    // Gradle's cache is safe for concurrent access (file locking)
+    if (env.GRADLE_USER_HOME) {
+      binds.push(`${env.GRADLE_USER_HOME}:/gradle-cache`);
     }
 
     log.info('Creating new container', {


### PR DESCRIPTION
## Summary

- Adds `GRADLE_USER_HOME` environment variable option to share the host's Gradle cache with all containers
- Mounts the configured path at `/gradle-cache` inside containers
- Sets `GRADLE_USER_HOME=/gradle-cache` env var inside containers so Gradle uses the shared cache
- Updates documentation in `.env.example` and `doc/DESIGN.md`

This follows the same pattern as the existing pnpm store sharing feature.

Fixes #51

## Test plan

- [ ] Set `GRADLE_USER_HOME` to an existing Gradle cache directory (e.g., `~/.gradle`)
- [ ] Create a new session with an Android/Java project that uses Gradle
- [ ] Verify that Gradle builds use the shared cache (faster subsequent builds, cached dependencies)
- [ ] Verify concurrent sessions can both access the cache without issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)