### PR TITLE
Add ReadDisplay component for nicely formatting Read tool messages

### DIFF
--- a/src/components/messages/MessageBubble.tsx
+++ b/src/components/messages/MessageBubble.tsx
@@ -9,6 +9,7 @@ import { OctagonX } from 'lucide-react';
 import { CopyButton } from './CopyButton';
 import { RawJsonDisplay } from './RawJsonDisplay';
 import { EditDisplay } from './EditDisplay';
+import { ReadDisplay } from './ReadDisplay';
 import { TodoWriteDisplay } from './TodoWriteDisplay';
 import { GlobDisplay } from './GlobDisplay';
 import { WebSearchDisplay } from './WebSearchDisplay';
@@ -116,6 +117,10 @@ function renderContentBlocks(
 
             if (block.name === 'Edit') {
               return <EditDisplay key={block.id} tool={tool} />;
+            }
+
+            if (block.name === 'Read') {
+              return <ReadDisplay key={block.id} tool={tool} />;
             }
 
             if (block.name === 'WebSearch') {

--- a/src/components/messages/ReadDisplay.tsx
+++ b/src/components/messages/ReadDisplay.tsx
@@ -1,0 +1,274 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import { cn } from '@/lib/utils';
+import { Card, CardContent } from '@/components/ui/card';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import { Badge } from '@/components/ui/badge';
+import type { ToolCall } from './types';
+
+interface ReadInput {
+  file_path?: string;
+  offset?: number;
+  limit?: number;
+}
+
+interface ParsedLine {
+  lineNumber: number;
+  content: string;
+}
+
+/**
+ * Parse Read tool output which has format like "     1→content" where:
+ * - Line numbers are right-aligned with spaces
+ * - Arrow separator (→) between line number and content
+ * - Content may have leading whitespace that should be preserved
+ */
+function parseReadOutput(output: string): ParsedLine[] {
+  if (!output || typeof output !== 'string') {
+    return [];
+  }
+
+  const lines = output.split('\n');
+  const result: ParsedLine[] = [];
+
+  // Regex to match Claude's Read output format: spaces + number + → + content
+  // The arrow character is → (U+2192)
+  const linePattern = /^\s*(\d+)→(.*)$/;
+
+  for (const line of lines) {
+    // Skip system-reminder tags that may be injected
+    if (line.includes('<system-reminder>') || line.includes('</system-reminder>')) {
+      continue;
+    }
+
+    const match = line.match(linePattern);
+    if (match) {
+      result.push({
+        lineNumber: parseInt(match[1], 10),
+        content: match[2],
+      });
+    } else if (line.trim() && result.length === 0) {
+      // If we haven't matched the pattern yet and there's content,
+      // this might be raw file content without line numbers
+      // In this case, just add lines with sequential numbers
+      const rawLines = output
+        .split('\n')
+        .filter((l) => !l.includes('<system-reminder>') && !l.includes('</system-reminder>'));
+      return rawLines.map((content, index) => ({
+        lineNumber: index + 1,
+        content,
+      }));
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Detect file type from extension for syntax highlighting hints.
+ */
+function getFileType(filePath: string): string {
+  const ext = filePath.split('.').pop()?.toLowerCase() ?? '';
+  const typeMap: Record<string, string> = {
+    ts: 'typescript',
+    tsx: 'typescript',
+    js: 'javascript',
+    jsx: 'javascript',
+    py: 'python',
+    rb: 'ruby',
+    rs: 'rust',
+    go: 'go',
+    java: 'java',
+    kt: 'kotlin',
+    swift: 'swift',
+    c: 'c',
+    cpp: 'cpp',
+    h: 'c',
+    hpp: 'cpp',
+    css: 'css',
+    scss: 'scss',
+    less: 'less',
+    html: 'html',
+    xml: 'xml',
+    json: 'json',
+    yaml: 'yaml',
+    yml: 'yaml',
+    md: 'markdown',
+    sql: 'sql',
+    sh: 'shell',
+    bash: 'shell',
+    zsh: 'shell',
+    dockerfile: 'docker',
+    prisma: 'prisma',
+  };
+  return typeMap[ext] ?? 'text';
+}
+
+/**
+ * FileIcon component for Read tool display
+ */
+function FileIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={cn('w-4 h-4 text-muted-foreground flex-shrink-0', className)}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={1.5}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Specialized display for Read tool calls.
+ * Shows file path and nicely formatted file content with line numbers.
+ */
+export function ReadDisplay({ tool }: { tool: ToolCall }) {
+  const [expanded, setExpanded] = useState(false);
+  const hasOutput = tool.output !== undefined;
+  const isPending = !hasOutput;
+
+  const input = tool.input as ReadInput | undefined;
+  const filePath = input?.file_path ?? 'Unknown file';
+  const offset = input?.offset;
+  const limit = input?.limit;
+
+  // Extract just the filename for the header
+  const fileName = filePath.split('/').pop() ?? filePath;
+  const fileType = useMemo(() => getFileType(filePath), [filePath]);
+
+  const parsedLines = useMemo(() => {
+    if (typeof tool.output !== 'string') {
+      return [];
+    }
+    return parseReadOutput(tool.output);
+  }, [tool.output]);
+
+  // Calculate the width needed for line numbers based on the highest line number
+  const lineNumberWidth = useMemo(() => {
+    if (parsedLines.length === 0) return 3;
+    const maxLineNum = parsedLines[parsedLines.length - 1]?.lineNumber ?? 1;
+    return Math.max(3, String(maxLineNum).length);
+  }, [parsedLines]);
+
+  return (
+    <div className="group">
+      <Collapsible open={expanded} onOpenChange={setExpanded}>
+        <Card
+          className={cn(
+            'mt-2',
+            tool.is_error && 'border-red-300 dark:border-red-700',
+            isPending && 'border-yellow-300 dark:border-yellow-700'
+          )}
+        >
+          <CollapsibleTrigger className="w-full px-3 py-2 text-left flex items-center justify-between text-sm hover:bg-muted/50 rounded-t-xl">
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2">
+                <FileIcon />
+                <span className="font-mono text-primary">Read</span>
+                <span className="text-muted-foreground font-mono text-xs truncate">{fileName}</span>
+                {isPending && (
+                  <Badge
+                    variant="outline"
+                    className="text-xs border-yellow-500 text-yellow-700 dark:text-yellow-400"
+                  >
+                    Reading...
+                  </Badge>
+                )}
+                {tool.is_error && (
+                  <Badge variant="destructive" className="text-xs">
+                    Error
+                  </Badge>
+                )}
+                {hasOutput && !tool.is_error && (
+                  <Badge
+                    variant="outline"
+                    className="text-xs border-blue-500 text-blue-700 dark:text-blue-400"
+                  >
+                    {parsedLines.length} {parsedLines.length === 1 ? 'line' : 'lines'}
+                  </Badge>
+                )}
+              </div>
+              <div className="text-muted-foreground text-xs mt-1 truncate">{filePath}</div>
+            </div>
+            <span className="text-muted-foreground ml-2 flex-shrink-0">{expanded ? '−' : '+'}</span>
+          </CollapsibleTrigger>
+
+          <CollapsibleContent>
+            <CardContent className="p-3 space-y-3 text-xs">
+              {/* Parameters section - only show if offset or limit are specified */}
+              {(offset !== undefined || limit !== undefined) && (
+                <div className="flex gap-4 text-muted-foreground">
+                  {offset !== undefined && (
+                    <span>
+                      Offset: <code className="bg-muted px-1.5 py-0.5 rounded">{offset}</code>
+                    </span>
+                  )}
+                  {limit !== undefined && (
+                    <span>
+                      Limit: <code className="bg-muted px-1.5 py-0.5 rounded">{limit}</code>
+                    </span>
+                  )}
+                </div>
+              )}
+
+              {/* File type badge */}
+              {hasOutput && !tool.is_error && fileType !== 'text' && (
+                <div>
+                  <Badge variant="secondary" className="text-xs">
+                    {fileType}
+                  </Badge>
+                </div>
+              )}
+
+              {/* File content section */}
+              {hasOutput && (
+                <div>
+                  {tool.is_error ? (
+                    <pre className="bg-red-50 dark:bg-red-950 text-red-800 dark:text-red-200 p-2 rounded overflow-x-auto max-h-96 overflow-y-auto whitespace-pre-wrap break-words">
+                      {typeof tool.output === 'string'
+                        ? tool.output
+                        : JSON.stringify(tool.output, null, 2)}
+                    </pre>
+                  ) : parsedLines.length === 0 ? (
+                    <div className="text-muted-foreground italic py-2">(empty file)</div>
+                  ) : (
+                    <div className="bg-muted rounded overflow-hidden">
+                      <pre className="max-h-96 overflow-y-auto overflow-x-auto text-sm">
+                        <code className="block">
+                          {parsedLines.map(({ lineNumber, content }) => (
+                            <div
+                              key={lineNumber}
+                              className="flex hover:bg-background/50 leading-relaxed"
+                            >
+                              {/* Line number */}
+                              <span
+                                className="text-muted-foreground select-none pr-3 pl-2 text-right flex-shrink-0 border-r border-border/50"
+                                style={{ minWidth: `${lineNumberWidth + 2}ch` }}
+                              >
+                                {lineNumber}
+                              </span>
+                              {/* Line content */}
+                              <span className="pl-3 pr-2 whitespace-pre">{content}</span>
+                            </div>
+                          ))}
+                        </code>
+                      </pre>
+                    </div>
+                  )}
+                </div>
+              )}
+            </CardContent>
+          </CollapsibleContent>
+        </Card>
+      </Collapsible>
+    </div>
+  );
+}

--- a/src/components/messages/index.ts
+++ b/src/components/messages/index.ts
@@ -4,6 +4,7 @@
 export { MessageBubble } from './MessageBubble';
 export { CopyButton } from './CopyButton';
 export { EditDisplay } from './EditDisplay';
+export { ReadDisplay } from './ReadDisplay';
 export { GlobDisplay } from './GlobDisplay';
 export { RawJsonDisplay } from './RawJsonDisplay';
 export { TodoWriteDisplay } from './TodoWriteDisplay';


### PR DESCRIPTION
## Summary

- Adds a specialized `ReadDisplay` component for Read tool calls that nicely formats the output instead of showing raw JSON
- Displays file path in header with file icon, filename, and line count badge
- Parses and formats file content with properly aligned line numbers
- Shows file type badge based on extension (typescript, python, etc.)
- Displays offset/limit parameters when specified
- Handles errors and empty files gracefully

## Changes

1. **ReadDisplay.tsx** - New specialized display component for Read tool calls
2. **MessageBubble.tsx** - Added Read tool detection to route to ReadDisplay
3. **index.ts** - Exported ReadDisplay component

## Before

Raw JSON displayed for Read tool input and unformatted output with the `1→content` format.

## After

- Clean collapsible card with file icon, tool name, and filename
- File path shown as subheader
- Line count badge showing number of lines read
- Expandable content section with:
  - Right-aligned line numbers with visual separator
  - Properly formatted code content
  - File type badge for recognized extensions

Fixes #33

## Test plan

- [ ] Verify Read tool calls display nicely formatted output
- [ ] Check line numbers are properly parsed and displayed
- [ ] Test with different file types (ts, tsx, py, json, etc.)
- [ ] Verify error states display correctly
- [ ] Test with offset/limit parameters
- [ ] Confirm collapsed state shows line count badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)