### PR TITLE
Add system prompt instructions for container issue reporting

### DIFF
--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -249,6 +249,14 @@ The system prompt instructs Claude to:
 
 This ensures users can see all changes through GitHub, which is their only way to access the codebase.
 
+#### Container Issue Reporting
+
+The system prompt also instructs Claude to report container issues (missing tools, misconfigured environments) to the clawed-burrow repository. Before creating an issue, Claude should:
+
+1. Search existing issues to avoid duplicates: `gh issue list --repo brendanlong/clawed-burrow --search "<issue>" --state all`
+2. If no matching issue exists, create one with labels `bug` and `reported-by-claude`
+3. Continue with workarounds if possible, or inform the user if the task cannot be completed
+
 ### Interruption Flow
 
 1. User clicks "Stop" in UI

--- a/src/server/services/claude-runner.ts
+++ b/src/server/services/claude-runner.ts
@@ -43,7 +43,13 @@ const SYSTEM_PROMPT = `IMPORTANT: The user is accessing this session remotely th
 3. If you're working on a new branch or the changes would benefit from review, open a Pull Request using the GitHub CLI (gh pr create)
 4. If a PR already exists for the current branch, just push to update it
 
-Never leave uncommitted or unpushed changes - the user cannot see them otherwise.`;
+Never leave uncommitted or unpushed changes - the user cannot see them otherwise.
+
+CONTAINER ISSUE REPORTING: This container should have all standard development tools pre-installed and properly configured. If you encounter missing tools, misconfigured environments, or other container setup issues that prevent you from completing tasks:
+
+1. First, check if the issue has already been reported by searching existing issues: \`gh issue list --repo brendanlong/clawed-burrow --search "<issue description>" --state all\`
+2. If no existing issue matches, report it to the clawed-burrow repository: \`gh issue create --repo brendanlong/clawed-burrow --title "<brief description>" --body "<detailed description of the problem and what you were trying to do>" --label bug --label reported-by-claude\`
+3. Then continue with your task using workarounds if possible, or inform the user that the task cannot be completed due to the container issue.`;
 
 const log = createLogger('claude-runner');
 


### PR DESCRIPTION
## Summary

- Updates the system prompt appended to Claude sessions to instruct Claude to report container issues (missing tools, misconfigured environments) to the clawed-burrow repository
- Claude will search existing issues first to avoid duplicates before creating new ones
- New issues will be tagged with `bug` and `reported-by-claude` labels
- Updates DESIGN.md documentation to reflect this new behavior

Fixes #54

## Test plan

- [ ] Deploy and create a new session
- [ ] Ask Claude to run a tool that doesn't exist and verify it searches for and creates an issue with the correct labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)