### PR TITLE
Add PWA manifest for Add to Home Screen support

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,30 @@
+{
+  "name": "Clawed Burrow",
+  "short_name": "Burrow",
+  "description": "Mobile-friendly access to Claude Code sessions",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#f9fafb",
+  "theme_color": "#1f2937",
+  "orientation": "any",
+  "icons": [
+    {
+      "src": "/favicon-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/favicon-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/apple-touch-icon.png",
+      "sizes": "180x180",
+      "type": "image/png",
+      "purpose": "any"
+    }
+  ]
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,6 +16,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
         <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
         <link rel="shortcut icon" href="/favicon.ico" />
+        <link rel="manifest" href="/manifest.json" />
+        <meta name="mobile-web-app-capable" content="yes" />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+        <meta name="apple-mobile-web-app-title" content="Burrow" />
+        <meta name="theme-color" content="#1f2937" />
       </head>
       <body className="bg-gray-50 min-h-screen">
         <Providers>{children}</Providers>


### PR DESCRIPTION
## Summary
- Add web app manifest (`manifest.json`) with app name, icons, and display settings
- Add manifest link and mobile web app meta tags to `layout.tsx`
- Enables "Add to Home Screen" / "Install app" functionality on mobile browsers

## Test plan
- [ ] On Firefox Android: Menu → Add to Home Screen
- [ ] On Chrome Android: Menu → Install app (or Add to Home screen)
- [ ] On Safari iOS: Share → Add to Home Screen
- [ ] Verify app launches in standalone mode (no browser chrome)

🤖 Generated with [Claude Code](https://claude.com/claude-code)