### PR TITLE
Add CLAUDE_MCP_CONFIG support for MCP servers in session containers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,3 +39,8 @@ PASSWORD_HASH="JGFyZ29uMmlkJHY9MTkkbT02NTUzNix0PTMscD00JHlvdXJfc2FsdF9oZXJlJHlvd
 # Defaults to local build (claude-code-runner:latest)
 # For production with auto-updates, use the GHCR image:
 # CLAUDE_RUNNER_IMAGE="ghcr.io/brendanlong/clawed-burrow-runner:latest"
+
+# Optional: Claude Code MCP server configuration file
+# This file contains MCP server definitions (added via `claude mcp add`)
+# Find your config with: ls ~/.claude.json
+# CLAUDE_MCP_CONFIG="$HOME/.claude.json"

--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -500,6 +500,13 @@ ORDER BY sequence ASC;
 - Gradle's cache is safe for concurrent access (uses file locking)
 - Includes downloaded dependencies, wrapper distributions, and build caches
 
+### MCP Server Configuration
+
+- Set `CLAUDE_MCP_CONFIG` to the host's Claude MCP configuration file (e.g., `/home/user/.claude.json`)
+- This file contains MCP server definitions added via `claude mcp add` on the host
+- The file is mounted read-only at `/home/claudeuser/.claude.json` in containers
+- Allows session containers to use the same MCP servers configured on the host
+
 ## UI Screens
 
 ### Session List (Home)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,6 +22,8 @@ services:
       - PNPM_STORE_PATH=${PNPM_STORE_PATH:-}
       # Optional: shared Gradle cache path on host (for faster builds)
       - GRADLE_USER_HOME=${GRADLE_USER_HOME:-}
+      # Optional: Claude MCP server configuration file path on host
+      - CLAUDE_MCP_CONFIG=${CLAUDE_MCP_CONFIG:-}
     volumes:
       - ${HOME}/.clawed-burrow:/data
       - /var/run/docker.sock:/var/run/docker.sock

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -34,6 +34,10 @@ const envSchema = z.object({
   // Docker image to use for Claude Code runner containers
   // Defaults to local build, but can be set to GHCR image for production
   CLAUDE_RUNNER_IMAGE: z.string().default('claude-code-runner:latest'),
+  // Optional path to Claude MCP server configuration file on host
+  // This file contains MCP server definitions (added via `claude mcp add`)
+  // Example: /home/user/.claude.json
+  CLAUDE_MCP_CONFIG: z.string().optional(),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/src/server/services/docker.ts
+++ b/src/server/services/docker.ts
@@ -148,6 +148,12 @@ export async function createAndStartContainer(config: ContainerConfig): Promise<
       binds.push(`${env.GRADLE_USER_HOME}:/gradle-cache`);
     }
 
+    // Mount MCP server configuration if configured
+    // This allows Claude to use MCP servers defined on the host
+    if (env.CLAUDE_MCP_CONFIG) {
+      binds.push(`${env.CLAUDE_MCP_CONFIG}:/home/claudeuser/.claude.json:ro`);
+    }
+
     log.info('Creating new container', {
       sessionId: config.sessionId,
       image: CLAUDE_CODE_IMAGE,


### PR DESCRIPTION
## Summary

- Adds optional `CLAUDE_MCP_CONFIG` environment variable to mount the host's MCP server configuration (`~/.claude.json`) into session containers
- When configured, session containers can use MCP servers defined on the host via `claude mcp add`
- File is mounted read-only at `/home/claudeuser/.claude.json`

This resolves the issue where MCP servers configured on the host weren't available in session containers because only `~/.claude/` (the auth directory) was being mounted, but MCP server definitions live in `~/.claude.json`.

## Test plan

- [ ] Set `CLAUDE_MCP_CONFIG=$HOME/.claude.json` in `.env`
- [ ] Start a new session
- [ ] Verify MCP servers are available with `claude mcp list` inside the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)