### PR TITLE
Redirect to login when session is invalid or expired

### DIFF
--- a/src/lib/trpc.ts
+++ b/src/lib/trpc.ts
@@ -1,12 +1,15 @@
 'use client';
 
-import { createTRPCReact } from '@trpc/react-query';
-import { httpBatchLink, httpSubscriptionLink, splitLink } from '@trpc/client';
+import { createTRPCReact, TRPCClientError } from '@trpc/react-query';
+import { httpBatchLink, httpSubscriptionLink, splitLink, TRPCLink } from '@trpc/client';
+import { observable } from '@trpc/server/observable';
 import { EventSourcePolyfill } from 'event-source-polyfill';
 import superjson from 'superjson';
 import type { AppRouter } from '@/server/routers';
 
 export const trpc = createTRPCReact<AppRouter>();
+
+const TOKEN_KEY = 'auth_token';
 
 function getBaseUrl() {
   if (typeof window !== 'undefined') {
@@ -17,12 +20,54 @@ function getBaseUrl() {
 
 function getAuthToken(): string | null {
   if (typeof window === 'undefined') return null;
-  return localStorage.getItem('auth_token');
+  return localStorage.getItem(TOKEN_KEY);
+}
+
+/**
+ * Clears the auth token and redirects to login page.
+ * Called when we receive an UNAUTHORIZED error from the server.
+ */
+function handleUnauthorized() {
+  if (typeof window === 'undefined') return;
+
+  localStorage.removeItem(TOKEN_KEY);
+  // Only redirect if we're not already on the login page
+  if (window.location.pathname !== '/login') {
+    window.location.href = '/login';
+  }
+}
+
+/**
+ * Custom tRPC link that intercepts UNAUTHORIZED errors and redirects to login.
+ */
+function authErrorLink(): TRPCLink<AppRouter> {
+  return () => {
+    return ({ next, op }) => {
+      return observable((observer) => {
+        const unsubscribe = next(op).subscribe({
+          next(value) {
+            observer.next(value);
+          },
+          error(err) {
+            if (err instanceof TRPCClientError && err.data?.code === 'UNAUTHORIZED') {
+              handleUnauthorized();
+            }
+            observer.error(err);
+          },
+          complete() {
+            observer.complete();
+          },
+        });
+        return unsubscribe;
+      });
+    };
+  };
 }
 
 export function createTRPCClient() {
   return trpc.createClient({
     links: [
+      authErrorLink(),
       splitLink({
         condition: (op) => op.type === 'subscription',
         true: httpSubscriptionLink({


### PR DESCRIPTION
## Summary
- Adds a custom tRPC link that intercepts `UNAUTHORIZED` errors from the server
- Automatically clears the invalid token from localStorage when an auth error occurs
- Redirects the user to the login page instead of showing error messages

This fixes the issue where users with expired or invalid sessions would see weird error messages instead of being redirected to the login page.

## Test plan
- [ ] Navigate to an authenticated page without being logged in - should redirect to `/login`
- [ ] Log in, then manually corrupt the token in localStorage (e.g., change a character) - next API call should clear token and redirect to login
- [ ] Log in, wait for token to expire (or manually delete the session from the database) - next API call should clear token and redirect to login
- [ ] Verify normal authenticated usage still works correctly

Fixes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)