### PR TITLE
Add postinstall script to auto-generate Prisma client

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "db:migrate": "prisma migrate dev",
     "db:push": "prisma db push",
     "docker:build": "docker build -t claude-code-runner:latest -f docker/Dockerfile.claude-code docker/",
+    "postinstall": "prisma generate",
     "prepare": "husky",
     "hash-password": "tsx scripts/hash-password.ts",
     "test": "vitest",


### PR DESCRIPTION
## Summary

- Adds a `postinstall` script that runs `prisma generate` after `pnpm install`
- This works with the existing SessionStart hook that runs `pnpm install`, ensuring the Prisma client is always generated when Claude starts a session

## Test plan

- [x] Verified `pnpm install` now runs `prisma generate` automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)