### PR TITLE
Fix Podman-in-Podman by auto-detecting host socket

### DIFF
--- a/docker/Dockerfile.claude-code
+++ b/docker/Dockerfile.claude-code
@@ -134,6 +134,8 @@ RUN git config --global user.email "claude@anthropic.com" && \
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # Configure podman for rootless operation with fuse-overlayfs
+# NOTE: This is a fallback configuration. In container-in-container setups,
+# Podman should use the host's socket instead (see profile.d script below).
 RUN mkdir -p /home/claudeuser/.config/containers && \
     echo '[storage]' > /home/claudeuser/.config/containers/storage.conf && \
     echo 'driver = "overlay"' >> /home/claudeuser/.config/containers/storage.conf && \
@@ -143,6 +145,28 @@ RUN mkdir -p /home/claudeuser/.config/containers && \
 # Configure podman to use Docker Hub for unqualified image names
 # This allows short names like 'postgres:16' to resolve to 'docker.io/library/postgres:16'
 RUN echo 'unqualified-search-registries = ["docker.io"]' > /home/claudeuser/.config/containers/registries.conf
+
+# Configure CONTAINER_HOST to use the host's Docker/Podman socket when available
+# This is critical for Podman-in-Podman setups where nested user namespaces don't work.
+# When the host socket is mounted at /var/run/docker.sock, podman commands will use
+# the host's container runtime instead of trying to run nested containers.
+# This script runs for login shells (via /etc/profile.d)
+USER root
+RUN echo '#!/bin/sh' > /etc/profile.d/container-host.sh && \
+    echo '# Auto-detect host Docker/Podman socket for container-in-container support' >> /etc/profile.d/container-host.sh && \
+    echo '# Podman-in-Podman with nested user namespaces fails, so use host socket instead' >> /etc/profile.d/container-host.sh && \
+    echo 'if [ -S /var/run/docker.sock ] && [ -z "$CONTAINER_HOST" ]; then' >> /etc/profile.d/container-host.sh && \
+    echo '    export CONTAINER_HOST="unix:///var/run/docker.sock"' >> /etc/profile.d/container-host.sh && \
+    echo 'fi' >> /etc/profile.d/container-host.sh && \
+    chmod +x /etc/profile.d/container-host.sh
+
+# Also add to bashrc for non-login shells (e.g., when running commands via docker exec)
+USER claudeuser
+RUN echo '' >> /home/claudeuser/.bashrc && \
+    echo '# Auto-detect host Docker/Podman socket for container-in-container support' >> /home/claudeuser/.bashrc && \
+    echo 'if [ -S /var/run/docker.sock ] && [ -z "$CONTAINER_HOST" ]; then' >> /home/claudeuser/.bashrc && \
+    echo '    export CONTAINER_HOST="unix:///var/run/docker.sock"' >> /home/claudeuser/.bashrc && \
+    echo 'fi' >> /home/claudeuser/.bashrc
 
 # Entry point that keeps container alive
 CMD ["tail", "-f", "/dev/null"]


### PR DESCRIPTION
## Summary

- Fixes rootless Podman-in-Podman failures caused by nested user namespace limitations
- Adds shell configuration to auto-detect and use the host's Docker/Podman socket when mounted
- Updates design documentation explaining why this is required

## Problem

When running inside a rootless Podman container, attempting to run nested containers fails with:
- `newuidmap: write to uid_map failed: Operation not permitted`
- `potentially insufficient UIDs or GIDs available in user namespace`

This breaks integration tests that use docker-compose (e.g., lion-reader's postgres/redis setup).

## Solution

The fix adds automatic `CONTAINER_HOST` detection in the runner container:
- `/etc/profile.d/container-host.sh` for login shells
- `.bashrc` configuration for non-login shells (docker exec)

When the host's Podman socket is mounted at `/var/run/docker.sock`, podman commands will automatically use the host's container runtime instead of trying to create nested containers.

## Test plan

- [ ] Rebuild the claude-code-runner image with these changes
- [ ] Create a new session and verify `podman run hello-world` works when socket is mounted
- [ ] Verify `podman-compose up -d` works for projects with docker-compose files

Fixes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)