### PR TITLE
Add Android debug keystore to Docker image

### DIFF
--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -331,6 +331,12 @@ RUN mkdir -p ${ANDROID_HOME}/cmdline-tools && \
     yes | sdkmanager --licenses > /dev/null 2>&1 && \
     sdkmanager "platform-tools" "platforms;android-35" "build-tools;35.0.0"
 
+# Create Android debug keystore for debug builds
+RUN mkdir -p /home/claudeuser/.android && \
+    keytool -genkey -v -keystore /home/claudeuser/.android/debug.keystore \
+      -alias androiddebugkey -keyalg RSA -keysize 2048 -validity 10000 \
+      -storepass android -keypass android -dname "CN=Android Debug,O=Android,C=US"
+
 # Configure git identity for commits
 RUN git config --global user.email "claude@anthropic.com" && \
     git config --global user.name "Claude"

--- a/docker/Dockerfile.claude-code
+++ b/docker/Dockerfile.claude-code
@@ -89,6 +89,18 @@ RUN mkdir -p ${ANDROID_HOME}/cmdline-tools && \
 RUN yes | sdkmanager --licenses > /dev/null 2>&1 && \
     sdkmanager "platform-tools" "platforms;android-35" "build-tools;35.0.0"
 
+# Create Android debug keystore for debug builds
+RUN mkdir -p /home/claudeuser/.android && \
+    keytool -genkey -v \
+        -keystore /home/claudeuser/.android/debug.keystore \
+        -alias androiddebugkey \
+        -keyalg RSA \
+        -keysize 2048 \
+        -validity 10000 \
+        -storepass android \
+        -keypass android \
+        -dname "CN=Android Debug,O=Android,C=US"
+
 # Configure pnpm to use shared store if mounted at /pnpm-store
 # The store supports concurrent access with atomic operations
 ENV PNPM_HOME="/home/claudeuser/.local/share/pnpm"


### PR DESCRIPTION
## Summary
- Adds Android debug keystore generation to the Docker image build process
- Creates the standard debug.keystore file at `/home/claudeuser/.android/debug.keystore`
- Uses standard debug keystore parameters (password: android, alias: androiddebugkey)
- Updates the design document to reflect this change

## Test plan
- [ ] Rebuild the Docker image with `docker build -f docker/Dockerfile.claude-code -t claude-code-runner:latest .`
- [ ] Verify the keystore exists: `docker run --rm claude-code-runner:latest ls -la /home/claudeuser/.android/debug.keystore`
- [ ] Run an Android debug build in the container to verify it works

Fixes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)