### PR TITLE
Add React component tests with Testing Library

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "test:run": "vitest run",
     "test:unit": "vitest run --config vitest.config.ts",
     "test:integration": "vitest run --config vitest.integration.config.ts",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:component": "vitest run --config vitest.component.config.ts"
   },
   "dependencies": {
     "@prisma/client": "^5.22.0",
@@ -61,25 +62,29 @@
     "zod": "^4.3.5"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/dockerode": "^4.0.0",
     "@types/event-source-polyfill": "^1.0.5",
     "@types/node": "^25.0.9",
     "@types/react": "^19.2.8",
     "@types/react-dom": "^19.2.3",
     "@types/uuid": "^10.0.0",
+    "@vitest/coverage-v8": "^4.0.17",
     "autoprefixer": "^10.4.23",
     "eslint": "^9.39.2",
     "eslint-config-next": "^16.1.3",
     "eslint-config-prettier": "^10.1.8",
     "husky": "^9.1.7",
+    "jsdom": "^27.4.0",
     "lint-staged": "^16.2.7",
     "postcss": "^8.5.6",
     "prettier": "^3.8.0",
     "tailwindcss": "^3.4.19",
     "tsx": "^4.21.0",
     "typescript-eslint": "^8.53.1",
-    "vitest": "^4.0.17",
-    "@vitest/coverage-v8": "^4.0.17"
+    "vitest": "^4.0.17"
   },
   "packageManager": "pnpm@10.26.2+sha512.0e308ff2005fc7410366f154f625f6631ab2b16b1d2e70238444dd6ae9d630a8482d92a451144debc492416896ed16f7b114a86ec68b8404b2443869e68ffda6",
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,15 @@ importers:
         specifier: ^4.3.5
         version: 4.3.5
     devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/dockerode':
         specifier: ^4.0.0
         version: 4.0.0
@@ -134,7 +143,7 @@ importers:
         version: 10.0.0
       '@vitest/coverage-v8':
         specifier: ^4.0.17
