### PR TITLE
Pre-install docker-compose in the container

### DIFF
--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -314,6 +314,12 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | \
       tee /etc/apt/sources.list.d/github-cli.list && \
     apt-get update && apt-get install -y gh
 
+# Install Docker Compose V2 plugin
+RUN DOCKER_CONFIG=/usr/lib/docker/cli-plugins && \
+    mkdir -p ${DOCKER_CONFIG} && \
+    curl -SL "https://github.com/docker/compose/releases/latest/download/docker-compose-linux-$(uname -m)" -o ${DOCKER_CONFIG}/docker-compose && \
+    chmod +x ${DOCKER_CONFIG}/docker-compose
+
 # Install pnpm and Claude Code
 RUN npm install -g pnpm @anthropic-ai/claude-code
 

--- a/docker/Dockerfile.claude-code
+++ b/docker/Dockerfile.claude-code
@@ -51,6 +51,12 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
     apt-get install -y gh && \
     rm -rf /var/lib/apt/lists/*
 
+# Install Docker Compose V2 plugin
+RUN DOCKER_CONFIG=/usr/lib/docker/cli-plugins && \
+    mkdir -p ${DOCKER_CONFIG} && \
+    curl -SL "https://github.com/docker/compose/releases/latest/download/docker-compose-linux-$(uname -m)" -o ${DOCKER_CONFIG}/docker-compose && \
+    chmod +x ${DOCKER_CONFIG}/docker-compose
+
 # Enable corepack for pnpm (built into Node.js) and install Claude Code
 RUN corepack enable && \
     corepack prepare pnpm@latest --activate && \


### PR DESCRIPTION
## Summary
- Installs Docker Compose V2 as a CLI plugin in the Claude Code container image
- Updates the design documentation to reflect this change

This allows sessions to use `docker compose` commands for projects that rely on docker-compose for development environments.

Fixes #81

## Test plan
- [ ] Rebuild the container image with `docker build -f docker/Dockerfile.claude-code -t claude-code-runner:latest docker/`
- [ ] Verify `docker compose version` works inside a new session container

🤖 Generated with [Claude Code](https://claude.com/claude-code)