### PR TITLE
Add user message and visual indicator when interrupting Claude

### DIFF
--- a/src/components/messages/types.ts
+++ b/src/components/messages/types.ts
@@ -36,7 +36,7 @@ export interface AssistantMessage {
 
 export interface MessageContent {
   type?: string;
-  subtype?: string; // 'init' | 'error' | 'success' etc.
+  subtype?: string; // 'init' | 'error' | 'success' | 'interrupt' etc.
   content?: string | ContentBlock[];
   // Assistant message wrapper
   message?: AssistantMessage;
@@ -58,6 +58,8 @@ export interface MessageContent {
     cache_read_input_tokens?: number;
     cache_creation_input_tokens?: number;
   };
+  // Interrupt flag - set when this message was interrupted by the user
+  interrupted?: boolean;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary
- When a user interrupts a Claude session, a special "Interrupted" user message is now inserted
- The last non-user message (assistant/system/result) is marked with an `interrupted: true` flag
- Messages marked as interrupted display with an amber border and a "May be incomplete" indicator
- The interrupt message displays as a compact right-aligned message with an octagon-X icon

## Test plan
- [ ] Start a Claude session and send a prompt
- [ ] While Claude is working, click the "Stop" button
- [ ] Verify that:
  - [ ] An "Interrupted" message appears on the user side (right-aligned)
  - [ ] The last assistant message shows an amber border
  - [ ] The last assistant message shows "May be incomplete" text with an icon
- [ ] Verify that subsequent messages work normally after interruption

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)