### PR TITLE
Show feedback when interrupting Claude with Stop button

### DIFF
--- a/src/app/session/[id]/page.tsx
+++ b/src/app/session/[id]/page.tsx
@@ -301,6 +301,7 @@ function useClaudeState(sessionId: string) {
     isRunning,
     send,
     interrupt,
+    isInterrupting: interruptMutation.isPending,
   };
 }
 
@@ -326,7 +327,12 @@ function SessionView({ sessionId }: { sessionId: string }) {
   } = useSessionMessages(sessionId);
 
   // Claude state: running, send, interrupt
-  const { isRunning: isClaudeRunning, send: sendPrompt, interrupt } = useClaudeState(sessionId);
+  const {
+    isRunning: isClaudeRunning,
+    send: sendPrompt,
+    interrupt,
+    isInterrupting,
+  } = useClaudeState(sessionId);
 
   // Working indicator: page title and favicon
   useWorkingIndicator(session?.name, isClaudeRunning);
@@ -462,6 +468,7 @@ function SessionView({ sessionId }: { sessionId: string }) {
         onSubmit={handleSendPrompt}
         onInterrupt={interrupt}
         isRunning={isClaudeRunning}
+        isInterrupting={isInterrupting}
         disabled={session.status !== 'running'}
       />
     </div>

--- a/src/components/PromptInput.tsx
+++ b/src/components/PromptInput.tsx
@@ -8,10 +8,17 @@ interface PromptInputProps {
   onSubmit: (prompt: string) => void;
   onInterrupt: () => void;
   isRunning: boolean;
+  isInterrupting: boolean;
   disabled: boolean;
 }
 
-export function PromptInput({ onSubmit, onInterrupt, isRunning, disabled }: PromptInputProps) {
+export function PromptInput({
+  onSubmit,
+  onInterrupt,
+  isRunning,
+  isInterrupting,
+  disabled,
+}: PromptInputProps) {
   const [prompt, setPrompt] = useState('');
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -60,8 +67,13 @@ export function PromptInput({ onSubmit, onInterrupt, isRunning, disabled }: Prom
         </div>
 
         {isRunning ? (
-          <Button type="button" variant="destructive" onClick={onInterrupt}>
-            Stop
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={onInterrupt}
+            disabled={isInterrupting}
+          >
+            {isInterrupting ? 'Stopping...' : 'Stop'}
           </Button>
         ) : (
           <Button type="submit" disabled={!prompt.trim() || disabled}>


### PR DESCRIPTION
## Summary
- Disable the Stop button and show "Stopping..." while the interrupt mutation is pending
- Provides visual feedback so users know their click was registered

## Test plan
- [ ] Start a Claude session and trigger a long-running operation
- [ ] Click the Stop button
- [ ] Verify the button shows "Stopping..." and is disabled until the interrupt completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)