### PR TITLE
Remove chown logic and unused podman functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ podman run -d \
   -e DATA_HOST_PATH="$HOME/.clawed-burrow" \
   -e NODE_ENV=production \
   -e PASSWORD_HASH="$PASSWORD_HASH" \
+  -e PODMAN_SOCKET_PATH="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/podman/podman.sock" \
   -e CLAUDE_RUNNER_IMAGE=ghcr.io/brendanlong/clawed-burrow-runner:latest \
   ${PNPM_STORE_PATH:+-e PNPM_STORE_PATH="$PNPM_STORE_PATH"} \
   ${GRADLE_USER_HOME:+-e GRADLE_USER_HOME="$GRADLE_USER_HOME"} \

--- a/src/server/services/git.ts
+++ b/src/server/services/git.ts
@@ -1,15 +1,7 @@
 import simpleGit from 'simple-git';
 import { mkdir, rm, access } from 'fs/promises';
 import { join } from 'path';
-import { exec } from 'child_process';
-import { promisify } from 'util';
 import { env } from '@/lib/env';
-
-const execAsync = promisify(exec);
-
-// UID/GID for claudeuser in session containers
-const CLAUDEUSER_UID = 1000;
-const CLAUDEUSER_GID = 1000;
 
 const WORKSPACES_DIR = join(env.DATA_DIR, 'workspaces');
 
@@ -72,10 +64,6 @@ export async function cloneRepo(
   // Create and check out a session-specific branch to avoid working directly on main/master
   const sessionBranch = `${env.SESSION_BRANCH_PREFIX}${sessionId}`;
   await repoGit.checkoutLocalBranch(sessionBranch);
-
-  // Chown the entire workspace to claudeuser (UID 1000) so the session container can write to it
-  // This is needed because the app container runs as root but session containers run as claudeuser
-  await execAsync(`chown -R ${CLAUDEUSER_UID}:${CLAUDEUSER_GID} "${workspacePath}"`);
 
   return { workspacePath, repoPath: repoName };
 }

--- a/src/server/services/podman.test.ts
+++ b/src/server/services/podman.test.ts
@@ -87,7 +87,6 @@ import {
   killProcessesByPattern,
   readFileInContainer,
   fileExistsInContainer,
-  countLinesInContainer,
   tailFileInContainer,
 } from './podman';
 
@@ -566,40 +565,6 @@ describe('podman service', () => {
       const exists = await fileExistsInContainer('test-container', '/tmp/nonexistent.txt');
 
       expect(exists).toBe(false);
-    });
-  });
-
-  describe('countLinesInContainer', () => {
-    it('should return line count', async () => {
-      mockSpawn.mockImplementation(() => {
-        const proc = createMockProcess();
-        process.nextTick(() => {
-          proc.stdout.emit('data', Buffer.from('42 /tmp/test.txt\n'));
-          proc.emit('close', 0);
-        });
-        return proc;
-      });
-
-      const count = await countLinesInContainer('test-container', '/tmp/test.txt');
-
-      expect(count).toBe(42);
-      expect(mockSpawn).toHaveBeenCalledWith(
-        'podman',
-        ['exec', 'test-container', 'wc', '-l', '/tmp/test.txt'],
-        podmanEnvMatcher
-      );
-    });
-
-    it('should return 0 on error', async () => {
-      mockSpawn.mockImplementation(() => {
-        const proc = createMockProcess();
-        process.nextTick(() => proc.emit('close', 1));
-        return proc;
-      });
-
-      const count = await countLinesInContainer('test-container', '/tmp/test.txt');
-
-      expect(count).toBe(0);
     });
   });
 


### PR DESCRIPTION
With --userns=keep-id, UID mapping is consistent between the main container and session containers, so explicit chown is no longer needed. Also remove deprecated execInContainerWithOutputFile and unused countLinesInContainer functions.

- Remove chown call from git.ts clone function
- Remove execInContainerWithOutputFile (deprecated, unused)
- Remove countLinesInContainer (unused in production)
- Add PODMAN_SOCKET_PATH to README example command