### PR TITLE
Increase message page size and scroll trigger distance

### DIFF
--- a/src/app/session/[id]/page.tsx
+++ b/src/app/session/[id]/page.tsx
@@ -20,6 +20,8 @@ interface Message {
   sequence: number;
 }
 
+const MESSAGE_PAGE_SIZE = 20;
+
 /**
  * Hook for managing session state: fetching session data, SSE updates, and start/stop mutations.
  */
@@ -90,10 +92,10 @@ function useSessionMessages(sessionId: string) {
     hasNextPage,
     fetchNextPage,
   } = trpc.claude.getHistory.useInfiniteQuery(
-    { sessionId, limit: 10 },
+    { sessionId, limit: MESSAGE_PAGE_SIZE },
     {
       // Limit stored pages to prevent memory growth
-      // With 10 messages per page, this keeps up to 5000 messages in memory
+      // With MESSAGE_PAGE_SIZE messages per page, this keeps up to 10000 messages in memory
       maxPages: 500,
       // Message data is immutable - never refetch automatically
       staleTime: Infinity,
@@ -150,7 +152,7 @@ function useSessionMessages(sessionId: string) {
         const newMessage = trackedData.data.message;
 
         // Add message directly to the infinite query cache
-        utils.claude.getHistory.setInfiniteData({ sessionId, limit: 10 }, (old) => {
+        utils.claude.getHistory.setInfiniteData({ sessionId, limit: MESSAGE_PAGE_SIZE }, (old) => {
           if (!old) {
             // No existing data - create initial page
             return {

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -222,7 +222,7 @@ export function MessageList({
       },
       {
         root: container,
-        rootMargin: '50% 0px 0px 0px',
+        rootMargin: '100% 0px 0px 0px',
         threshold: 0,
       }
     );


### PR DESCRIPTION
## Summary
- Double message page size from 10 to 20 messages per fetch
- Double scroll trigger distance from 50% to 100% of viewport height
- Extract page size into a `MESSAGE_PAGE_SIZE` constant for maintainability

This prevents fast swiping from reaching the top of the message list before older messages have loaded.

## Test plan
- [x] Tests pass (`pnpm test:run`)
- [ ] Manually test scrolling up quickly in a session with many messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)