-        version: 4.0.17(vitest@4.0.17(@types/node@25.0.9)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.0.17(vitest@4.0.17(@types/node@25.0.9)(jiti@1.21.7)(jsdom@27.4.0)(tsx@4.21.0)(yaml@2.8.2))
       autoprefixer:
         specifier: ^10.4.23
         version: 10.4.23(postcss@8.5.6)
@@ -150,6 +159,9 @@ importers:
       husky:
         specifier: ^9.1.7
         version: 9.1.7
+      jsdom:
+        specifier: ^27.4.0
+        version: 27.4.0
       lint-staged:
         specifier: ^16.2.7
         version: 16.2.7
@@ -170,13 +182,28 @@ importers:
         version: 8.53.1(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
       vitest:
         specifier: ^4.0.17
-        version: 4.0.17(@types/node@25.0.9)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.17(@types/node@25.0.9)(jiti@1.21.7)(jsdom@27.4.0)(tsx@4.21.0)(yaml@2.8.2)
 
 packages:
+
+  '@acemir/cssom@0.9.31':
+    resolution: {integrity: sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==}
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@asamuzakjp/css-color@4.1.1':
+    resolution: {integrity: sha512-B0Hv6G3gWGMn0xKJ0txEi/jM5iFpT3MfDxmhZFb4W047GvytCf1DHQ1D69W3zHI4yWe2aTZAA0JnbMZ7Xc8DuQ==}
+
+  '@asamuzakjp/dom-selector@6.7.6':
+    resolution: {integrity: sha512-hBaJER6A9MpdG3WgdlOolHmbOYvSk46y7IQN/1+iqiCuUu6iWdQrs9DGKF8ocqsEqWujWf/V7b7vaDgiUmIvUg==}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.28.6':
     resolution: {integrity: sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==}
@@ -233,6 +260,10 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/runtime@7.28.6':
+    resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
@@ -250,6 +281,38 @@ packages:
 
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-syntax-patches-for-csstree@1.0.25':
+    resolution: {integrity: sha512-g0Kw9W3vjx5BEBAF8c5Fm2NcB/Fs8jJXh85aXqwEXiL+tqtOut07TWgyaGzAAfTM+gKckrrncyeGEZPcaRgm2Q==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
 
   '@emnapi/core@1.8.1':
@@ -454,6 +517,15 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@exodus/bytes@1.9.0':
+    resolution: {integrity: sha512-lagqsvnk09NKogQaN/XrtlWeUF8SRhT12odMvbTIIaVObqzwAogL6jhR4DAp0gPuKoM1AOVrKUshJpRdpMFrww==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@floating-ui/core@1.7.3':
     resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
@@ -1313,6 +1385,35 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@trpc/client@11.8.1':
     resolution: {integrity: sha512-L/SJFGanr9xGABmuDoeXR4xAdHJmsXsiF9OuH+apecJ+8sUITzVT1EPeqp0ebqA6lBhEl5pPfg3rngVhi/h60Q==}
     peerDependencies:
@@ -1353,6 +1454,9 @@ packages:
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -1600,6 +1704,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
@@ -1618,6 +1726,10 @@ packages:
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
 
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
@@ -1648,6 +1760,9 @@ packages:
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -1733,6 +1848,9 @@ packages:
 
   bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -1859,16 +1977,31 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.1.0:
+    resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  cssstyle@5.3.7:
+    resolution: {integrity: sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==}
+    engines: {node: '>=20'}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
+  data-urls@6.0.1:
+    resolution: {integrity: sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==}
+    engines: {node: '>=20'}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -1899,6 +2032,9 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -1909,6 +2045,10 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -1935,6 +2075,12 @@ packages:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
 
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -1956,6 +2102,10 @@ packages:
 
   entities@2.2.0:
     resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
 
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
@@ -2309,8 +2459,20 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
@@ -2335,6 +2497,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -2422,6 +2588,9 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -2497,6 +2666,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@27.4.0:
+    resolution: {integrity: sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -2576,6 +2754,10 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  lru-cache@11.2.4:
+    resolution: {integrity: sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -2583,6 +2765,10 @@ packages:
     resolution: {integrity: sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -2603,6 +2789,9 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdn-data@2.12.2:
+    resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -2614,6 +2803,10 @@ packages:
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -2756,6 +2949,9 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse5@8.0.0:
+    resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -2858,6 +3054,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   prisma@5.22.0:
     resolution: {integrity: sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==}
     engines: {node: '>=16.13'}
@@ -2887,6 +3087,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -2933,6 +3136,10 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
@@ -2943,6 +3150,10 @@ packages:
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
   resolve-from@4.0.0:
@@ -2997,6 +3208,10 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -3142,6 +3357,10 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -3175,6 +3394,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tailwind-merge@3.4.0:
     resolution: {integrity: sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==}
@@ -3218,9 +3440,24 @@ packages:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.0.19:
+    resolution: {integrity: sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A==}
+
+  tldts@7.0.19:
+    resolution: {integrity: sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  tough-cookie@6.0.0:
+    resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   ts-api-utils@2.4.0:
     resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
@@ -3404,6 +3641,26 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@15.1.0:
+    resolution: {integrity: sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==}
+    engines: {node: '>=20'}
+
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -3445,6 +3702,25 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  ws@8.19.0:
+    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -3480,7 +3756,29 @@ packages:
 
 snapshots:
 
+  '@acemir/cssom@0.9.31': {}
+
+  '@adobe/css-tools@4.4.4': {}
+
   '@alloc/quick-lru@5.2.0': {}
+
+  '@asamuzakjp/css-color@4.1.1':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 11.2.4
+
+  '@asamuzakjp/dom-selector@6.7.6':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.1.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.2.4
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.28.6':
     dependencies:
@@ -3559,6 +3857,8 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.6
 
+  '@babel/runtime@7.28.6': {}
+
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.28.6
@@ -3585,6 +3885,28 @@ snapshots:
   '@balena/dockerignore@1.0.2': {}
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-syntax-patches-for-csstree@1.0.25': {}
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@emnapi/core@1.8.1':
     dependencies:
@@ -3725,6 +4047,8 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@exodus/bytes@1.9.0': {}
 
   '@floating-ui/core@1.7.3':
     dependencies:
@@ -4441,6 +4765,40 @@ snapshots:
       '@tanstack/query-core': 5.90.19
       react: 19.2.3
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.28.6
+      '@babel/runtime': 7.28.6
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@testing-library/dom': 10.4.1
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@trpc/client@11.8.1(@trpc/server@11.8.1(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
       '@trpc/server': 11.8.1(typescript@5.9.3)
@@ -4475,6 +4833,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.3':
     dependencies:
@@ -4674,7 +5034,7 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitest/coverage-v8@4.0.17(vitest@4.0.17(@types/node@25.0.9)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/coverage-v8@4.0.17(vitest@4.0.17(@types/node@25.0.9)(jiti@1.21.7)(jsdom@27.4.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.17
@@ -4686,7 +5046,7 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.17(@types/node@25.0.9)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.0.17(@types/node@25.0.9)(jiti@1.21.7)(jsdom@27.4.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/expect@4.0.17':
     dependencies:
@@ -4733,6 +5093,8 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  agent-base@7.1.4: {}
+
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -4751,6 +5113,8 @@ snapshots:
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansi-styles@5.2.0: {}
 
   ansi-styles@6.2.3: {}
 
@@ -4778,6 +5142,10 @@ snapshots:
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.2: {}
 
@@ -4890,6 +5258,10 @@ snapshots:
   bcrypt-pbkdf@1.0.2:
     dependencies:
       tweetnacl: 0.14.5
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   binary-extensions@2.3.0: {}
 
@@ -5027,11 +5399,30 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.1.0:
+    dependencies:
+      mdn-data: 2.12.2
+      source-map-js: 1.2.1
+
+  css.escape@1.5.1: {}
+
   cssesc@3.0.0: {}
+
+  cssstyle@5.3.7:
+    dependencies:
+      '@asamuzakjp/css-color': 4.1.1
+      '@csstools/css-syntax-patches-for-csstree': 1.0.25
+      css-tree: 3.1.0
+      lru-cache: 11.2.4
 
   csstype@3.2.3: {}
 
   damerau-levenshtein@1.0.8: {}
+
+  data-urls@6.0.1:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 15.1.0
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -5059,6 +5450,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decimal.js@10.6.0: {}
+
   deep-is@0.1.4: {}
 
   define-data-property@1.1.4:
@@ -5072,6 +5465,8 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  dequal@2.0.3: {}
 
   detect-libc@2.1.2:
     optional: true
@@ -5107,6 +5502,10 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -5126,6 +5525,8 @@ snapshots:
       once: 1.4.0
 
   entities@2.2.0: {}
+
+  entities@6.0.1: {}
 
   environment@1.1.0: {}
 
@@ -5641,7 +6042,27 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.9.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-escaper@2.0.2: {}
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   husky@9.1.7: {}
 
@@ -5657,6 +6078,8 @@ snapshots:
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   inherits@2.0.4: {}
 
@@ -5749,6 +6172,8 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -5825,6 +6250,34 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@27.4.0:
+    dependencies:
+      '@acemir/cssom': 0.9.31
+      '@asamuzakjp/dom-selector': 6.7.6
+      '@exodus/bytes': 1.9.0
+      cssstyle: 5.3.7
+      data-urls: 6.0.1
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      parse5: 8.0.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 15.1.0
+      ws: 8.19.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   jsesc@3.1.0: {}
 
@@ -5907,6 +6360,8 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  lru-cache@11.2.4: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -5914,6 +6369,8 @@ snapshots:
   lucide-react@0.562.0(react@19.2.3):
     dependencies:
       react: 19.2.3
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -5933,6 +6390,8 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  mdn-data@2.12.2: {}
+
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
@@ -5941,6 +6400,8 @@ snapshots:
       picomatch: 2.3.1
 
   mimic-function@5.0.1: {}
+
+  min-indent@1.0.1: {}
 
   minimatch@3.1.2:
     dependencies:
@@ -6086,6 +6547,10 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse5@8.0.0:
+    dependencies:
+      entities: 6.0.1
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -6157,6 +6622,12 @@ snapshots:
 
   prettier@3.8.0: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   prisma@5.22.0:
     dependencies:
       '@prisma/engines': 5.22.0
@@ -6199,6 +6670,8 @@ snapshots:
       scheduler: 0.27.0
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.8)(react@19.2.3):
     dependencies:
@@ -6243,6 +6716,11 @@ snapshots:
     dependencies:
       picomatch: 2.3.1
 
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
   reflect.getprototypeof@1.0.10:
     dependencies:
       call-bind: 1.0.8
@@ -6264,6 +6742,8 @@ snapshots:
       set-function-name: 2.0.2
 
   require-directory@2.1.1: {}
+
+  require-from-string@2.0.2: {}
 
   resolve-from@4.0.0: {}
 
@@ -6347,6 +6827,10 @@ snapshots:
       is-regex: 1.2.1
 
   safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -6565,6 +7049,10 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   strip-json-comments@3.1.1: {}
 
   styled-jsx@5.1.6(@babel/core@7.28.6)(react@19.2.3):
@@ -6593,6 +7081,8 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  symbol-tree@3.2.4: {}
 
   tailwind-merge@3.4.0: {}
 
@@ -6662,9 +7152,23 @@ snapshots:
 
   tinyrainbow@3.0.3: {}
 
+  tldts-core@7.0.19: {}
+
+  tldts@7.0.19:
+    dependencies:
+      tldts-core: 7.0.19
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  tough-cookie@6.0.0:
+    dependencies:
+      tldts: 7.0.19
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
@@ -6821,7 +7325,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.2
 
-  vitest@4.0.17(@types/node@25.0.9)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2):
+  vitest@4.0.17(@types/node@25.0.9)(jiti@1.21.7)(jsdom@27.4.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.17
       '@vitest/mocker': 4.0.17(vite@7.3.1(@types/node@25.0.9)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2))
@@ -6845,6 +7349,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.0.9
+      jsdom: 27.4.0
     transitivePeerDependencies:
       - jiti
       - less
@@ -6857,6 +7362,21 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@15.1.0:
+    dependencies:
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -6923,6 +7443,12 @@ snapshots:
       strip-ansi: 7.1.2
 
   wrappy@1.0.2: {}
+
+  ws@8.19.0: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   y18n@5.0.8: {}
 

--- a/src/components/PromptInput.test.tsx
+++ b/src/components/PromptInput.test.tsx
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { PromptInput } from './PromptInput';
+
+describe('PromptInput', () => {
+  const defaultProps = {
+    onSubmit: vi.fn(),
+    onInterrupt: vi.fn(),
+    isRunning: false,
+    isInterrupting: false,
+    disabled: false,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('rendering', () => {
+    it('renders textarea and send button', () => {
+      render(<PromptInput {...defaultProps} />);
+
+      expect(screen.getByRole('textbox')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /send/i })).toBeInTheDocument();
+    });
+
+    it('shows default placeholder when idle', () => {
+      render(<PromptInput {...defaultProps} />);
+
+      expect(
+        screen.getByPlaceholderText(/type your message.*enter to send.*shift\+enter for new line/i)
+      ).toBeInTheDocument();
+    });
+
+    it('shows "Claude is thinking..." placeholder when running', () => {
+      render(<PromptInput {...defaultProps} isRunning={true} />);
+
+      expect(screen.getByPlaceholderText(/claude is thinking/i)).toBeInTheDocument();
+    });
+
+    it('shows "Session is not running" placeholder when disabled', () => {
+      render(<PromptInput {...defaultProps} disabled={true} />);
+
+      expect(screen.getByPlaceholderText(/session is not running/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('send button behavior', () => {
+    it('shows Stop button when Claude is running', () => {
+      render(<PromptInput {...defaultProps} isRunning={true} />);
+
+      expect(screen.getByRole('button', { name: /stop/i })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /send/i })).not.toBeInTheDocument();
+    });
+
+    it('shows "Stopping..." when isInterrupting is true', () => {
+      render(<PromptInput {...defaultProps} isRunning={true} isInterrupting={true} />);
+
+      expect(screen.getByRole('button', { name: /stopping/i })).toBeInTheDocument();
+    });
+
+    it('disables send button when input is empty', () => {
+      render(<PromptInput {...defaultProps} />);
+
+      expect(screen.getByRole('button', { name: /send/i })).toBeDisabled();
+    });
+
+    it('disables send button when component is disabled', () => {
+      render(<PromptInput {...defaultProps} disabled={true} />);
+
+      expect(screen.getByRole('button', { name: /send/i })).toBeDisabled();
+    });
+
+    it('enables send button when input has content', async () => {
+      const user = userEvent.setup();
+      render(<PromptInput {...defaultProps} />);
+
+      await user.type(screen.getByRole('textbox'), 'Hello');
+
+      expect(screen.getByRole('button', { name: /send/i })).not.toBeDisabled();
+    });
+
+    it('disables stop button when isInterrupting is true', () => {
+      render(<PromptInput {...defaultProps} isRunning={true} isInterrupting={true} />);
+
+      expect(screen.getByRole('button', { name: /stopping/i })).toBeDisabled();
+    });
+  });
+
+  describe('form submission', () => {
+    it('calls onSubmit with trimmed prompt when send button is clicked', async () => {
+      const onSubmit = vi.fn();
+      const user = userEvent.setup();
+      render(<PromptInput {...defaultProps} onSubmit={onSubmit} />);
+
+      await user.type(screen.getByRole('textbox'), '  Hello world  ');
+      await user.click(screen.getByRole('button', { name: /send/i }));
+
+      expect(onSubmit).toHaveBeenCalledWith('Hello world');
+    });
+
+    it('clears input after successful submission', async () => {
+      const user = userEvent.setup();
+      render(<PromptInput {...defaultProps} />);
+
+      const textarea = screen.getByRole('textbox');
+      await user.type(textarea, 'Test message');
+      await user.click(screen.getByRole('button', { name: /send/i }));
+
+      expect(textarea).toHaveValue('');
+    });
+
+    it('does not call onSubmit when input is empty', async () => {
+      const onSubmit = vi.fn();
+      const user = userEvent.setup();
+      render(<PromptInput {...defaultProps} onSubmit={onSubmit} />);
+
+      await user.click(screen.getByRole('button', { name: /send/i }));
+
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('does not call onSubmit when input is only whitespace', async () => {
+      const onSubmit = vi.fn();
+      const user = userEvent.setup();
+      render(<PromptInput {...defaultProps} onSubmit={onSubmit} />);
+
+      await user.type(screen.getByRole('textbox'), '   ');
+      await user.click(screen.getByRole('button', { name: /send/i }));
+
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('does not call onSubmit when disabled', async () => {
+      const onSubmit = vi.fn();
+      const user = userEvent.setup();
+      render(<PromptInput {...defaultProps} onSubmit={onSubmit} disabled={true} />);
+
+      // Try to type (won't work since disabled)
+      await user.type(screen.getByRole('textbox'), 'Test');
+
+      // Button should still be disabled
+      expect(screen.getByRole('button', { name: /send/i })).toBeDisabled();
+    });
+
+    it('does not call onSubmit when running', () => {
+      const onSubmit = vi.fn();
+      render(<PromptInput {...defaultProps} onSubmit={onSubmit} isRunning={true} />);
+
+      // Textarea should be disabled when running
+      expect(screen.getByRole('textbox')).toBeDisabled();
+    });
+  });
+
+  describe('keyboard handling', () => {
+    it('submits on Enter key', async () => {
+      const onSubmit = vi.fn();
+      const user = userEvent.setup();
+      render(<PromptInput {...defaultProps} onSubmit={onSubmit} />);
+
+      await user.type(screen.getByRole('textbox'), 'Test message{Enter}');
+
+      expect(onSubmit).toHaveBeenCalledWith('Test message');
+    });
+
+    it('does not submit on Shift+Enter', async () => {
+      const onSubmit = vi.fn();
+      const user = userEvent.setup();
+      render(<PromptInput {...defaultProps} onSubmit={onSubmit} />);
+
+      await user.type(screen.getByRole('textbox'), 'Line 1{Shift>}{Enter}{/Shift}Line 2');
+
+      expect(onSubmit).not.toHaveBeenCalled();
+      expect(screen.getByRole('textbox')).toHaveValue('Line 1\nLine 2');
+    });
+  });
+
+  describe('interrupt behavior', () => {
+    it('calls onInterrupt when Stop button is clicked', async () => {
+      const onInterrupt = vi.fn();
+      const user = userEvent.setup();
+      render(<PromptInput {...defaultProps} onInterrupt={onInterrupt} isRunning={true} />);
+
+      await user.click(screen.getByRole('button', { name: /stop/i }));
+
+      expect(onInterrupt).toHaveBeenCalled();
+    });
+
+    it('does not call onInterrupt when button is disabled', async () => {
+      const onInterrupt = vi.fn();
+      render(
+        <PromptInput
+          {...defaultProps}
+          onInterrupt={onInterrupt}
+          isRunning={true}
+          isInterrupting={true}
+        />
+      );
+
+      // Button should be disabled
+      expect(screen.getByRole('button', { name: /stopping/i })).toBeDisabled();
+    });
+  });
+
+  describe('textarea behavior', () => {
+    it('disables textarea when component is disabled', () => {
+      render(<PromptInput {...defaultProps} disabled={true} />);
+
+      expect(screen.getByRole('textbox')).toBeDisabled();
+    });
+
+    it('disables textarea when Claude is running', () => {
+      render(<PromptInput {...defaultProps} isRunning={true} />);
+
+      expect(screen.getByRole('textbox')).toBeDisabled();
+    });
+
+    it('allows typing when not disabled or running', async () => {
+      const user = userEvent.setup();
+      render(<PromptInput {...defaultProps} />);
+
+      const textarea = screen.getByRole('textbox');
+      await user.type(textarea, 'Hello');
+
+      expect(textarea).toHaveValue('Hello');
+    });
+  });
+});

--- a/src/components/SessionList.test.tsx
+++ b/src/components/SessionList.test.tsx
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { trpc } from '@/lib/trpc';
+
+// Mock the trpc module
+vi.mock('@/lib/trpc', () => ({
+  trpc: {
+    sessions: {
+      list: {
+        useQuery: vi.fn(),
+      },
+      start: {
+        useMutation: vi.fn(() => ({
+          mutate: vi.fn(),
+          isPending: false,
+        })),
+      },
+      stop: {
+        useMutation: vi.fn(() => ({
+          mutate: vi.fn(),
+          isPending: false,
+        })),
+      },
+      delete: {
+        useMutation: vi.fn(() => ({
+          mutate: vi.fn(),
+          isPending: false,
+        })),
+      },
+    },
+  },
+}));
+
+// Mock next/link
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+// Import component after mocks are set up
+import { SessionList } from './SessionList';
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe('SessionList', () => {
+  const mockUseQuery = vi.mocked(trpc.sessions.list.useQuery);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('loading state', () => {
+    it('shows spinner while loading', () => {
+      mockUseQuery.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        refetch: vi.fn(),
+      } as unknown as ReturnType<typeof trpc.sessions.list.useQuery>);
+
+      render(<SessionList />, { wrapper: createWrapper() });
+
+      // Check for spinner (via role or class)
+      const spinner = document.querySelector('[class*="animate-spin"]');
+      expect(spinner).toBeInTheDocument();
+    });
+  });
+
+  describe('empty state', () => {
+    it('shows empty state message when no sessions', () => {
+      mockUseQuery.mockReturnValue({
+        data: { sessions: [] },
+        isLoading: false,
+        refetch: vi.fn(),
+      } as unknown as ReturnType<typeof trpc.sessions.list.useQuery>);
+
+      render(<SessionList />, { wrapper: createWrapper() });
+
+      expect(screen.getByText('No sessions yet')).toBeInTheDocument();
+      expect(screen.getByText('Get started by creating a new session.')).toBeInTheDocument();
+    });
+
+    it('shows "New Session" link in empty state', () => {
+      mockUseQuery.mockReturnValue({
+        data: { sessions: [] },
+        isLoading: false,
+        refetch: vi.fn(),
+      } as unknown as ReturnType<typeof trpc.sessions.list.useQuery>);
+
+      render(<SessionList />, { wrapper: createWrapper() });
+
+      const newSessionLink = screen.getByRole('link', { name: /new session/i });
+      expect(newSessionLink).toBeInTheDocument();
+      expect(newSessionLink).toHaveAttribute('href', '/new');
+    });
+  });
+
+  describe('sessions list', () => {
+    const mockSessions = [
+      {
+        id: 'session-1',
+        name: 'Test Session 1',
+        repoUrl: 'https://github.com/user/repo1.git',
+        branch: 'main',
+        status: 'running',
+        updatedAt: new Date('2024-01-15T10:00:00Z'),
+      },
+      {
+        id: 'session-2',
+        name: 'Test Session 2',
+        repoUrl: 'https://github.com/user/repo2.git',
+        branch: 'feature-branch',
+        status: 'stopped',
+        updatedAt: new Date('2024-01-14T09:00:00Z'),
+      },
+    ];
+
+    it('renders list of sessions', () => {
+      mockUseQuery.mockReturnValue({
+        data: { sessions: mockSessions },
+        isLoading: false,
+        refetch: vi.fn(),
+      } as unknown as ReturnType<typeof trpc.sessions.list.useQuery>);
+
+      render(<SessionList />, { wrapper: createWrapper() });
+
+      expect(screen.getByText('Test Session 1')).toBeInTheDocument();
+      expect(screen.getByText('Test Session 2')).toBeInTheDocument();
+    });
+
+    it('links to individual session pages', () => {
+      mockUseQuery.mockReturnValue({
+        data: { sessions: mockSessions },
+        isLoading: false,
+        refetch: vi.fn(),
+      } as unknown as ReturnType<typeof trpc.sessions.list.useQuery>);
+
+      render(<SessionList />, { wrapper: createWrapper() });
+
+      const sessionLinks = screen.getAllByRole('link');
+      const session1Link = sessionLinks.find((link) =>
+        link.getAttribute('href')?.includes('session-1')
+      );
+      expect(session1Link).toHaveAttribute('href', '/session/session-1');
+    });
+
+    it('renders sessions in order', () => {
+      mockUseQuery.mockReturnValue({
+        data: { sessions: mockSessions },
+        isLoading: false,
+        refetch: vi.fn(),
+      } as unknown as ReturnType<typeof trpc.sessions.list.useQuery>);
+
+      render(<SessionList />, { wrapper: createWrapper() });
+
+      const sessionNames = screen.getAllByRole('listitem');
+      expect(sessionNames).toHaveLength(2);
+    });
+  });
+
+  describe('data handling', () => {
+    it('handles undefined data gracefully', () => {
+      mockUseQuery.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        refetch: vi.fn(),
+      } as unknown as ReturnType<typeof trpc.sessions.list.useQuery>);
+
+      render(<SessionList />, { wrapper: createWrapper() });
+
+      // Should show empty state when data is undefined
+      expect(screen.getByText('No sessions yet')).toBeInTheDocument();
+    });
+
+    it('handles null sessions array gracefully', () => {
+      mockUseQuery.mockReturnValue({
+        data: { sessions: null },
+        isLoading: false,
+        refetch: vi.fn(),
+      } as unknown as ReturnType<typeof trpc.sessions.list.useQuery>);
+
+      render(<SessionList />, { wrapper: createWrapper() });
+
+      // Should show empty state
+      expect(screen.getByText('No sessions yet')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/messages/MessageBubble.test.tsx
+++ b/src/components/messages/MessageBubble.test.tsx
@@ -1,0 +1,371 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MessageBubble } from './MessageBubble';
+import type { ToolResultMap, MessageContent } from './types';
+
+describe('MessageBubble', () => {
+  describe('unrecognized messages', () => {
+    it('shows raw JSON for unrecognized message types', () => {
+      const message = {
+        type: 'unknown_type',
+        content: { someField: 'value' },
+      };
+
+      render(<MessageBubble message={message} />);
+
+      expect(screen.getByText(/Unknown: unknown_type/)).toBeInTheDocument();
+    });
+
+    it('shows raw JSON for assistant messages without content array', () => {
+      const message = {
+        type: 'assistant',
+        content: { message: { invalid: true } }, // No content array
+      };
+
+      render(<MessageBubble message={message} />);
+
+      expect(screen.getByText(/Unknown: assistant/)).toBeInTheDocument();
+    });
+  });
+
+  describe('assistant messages', () => {
+    it('renders text content from assistant message', () => {
+      const message = {
+        type: 'assistant',
+        content: {
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'Hello, how can I help you today?' }],
+          },
+        } as MessageContent,
+      };
+
+      render(<MessageBubble message={message} />);
+
+      expect(screen.getByText('Hello, how can I help you today?')).toBeInTheDocument();
+    });
+
+    it('renders multiple text blocks joined', () => {
+      const message = {
+        type: 'assistant',
+        content: {
+          message: {
+            content: [
+              { type: 'text', text: 'First paragraph.' },
+              { type: 'text', text: 'Second paragraph.' },
+            ],
+          },
+        } as MessageContent,
+      };
+
+      render(<MessageBubble message={message} />);
+
+      expect(screen.getByText(/First paragraph/)).toBeInTheDocument();
+      expect(screen.getByText(/Second paragraph/)).toBeInTheDocument();
+    });
+
+    it('shows tool calls from assistant messages', () => {
+      const message = {
+        type: 'assistant',
+        content: {
+          message: {
+            content: [
+              { type: 'text', text: 'Let me check that file.' },
+              { type: 'tool_use', id: 'tool-1', name: 'Read', input: { file_path: '/test.txt' } },
+            ],
+          },
+        } as MessageContent,
+      };
+
+      render(<MessageBubble message={message} />);
+
+      expect(screen.getByText('Let me check that file.')).toBeInTheDocument();
+      expect(screen.getByText('Read')).toBeInTheDocument();
+    });
+
+    it('shows tool results when provided', () => {
+      const toolResults: ToolResultMap = new Map([
+        ['tool-1', { content: 'file contents here', is_error: false }],
+      ]);
+
+      const message = {
+        type: 'assistant',
+        content: {
+          message: {
+            content: [
+              { type: 'tool_use', id: 'tool-1', name: 'Read', input: { file_path: '/test.txt' } },
+            ],
+          },
+        } as MessageContent,
+      };
+
+      render(<MessageBubble message={message} toolResults={toolResults} />);
+
+      expect(screen.getByText('Read')).toBeInTheDocument();
+    });
+
+    it('shows interrupted indicator when message was interrupted', () => {
+      const message = {
+        type: 'assistant',
+        content: {
+          message: {
+            content: [{ type: 'text', text: 'I was about to...' }],
+          },
+          interrupted: true,
+        } as MessageContent,
+      };
+
+      render(<MessageBubble message={message} />);
+
+      expect(screen.getByText('May be incomplete')).toBeInTheDocument();
+    });
+  });
+
+  describe('user messages', () => {
+    it('renders simple user prompt', () => {
+      const message = {
+        type: 'user',
+        content: {
+          content: 'Can you help me with this code?',
+        } as MessageContent,
+      };
+
+      render(<MessageBubble message={message} />);
+
+      expect(screen.getByText('Can you help me with this code?')).toBeInTheDocument();
+    });
+
+    it('renders user message with content array', () => {
+      // User messages with message.content array are recognized as user,
+      // but the display uses content.content which should contain the text blocks
+      const message = {
+        type: 'user',
+        content: {
+          message: {
+            content: [{ type: 'text', text: 'User prompt text' }],
+          },
+          content: [{ type: 'text', text: 'User prompt text' }],
+        } as MessageContent,
+      };
+
+      render(<MessageBubble message={message} />);
+
+      expect(screen.getByText('User prompt text')).toBeInTheDocument();
+    });
+  });
+
+  describe('user interrupt messages', () => {
+    it('shows interrupt indicator', () => {
+      const message = {
+        type: 'user',
+        content: {
+          subtype: 'interrupt',
+        } as MessageContent,
+      };
+
+      render(<MessageBubble message={message} />);
+
+      expect(screen.getByText('Interrupted')).toBeInTheDocument();
+    });
+  });
+
+  describe('system messages', () => {
+    it('renders system message with badge', () => {
+      const message = {
+        type: 'system',
+        content: {
+          content: 'System notification text',
+        } as MessageContent,
+      };
+
+      render(<MessageBubble message={message} />);
+
+      expect(screen.getByText('System')).toBeInTheDocument();
+      expect(screen.getByText('System notification text')).toBeInTheDocument();
+    });
+  });
+
+  describe('system init messages', () => {
+    it('renders session started display', () => {
+      const message = {
+        type: 'system',
+        content: {
+          subtype: 'init',
+          model: 'claude-3-opus',
+          claude_code_version: '1.0.0',
+          session_id: 'test-session-123',
+          cwd: '/workspace',
+        } as MessageContent,
+      };
+
+      render(<MessageBubble message={message} />);
+
+      expect(screen.getByText('Session Started')).toBeInTheDocument();
+      expect(screen.getByText(/claude-3-opus/)).toBeInTheDocument();
+    });
+  });
+
+  describe('system error messages', () => {
+    it('renders error badge and content', () => {
+      const message = {
+        type: 'system',
+        content: {
+          subtype: 'error',
+          content: [{ type: 'text', text: 'An error occurred' }],
+        } as MessageContent,
+      };
+
+      render(<MessageBubble message={message} />);
+
+      expect(screen.getByText('Error')).toBeInTheDocument();
+    });
+  });
+
+  describe('result messages', () => {
+    it('renders turn complete display', () => {
+      const message = {
+        type: 'result',
+        content: {
+          subtype: 'success',
+          session_id: 'test-session',
+          total_cost_usd: 0.0123,
+          num_turns: 3,
+          duration_ms: 5000,
+        } as MessageContent,
+      };
+
+      render(<MessageBubble message={message} />);
+
+      expect(screen.getByText('Turn Complete')).toBeInTheDocument();
+      expect(screen.getByText(/\$0\.0123/)).toBeInTheDocument();
+    });
+
+    it('renders error result', () => {
+      const message = {
+        type: 'result',
+        content: {
+          subtype: 'error',
+          session_id: 'test-session',
+          num_turns: 1,
+        } as MessageContent,
+      };
+
+      render(<MessageBubble message={message} />);
+
+      expect(screen.getByText('Error')).toBeInTheDocument();
+    });
+  });
+
+  describe('tool result messages', () => {
+    it('renders tool result display for tool_result content', () => {
+      const message = {
+        type: 'user',
+        content: {
+          message: {
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: 'tool-1',
+                content: 'Tool execution output',
+              },
+            ],
+          },
+        } as MessageContent,
+      };
+
+      render(<MessageBubble message={message} />);
+
+      // Should render as tool result, not user message
+      expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('copy functionality', () => {
+    it('renders copy button for all message types', () => {
+      const message = {
+        type: 'assistant',
+        content: {
+          message: {
+            content: [{ type: 'text', text: 'Test message' }],
+          },
+        } as MessageContent,
+      };
+
+      render(<MessageBubble message={message} />);
+
+      // CopyButton should be present
+      expect(screen.getByRole('button', { name: /copy/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('TodoWrite tracking', () => {
+    it('passes todo tracking props to TodoWrite tool displays', () => {
+      const onTodoManualToggle = vi.fn();
+      const manuallyToggledTodoIds = new Set<string>();
+
+      const message = {
+        type: 'assistant',
+        content: {
+          message: {
+            content: [
+              {
+                type: 'tool_use',
+                id: 'todo-1',
+                name: 'TodoWrite',
+                input: {
+                  todos: [{ content: 'Task 1', status: 'pending', activeForm: 'Doing task' }],
+                },
+              },
+            ],
+          },
+        } as MessageContent,
+      };
+
+      render(
+        <MessageBubble
+          message={message}
+          latestTodoWriteId="todo-1"
+          manuallyToggledTodoIds={manuallyToggledTodoIds}
+          onTodoManualToggle={onTodoManualToggle}
+        />
+      );
+
+      // TodoWriteDisplay should be rendered (check for its specific elements)
+      expect(screen.getByText('TodoWrite')).toBeInTheDocument();
+    });
+  });
+
+  describe('styling', () => {
+    it('applies user message styling', () => {
+      const message = {
+        type: 'user',
+        content: {
+          content: 'User message',
+        } as MessageContent,
+      };
+
+      const { container } = render(<MessageBubble message={message} />);
+
+      // User messages have bg-primary class
+      const userBubble = container.querySelector('[class*="bg-primary"]');
+      expect(userBubble).toBeInTheDocument();
+    });
+
+    it('applies assistant message styling', () => {
+      const message = {
+        type: 'assistant',
+        content: {
+          message: {
+            content: [{ type: 'text', text: 'Assistant response' }],
+          },
+        } as MessageContent,
+      };
+
+      const { container } = render(<MessageBubble message={message} />);
+
+      // Assistant messages have bg-card and border
+      const assistantBubble = container.querySelector('[class*="bg-card"]');
+      expect(assistantBubble).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/messages/ToolCallDisplay.test.tsx
+++ b/src/components/messages/ToolCallDisplay.test.tsx
@@ -1,0 +1,238 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ToolCallDisplay } from './ToolCallDisplay';
+import type { ToolCall } from './types';
+
+describe('ToolCallDisplay', () => {
+  describe('rendering', () => {
+    it('renders tool name', () => {
+      const tool: ToolCall = {
+        name: 'Bash',
+        id: 'test-1',
+        input: { command: 'ls -la' },
+        output: 'file1.txt\nfile2.txt',
+      };
+
+      render(<ToolCallDisplay tool={tool} />);
+
+      expect(screen.getByText('Bash')).toBeInTheDocument();
+    });
+
+    it('renders description from input when present', () => {
+      const tool: ToolCall = {
+        name: 'Bash',
+        id: 'test-2',
+        input: { command: 'npm test', description: 'Run tests' },
+        output: 'All tests passed',
+      };
+
+      render(<ToolCallDisplay tool={tool} />);
+
+      expect(screen.getByText('Run tests')).toBeInTheDocument();
+    });
+
+    it('shows "Running..." badge when output is undefined', () => {
+      const tool: ToolCall = {
+        name: 'Bash',
+        id: 'test-3',
+        input: { command: 'npm install' },
+        // No output - pending state
+      };
+
+      render(<ToolCallDisplay tool={tool} />);
+
+      expect(screen.getByText('Running...')).toBeInTheDocument();
+    });
+
+    it('shows "Error" badge when is_error is true', () => {
+      const tool: ToolCall = {
+        name: 'Bash',
+        id: 'test-4',
+        input: { command: 'invalid-command' },
+        output: 'command not found',
+        is_error: true,
+      };
+
+      render(<ToolCallDisplay tool={tool} />);
+
+      expect(screen.getByText('Error')).toBeInTheDocument();
+    });
+
+    it('does not show "Running..." badge when output is present', () => {
+      const tool: ToolCall = {
+        name: 'Read',
+        id: 'test-5',
+        input: { file_path: '/test/file.txt' },
+        output: 'file contents',
+      };
+
+      render(<ToolCallDisplay tool={tool} />);
+
+      expect(screen.queryByText('Running...')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('expansion behavior', () => {
+    it('starts collapsed by default', () => {
+      const tool: ToolCall = {
+        name: 'Bash',
+        id: 'test-6',
+        input: { command: 'echo hello' },
+        output: 'hello',
+      };
+
+      render(<ToolCallDisplay tool={tool} />);
+
+      // Input label should not be in the document when collapsed
+      expect(screen.queryByText('Input:')).not.toBeInTheDocument();
+    });
+
+    it('expands when clicking the trigger', async () => {
+      const user = userEvent.setup();
+      const tool: ToolCall = {
+        name: 'Bash',
+        id: 'test-7',
+        input: { command: 'echo hello' },
+        output: 'hello',
+      };
+
+      render(<ToolCallDisplay tool={tool} />);
+
+      // Click the collapsible trigger
+      await user.click(screen.getByRole('button'));
+
+      // Input should be visible when expanded
+      expect(screen.getByText('Input:')).toBeVisible();
+      expect(screen.getByText('Output:')).toBeVisible();
+    });
+
+    it('shows expand/collapse indicator', () => {
+      const tool: ToolCall = {
+        name: 'Read',
+        id: 'test-8',
+        input: { file_path: '/test.txt' },
+        output: 'content',
+      };
+
+      render(<ToolCallDisplay tool={tool} />);
+
+      // Should show '+' when collapsed
+      expect(screen.getByText('+')).toBeInTheDocument();
+    });
+  });
+
+  describe('input display', () => {
+    it('displays command directly for Bash tool', async () => {
+      const user = userEvent.setup();
+      const tool: ToolCall = {
+        name: 'Bash',
+        id: 'test-9',
+        input: { command: 'npm run build' },
+        output: 'Build successful',
+      };
+
+      render(<ToolCallDisplay tool={tool} />);
+      await user.click(screen.getByRole('button'));
+
+      expect(screen.getByText('npm run build')).toBeInTheDocument();
+    });
+
+    it('displays JSON for non-Bash tools', async () => {
+      const user = userEvent.setup();
+      const tool: ToolCall = {
+        name: 'Read',
+        id: 'test-10',
+        input: { file_path: '/test/file.txt', limit: 100 },
+        output: 'file contents',
+      };
+
+      render(<ToolCallDisplay tool={tool} />);
+      await user.click(screen.getByRole('button'));
+
+      // Should show JSON-formatted input
+      expect(screen.getByText(/"file_path": "\/test\/file.txt"/)).toBeInTheDocument();
+    });
+  });
+
+  describe('output display', () => {
+    it('does not show output section when pending', async () => {
+      const user = userEvent.setup();
+      const tool: ToolCall = {
+        name: 'Bash',
+        id: 'test-11',
+        input: { command: 'sleep 10' },
+        // No output
+      };
+
+      render(<ToolCallDisplay tool={tool} />);
+      await user.click(screen.getByRole('button'));
+
+      expect(screen.getByText('Input:')).toBeVisible();
+      expect(screen.queryByText('Output:')).not.toBeInTheDocument();
+    });
+
+    it('shows string output directly', async () => {
+      const user = userEvent.setup();
+      const tool: ToolCall = {
+        name: 'Bash',
+        id: 'test-12',
+        input: { command: 'echo test' },
+        output: 'test output here',
+      };
+
+      render(<ToolCallDisplay tool={tool} />);
+      await user.click(screen.getByRole('button'));
+
+      expect(screen.getByText('test output here')).toBeInTheDocument();
+    });
+
+    it('shows JSON-formatted output for objects', async () => {
+      const user = userEvent.setup();
+      const tool: ToolCall = {
+        name: 'CustomTool',
+        id: 'test-13',
+        input: { param: 'value' },
+        output: { result: 'success', count: 42 },
+      };
+
+      render(<ToolCallDisplay tool={tool} />);
+      await user.click(screen.getByRole('button'));
+
+      expect(screen.getByText(/"result": "success"/)).toBeInTheDocument();
+    });
+  });
+
+  describe('styling', () => {
+    it('applies error styling when is_error is true', () => {
+      const tool: ToolCall = {
+        name: 'Bash',
+        id: 'test-14',
+        input: { command: 'exit 1' },
+        output: 'Error occurred',
+        is_error: true,
+      };
+
+      const { container } = render(<ToolCallDisplay tool={tool} />);
+
+      // Check for error border class
+      const card = container.querySelector('[class*="border-red"]');
+      expect(card).toBeInTheDocument();
+    });
+
+    it('applies pending styling when no output', () => {
+      const tool: ToolCall = {
+        name: 'Bash',
+        id: 'test-15',
+        input: { command: 'long-running' },
+        // No output
+      };
+
+      const { container } = render(<ToolCallDisplay tool={tool} />);
+
+      // Check for pending border class
+      const card = container.querySelector('[class*="border-yellow"]');
+      expect(card).toBeInTheDocument();
+    });
+  });
+});

--- a/src/test/setup-component.ts
+++ b/src/test/setup-component.ts
@@ -1,0 +1,8 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+
+// Cleanup after each test
+afterEach(() => {
+  cleanup();
+});

--- a/vitest.component.config.ts
+++ b/vitest.component.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    include: ['src/components/**/*.test.tsx'],
+    setupFiles: ['./src/test/setup-component.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      include: ['src/components/**/*.tsx'],
+      exclude: ['src/components/**/*.test.tsx'],
+    },
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Add React Testing Library and jsdom dependencies for component testing
- Create `vitest.component.config.ts` with jsdom environment configuration
- Create `src/test/setup-component.ts` for test setup/cleanup
- Add `test:component` npm script

Component tests added:
- **ToolCallDisplay** (15 tests): rendering, expansion, input/output display, styling
- **PromptInput** (23 tests): form submission, keyboard handling, disabled states, interrupt behavior
- **MessageBubble** (20 tests): different message types, tool calls, styling, copy functionality
- **SessionList** (8 tests): loading state, empty state, sessions list rendering

## Test plan
- [x] All 66 component tests pass (`pnpm test:component`)
- [x] All 178 existing tests still pass (`pnpm test:run`)
- [x] TypeScript typechecking passes (`pnpm typecheck`)
- [x] ESLint passes (`pnpm lint`)

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)