### PR TITLE
Add unqualified-search-registries for Podman to resolve short image names

### DIFF
--- a/docker/Dockerfile.claude-code
+++ b/docker/Dockerfile.claude-code
@@ -140,5 +140,9 @@ RUN mkdir -p /home/claudeuser/.config/containers && \
     echo '[storage.options.overlay]' >> /home/claudeuser/.config/containers/storage.conf && \
     echo 'mount_program = "/usr/bin/fuse-overlayfs"' >> /home/claudeuser/.config/containers/storage.conf
 
+# Configure podman to use Docker Hub for unqualified image names
+# This allows short names like 'postgres:16' to resolve to 'docker.io/library/postgres:16'
+RUN echo 'unqualified-search-registries = ["docker.io"]' > /home/claudeuser/.config/containers/registries.conf
+
 # Entry point that keeps container alive
 CMD ["tail", "-f", "/dev/null"]


### PR DESCRIPTION
## Summary

- Configures Podman inside runner containers to use Docker Hub as the default registry for unqualified image names
- Short names like `postgres:16` now resolve to `docker.io/library/postgres:16` automatically
- Matches Docker's default behavior for better compatibility with docker-compose files

## Test plan

- [ ] Rebuild the claude-code-runner image with the updated Dockerfile
- [ ] Start a session and verify `podman pull postgres:16` works without needing the full `docker.io/library/` prefix
- [ ] Verify `podman-compose up` works with compose files that use short image names

Fixes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)