### PR TITLE
Mount ~/.claude.json config file into runner containers

### DIFF
--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -4,7 +4,11 @@ import { resolve } from 'path';
 const envSchema = z.object({
   DATABASE_URL: z.string().default('file:./data/dev.db'),
   GITHUB_TOKEN: z.string().optional(),
+  // Path to the .claude directory containing credentials, history, etc.
   CLAUDE_AUTH_PATH: z.string().default('/root/.claude'),
+  // Path to the .claude.json config file (separate from .claude directory)
+  // Defaults to sibling of CLAUDE_AUTH_PATH (e.g., /root/.claude.json)
+  CLAUDE_CONFIG_PATH: z.string().optional(),
   // Path inside the container where data is mounted (for filesystem operations)
   DATA_DIR: z
     .string()

--- a/src/server/services/podman.ts
+++ b/src/server/services/podman.ts
@@ -217,6 +217,11 @@ export async function createAndStartContainer(config: ContainerConfig): Promise<
       `${env.CLAUDE_AUTH_PATH}:/home/claudeuser/.claude`,
     ];
 
+    // Mount .claude.json config file (separate from .claude directory)
+    // Defaults to sibling of CLAUDE_AUTH_PATH (e.g., /root/.claude → /root/.claude.json)
+    const claudeConfigPath = env.CLAUDE_CONFIG_PATH || `${env.CLAUDE_AUTH_PATH}.json`;
+    volumeArgs.push('-v', `${claudeConfigPath}:/home/claudeuser/.claude.json`);
+
     // Mount shared pnpm store if configured
     if (env.PNPM_STORE_PATH) {
       volumeArgs.push('-v', `${env.PNPM_STORE_PATH}:/pnpm-store`);


### PR DESCRIPTION
## Summary

- Fixes missing `.claude.json` config file in runner containers
- The `.claude.json` file is separate from the `.claude` directory and wasn't being mounted
- This caused runner containers to lose project settings, allowedTools, and other config

## Changes

- Added `CLAUDE_CONFIG_PATH` env var (optional, defaults to `CLAUDE_AUTH_PATH.json`)
- Mount the config file to `/home/claudeuser/.claude.json` in runner containers

## Test plan

- [x] Unit tests pass
- [x] TypeScript compiles
- [ ] Deploy and verify new containers have full `.claude.json` from host

🤖 Generated with [Claude Code](https://claude.com/claude-code)