### PR TITLE
Move Claude output log to /tmp to avoid untracked files in repo

### DIFF
--- a/src/server/services/claude-runner.ts
+++ b/src/server/services/claude-runner.ts
@@ -123,7 +123,8 @@ function getOutputFileName(sessionId: string): string {
 }
 
 function getOutputFilePath(sessionId: string): string {
-  return `/workspace/${getOutputFileName(sessionId)}`;
+  // Put output file in /tmp to avoid cluttering the workspace with untracked files
+  return `/tmp/${getOutputFileName(sessionId)}`;
 }
 
 export async function runClaudeCommand(


### PR DESCRIPTION
## Summary
- Moves the `.claude-output-*.jsonl` files from `/workspace` (the cloned repository) to `/tmp`
- This prevents the output files from showing up as untracked files in `git status`
- The files are temporary (all data is persisted to the database), so `/tmp` is an appropriate location

Fixes #59

## Test plan
- [ ] Start a new Claude session
- [ ] Verify that no `.claude-output-*.jsonl` files appear in the workspace
- [ ] Verify that Claude commands still work correctly (messages are captured and displayed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)