### PR TITLE
Add SKIP_IMAGE_PULL env var to disable runner image pulls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,4 +40,8 @@ PASSWORD_HASH="JGFyZ29uMmlkJHY9MTkkbT02NTUzNix0PTMscD00JHlvdXJfc2FsdF9oZXJlJHlvd
 # For production with auto-updates, use the GHCR image:
 # CLAUDE_RUNNER_IMAGE="ghcr.io/brendanlong/clawed-burrow-runner:latest"
 
+# Optional: Skip pulling runner images on container start
+# Useful for testing local image builds without pushing to registry
+# SKIP_IMAGE_PULL="true"
+
 PODMAN_SOCKET_PATH="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/podman/podman.sock"

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -38,6 +38,12 @@ const envSchema = z.object({
   // This socket is mounted into runner containers so Claude Code can run podman/docker commands
   // Example: /run/user/1000/podman/podman.sock
   PODMAN_SOCKET_PATH: z.string().optional(),
+  // Skip pulling runner images on container start
+  // Useful for testing local image builds without pushing to registry
+  SKIP_IMAGE_PULL: z
+    .string()
+    .optional()
+    .transform((val) => val === 'true' || val === '1'),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/src/server/services/podman.ts
+++ b/src/server/services/podman.ts
@@ -120,8 +120,15 @@ async function runPodmanIgnoreErrors(args: string[]): Promise<string> {
 /**
  * Ensure an image is up-to-date by pulling it.
  * Pulls are rate-limited to once per 5 minutes per image to avoid excessive pulls.
+ * Set SKIP_IMAGE_PULL=true to skip pulling entirely (useful for testing local builds).
  */
 async function ensureImagePulled(imageName: string): Promise<void> {
+  // Skip pulling if explicitly disabled (useful for testing local image builds)
+  if (env.SKIP_IMAGE_PULL) {
+    log.debug('Skipping pull, SKIP_IMAGE_PULL is set', { imageName });
+    return;
+  }
+
   const lastPull = lastPullTime.get(imageName);
   const now = Date.now();
 


### PR DESCRIPTION
## Summary
- Adds `SKIP_IMAGE_PULL` env var that disables automatic image pulls on container start
- When set to `true` or `1`, the service uses whatever runner image is available locally
- Useful for testing local image builds without pushing to a registry

## Test plan
- [x] Tests pass (`pnpm test:run`)
- [ ] Verify setting `SKIP_IMAGE_PULL=true` skips pull attempts
- [ ] Verify normal behavior without the env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)