### PR TITLE
Fix parseAuthHeader returning empty string for 'Bearer '

### DIFF
--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -81,9 +81,7 @@ describe('auth', () => {
       expect(parseAuthHeader('Bearer token extra')).toBeNull();
     });
 
-    // BUG: 'Bearer '.split(' ') = ['Bearer', ''] which has length 2, so returns ''
-    // Should return null for empty token
-    it.skip('should return null for Bearer with empty token', () => {
+    it('should return null for Bearer with empty token', () => {
       expect(parseAuthHeader('Bearer ')).toBeNull();
     });
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -26,6 +26,6 @@ export function generateSessionToken(): string {
 export function parseAuthHeader(authHeader: string | null): string | null {
   if (!authHeader) return null;
   const parts = authHeader.split(' ');
-  if (parts.length !== 2 || parts[0] !== 'Bearer') return null;
+  if (parts.length !== 2 || parts[0] !== 'Bearer' || !parts[1]) return null;
   return parts[1];
 }


### PR DESCRIPTION
## Summary

- Fixed bug where `parseAuthHeader('Bearer ')` returned empty string `''` instead of `null`
- Added check for empty token (`!parts[1]`) to the validation condition
- Enabled the previously skipped test case

Fixes #67

## Test plan

- [x] All existing tests pass
- [x] Previously skipped test now passes: `parseAuthHeader('Bearer ')` returns `null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)