### PR TITLE
Reconcile session status with Podman containers

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -7,9 +7,33 @@ export async function register() {
   // Only run on the server (not during build or in edge runtime)
   if (process.env.NEXT_RUNTIME === 'nodejs') {
     const { reconcileOrphanedProcesses } = await import('@/server/services/claude-runner');
+    const { reconcileSessionsWithPodman, startBackgroundReconciliation } =
+      await import('@/server/services/session-reconciler');
 
-    console.log('Starting server - reconciling orphaned Claude processes...');
+    console.log('Starting server - reconciling sessions with Podman...');
 
+    // Reconcile session states with actual Podman containers
+    try {
+      const sessionResult = await reconcileSessionsWithPodman();
+      if (sessionResult.sessionsUpdated > 0 || sessionResult.orphanedContainersCleaned > 0) {
+        console.log(
+          `Reconciled sessions: ${sessionResult.sessionsChecked} checked, ` +
+            `${sessionResult.sessionsUpdated} updated, ` +
+            `${sessionResult.sessionsMarkedStopped} marked stopped, ` +
+            `${sessionResult.sessionsMarkedRunning} marked running, ` +
+            `${sessionResult.orphanedContainersCleaned} orphaned containers cleaned`
+        );
+      } else {
+        console.log(
+          `Session reconciliation complete: ${sessionResult.sessionsChecked} sessions checked, all in sync`
+        );
+      }
+    } catch (err) {
+      console.error('Error reconciling sessions:', err);
+    }
+
+    // Reconcile orphaned Claude processes
+    console.log('Reconciling orphaned Claude processes...');
     try {
       const result = await reconcileOrphanedProcesses();
       if (result.total > 0) {
@@ -23,5 +47,8 @@ export async function register() {
     } catch (err) {
       console.error('Error reconciling orphaned processes:', err);
     }
+
+    // Start background polling for container state changes
+    startBackgroundReconciliation();
   }
 }

--- a/src/server/services/session-reconciler.test.ts
+++ b/src/server/services/session-reconciler.test.ts
@@ -1,0 +1,324 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+// Create mock objects that will be hoisted
+const { mockPodmanFunctions, mockPrisma } = vi.hoisted(() => {
+  const mockPodmanFunctions = {
+    getContainerStatus: vi.fn(),
+    listSessionContainers: vi.fn(),
+    removeContainer: vi.fn(),
+  };
+
+  const mockPrisma = {
+    session: {
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+  };
+
+  return { mockPodmanFunctions, mockPrisma };
+});
+
+// Mock the podman service
+vi.mock('./podman', () => mockPodmanFunctions);
+
+// Mock prisma
+vi.mock('@/lib/prisma', () => ({
+  prisma: mockPrisma,
+}));
+
+// Mock the logger
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+  toError: (e: unknown) => (e instanceof Error ? e : new Error(String(e))),
+}));
+
+// Import after mocks are set up
+import {
+  reconcileSessionsWithPodman,
+  syncSessionStatus,
+  startBackgroundReconciliation,
+  stopBackgroundReconciliation,
+} from './session-reconciler';
+
+describe('session-reconciler service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Stop any running background reconciliation between tests
+    stopBackgroundReconciliation();
+  });
+
+  afterEach(() => {
+    stopBackgroundReconciliation();
+  });
+
+  describe('reconcileSessionsWithPodman', () => {
+    it('should return empty result when no sessions exist', async () => {
+      mockPrisma.session.findMany.mockResolvedValue([]);
+      mockPodmanFunctions.listSessionContainers.mockResolvedValue([]);
+
+      const result = await reconcileSessionsWithPodman();
+
+      expect(result).toEqual({
+        sessionsChecked: 0,
+        sessionsUpdated: 0,
+        orphanedContainersCleaned: 0,
+        sessionsMarkedStopped: 0,
+        sessionsMarkedRunning: 0,
+      });
+    });
+
+    it('should mark running session as stopped when container is not found', async () => {
+      const session = {
+        id: 'session-1',
+        containerId: 'container-1',
+        status: 'running',
+      };
+      mockPrisma.session.findMany.mockResolvedValue([session]);
+      mockPodmanFunctions.listSessionContainers.mockResolvedValue([]);
+      mockPodmanFunctions.getContainerStatus.mockResolvedValue('not_found');
+      mockPrisma.session.update.mockResolvedValue({ ...session, status: 'stopped' });
+
+      const result = await reconcileSessionsWithPodman();
+
+      expect(result.sessionsChecked).toBe(1);
+      expect(result.sessionsMarkedStopped).toBe(1);
+      expect(result.sessionsUpdated).toBe(1);
+      expect(mockPrisma.session.update).toHaveBeenCalledWith({
+        where: { id: 'session-1' },
+        data: { status: 'stopped' },
+      });
+    });
+
+    it('should mark stopped session as running when container is actually running', async () => {
+      const session = {
+        id: 'session-1',
+        containerId: 'container-1',
+        status: 'stopped',
+      };
+      mockPrisma.session.findMany.mockResolvedValue([session]);
+      mockPodmanFunctions.listSessionContainers.mockResolvedValue([
+        { containerId: 'container-1', sessionId: 'session-1', status: 'running' },
+      ]);
+
+      const result = await reconcileSessionsWithPodman();
+
+      expect(result.sessionsChecked).toBe(1);
+      expect(result.sessionsMarkedRunning).toBe(1);
+      expect(result.sessionsUpdated).toBe(1);
+      expect(mockPrisma.session.update).toHaveBeenCalledWith({
+        where: { id: 'session-1' },
+        data: { status: 'running' },
+      });
+    });
+
+    it('should not update session when status matches container state', async () => {
+      const session = {
+        id: 'session-1',
+        containerId: 'container-1',
+        status: 'running',
+      };
+      mockPrisma.session.findMany.mockResolvedValue([session]);
+      mockPodmanFunctions.listSessionContainers.mockResolvedValue([
+        { containerId: 'container-1', sessionId: 'session-1', status: 'running' },
+      ]);
+
+      const result = await reconcileSessionsWithPodman();
+
+      expect(result.sessionsChecked).toBe(1);
+      expect(result.sessionsUpdated).toBe(0);
+      expect(mockPrisma.session.update).not.toHaveBeenCalled();
+    });
+
+    it('should update container ID when container was recreated', async () => {
+      const session = {
+        id: 'session-1',
+        containerId: 'old-container-1',
+        status: 'running',
+      };
+      mockPrisma.session.findMany.mockResolvedValue([session]);
+      mockPodmanFunctions.listSessionContainers.mockResolvedValue([
+        { containerId: 'new-container-1', sessionId: 'session-1', status: 'running' },
+      ]);
+      mockPrisma.session.update.mockResolvedValue({ ...session, containerId: 'new-container-1' });
+
+      const result = await reconcileSessionsWithPodman();
+
+      expect(result.sessionsChecked).toBe(1);
+      expect(result.sessionsUpdated).toBe(1);
+      expect(mockPrisma.session.update).toHaveBeenCalledWith({
+        where: { id: 'session-1' },
+        data: { containerId: 'new-container-1' },
+      });
+    });
+
+    it('should clean up orphaned containers with no matching session', async () => {
+      mockPrisma.session.findMany.mockResolvedValue([]);
+      mockPodmanFunctions.listSessionContainers.mockResolvedValue([
+        { containerId: 'orphan-container', sessionId: 'nonexistent-session', status: 'running' },
+      ]);
+      mockPrisma.session.findUnique.mockResolvedValue(null); // Session doesn't exist
+
+      const result = await reconcileSessionsWithPodman();
+
+      expect(result.orphanedContainersCleaned).toBe(1);
+      expect(mockPodmanFunctions.removeContainer).toHaveBeenCalledWith('orphan-container');
+    });
+
+    it('should not clean up container if session exists but not in findMany result (e.g., creating state)', async () => {
+      // Session in "creating" state won't be in findMany results (filtered out)
+      mockPrisma.session.findMany.mockResolvedValue([]);
+      mockPodmanFunctions.listSessionContainers.mockResolvedValue([
+        { containerId: 'container-1', sessionId: 'session-1', status: 'running' },
+      ]);
+      mockPrisma.session.findUnique.mockResolvedValue({
+        id: 'session-1',
+        status: 'creating',
+      });
+
+      const result = await reconcileSessionsWithPodman();
+
+      expect(result.orphanedContainersCleaned).toBe(0);
+      expect(mockPodmanFunctions.removeContainer).not.toHaveBeenCalled();
+    });
+
+    it('should handle errors during orphan container cleanup gracefully', async () => {
+      mockPrisma.session.findMany.mockResolvedValue([]);
+      mockPodmanFunctions.listSessionContainers.mockResolvedValue([
+        { containerId: 'orphan-container', sessionId: 'nonexistent-session', status: 'running' },
+      ]);
+      mockPrisma.session.findUnique.mockResolvedValue(null);
+      mockPodmanFunctions.removeContainer.mockRejectedValue(new Error('Remove failed'));
+
+      // Should not throw
+      const result = await reconcileSessionsWithPodman();
+
+      // The function should still complete, just with 0 cleaned (due to error)
+      expect(result.orphanedContainersCleaned).toBe(0);
+    });
+  });
+
+  describe('syncSessionStatus', () => {
+    it('should return null when session not found', async () => {
+      mockPrisma.session.findUnique.mockResolvedValue(null);
+
+      const result = await syncSessionStatus('nonexistent-session');
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when session has no container ID', async () => {
+      mockPrisma.session.findUnique.mockResolvedValue({
+        id: 'session-1',
+        containerId: null,
+        status: 'stopped',
+      });
+
+      const result = await syncSessionStatus('session-1');
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null for sessions in creating state', async () => {
+      mockPrisma.session.findUnique.mockResolvedValue({
+        id: 'session-1',
+        containerId: 'container-1',
+        status: 'creating',
+      });
+
+      const result = await syncSessionStatus('session-1');
+
+      expect(result).toBeNull();
+      expect(mockPodmanFunctions.getContainerStatus).not.toHaveBeenCalled();
+    });
+
+    it('should update and return new status when container is stopped but session marked running', async () => {
+      mockPrisma.session.findUnique.mockResolvedValue({
+        id: 'session-1',
+        containerId: 'container-1',
+        status: 'running',
+      });
+      mockPodmanFunctions.getContainerStatus.mockResolvedValue('stopped');
+
+      const result = await syncSessionStatus('session-1');
+
+      expect(result).toBe('stopped');
+      expect(mockPrisma.session.update).toHaveBeenCalledWith({
+        where: { id: 'session-1' },
+        data: { status: 'stopped' },
+      });
+    });
+
+    it('should update and return new status when container is running but session marked stopped', async () => {
+      mockPrisma.session.findUnique.mockResolvedValue({
+        id: 'session-1',
+        containerId: 'container-1',
+        status: 'stopped',
+      });
+      mockPodmanFunctions.getContainerStatus.mockResolvedValue('running');
+
+      const result = await syncSessionStatus('session-1');
+
+      expect(result).toBe('running');
+      expect(mockPrisma.session.update).toHaveBeenCalledWith({
+        where: { id: 'session-1' },
+        data: { status: 'running' },
+      });
+    });
+
+    it('should return null when status already matches container state', async () => {
+      mockPrisma.session.findUnique.mockResolvedValue({
+        id: 'session-1',
+        containerId: 'container-1',
+        status: 'running',
+      });
+      mockPodmanFunctions.getContainerStatus.mockResolvedValue('running');
+
+      const result = await syncSessionStatus('session-1');
+
+      expect(result).toBeNull();
+      expect(mockPrisma.session.update).not.toHaveBeenCalled();
+    });
+
+    it('should mark running session as stopped when container not found', async () => {
+      mockPrisma.session.findUnique.mockResolvedValue({
+        id: 'session-1',
+        containerId: 'container-1',
+        status: 'running',
+      });
+      mockPodmanFunctions.getContainerStatus.mockResolvedValue('not_found');
+
+      const result = await syncSessionStatus('session-1');
+
+      expect(result).toBe('stopped');
+      expect(mockPrisma.session.update).toHaveBeenCalledWith({
+        where: { id: 'session-1' },
+        data: { status: 'stopped' },
+      });
+    });
+  });
+
+  describe('background reconciliation', () => {
+    it('should start and stop background reconciliation', () => {
+      // Just test that these functions don't throw
+      startBackgroundReconciliation();
+      stopBackgroundReconciliation();
+    });
+
+    it('should warn when starting background reconciliation twice', () => {
+      startBackgroundReconciliation();
+      startBackgroundReconciliation(); // Should warn but not throw
+      stopBackgroundReconciliation();
+    });
+
+    it('should handle stopping when not running', () => {
+      // Should not throw
+      stopBackgroundReconciliation();
+    });
+  });
+});

--- a/src/server/services/session-reconciler.ts
+++ b/src/server/services/session-reconciler.ts
@@ -1,0 +1,274 @@
+import { prisma } from '@/lib/prisma';
+import { getContainerStatus, listSessionContainers, removeContainer } from './podman';
+import { createLogger, toError } from '@/lib/logger';
+import type { SessionStatus } from '@/lib/types';
+
+const log = createLogger('session-reconciler');
+
+// Polling interval for background reconciliation (5 minutes)
+const RECONCILIATION_INTERVAL_MS = 5 * 60 * 1000;
+
+// Track if background polling is active
+let reconciliationIntervalId: NodeJS.Timeout | null = null;
+
+/**
+ * Result of reconciling sessions with Podman containers.
+ */
+export interface ReconciliationResult {
+  /** Total sessions checked */
+  sessionsChecked: number;
+  /** Sessions updated to match container state */
+  sessionsUpdated: number;
+  /** Orphaned containers found (running but no DB session) */
+  orphanedContainersCleaned: number;
+  /** Sessions that were marked as stopped because container was gone */
+  sessionsMarkedStopped: number;
+  /** Sessions that were marked as running because container was running */
+  sessionsMarkedRunning: number;
+}
+
+/**
+ * Reconcile all sessions with actual Podman container states.
+ * This function:
+ * 1. Updates DB session status to match actual container state
+ * 2. Cleans up orphaned containers (running containers with no matching session)
+ * 3. Does NOT delete sessions - just marks them as stopped if container is gone
+ *
+ * Should be called at startup and periodically to stay in sync.
+ */
+export async function reconcileSessionsWithPodman(): Promise<ReconciliationResult> {
+  log.info('Starting session reconciliation with Podman');
+
+  const result: ReconciliationResult = {
+    sessionsChecked: 0,
+    sessionsUpdated: 0,
+    orphanedContainersCleaned: 0,
+    sessionsMarkedStopped: 0,
+    sessionsMarkedRunning: 0,
+  };
+
+  try {
+    // Get all sessions from DB that have container IDs
+    // (ignore 'creating' sessions as they may be in the process of starting)
+    const sessions = await prisma.session.findMany({
+      where: {
+        status: {
+          notIn: ['creating'],
+        },
+      },
+    });
+
+    // Get all actual containers from Podman
+    const containers = await listSessionContainers();
+    const containersBySessionId = new Map(containers.map((c) => [c.sessionId, c]));
+
+    // Check each DB session against actual container state
+    for (const session of sessions) {
+      result.sessionsChecked++;
+
+      const container = containersBySessionId.get(session.id);
+      let newStatus: SessionStatus | null = null;
+
+      if (!container && session.containerId) {
+        // Container doesn't exist but session thinks it's running/stopped with a containerId
+        // Check container status directly by ID to handle name mismatches
+        const containerStatus = await getContainerStatus(session.containerId);
+
+        if (containerStatus === 'not_found') {
+          // Container truly doesn't exist - mark session as stopped
+          if (session.status === 'running') {
+            newStatus = 'stopped';
+            result.sessionsMarkedStopped++;
+            log.info('Container not found, marking session as stopped', {
+              sessionId: session.id,
+              previousStatus: session.status,
+              containerId: session.containerId,
+            });
+          }
+        } else if (containerStatus === 'running' && session.status === 'stopped') {
+          // Container is running but session marked as stopped - update status
+          newStatus = 'running';
+          result.sessionsMarkedRunning++;
+          log.info('Container running but session marked stopped, updating', {
+            sessionId: session.id,
+            previousStatus: session.status,
+          });
+        } else if (containerStatus === 'stopped' && session.status === 'running') {
+          // Container is stopped but session marked as running - update status
+          newStatus = 'stopped';
+          result.sessionsMarkedStopped++;
+          log.info('Container stopped but session marked running, updating', {
+            sessionId: session.id,
+            previousStatus: session.status,
+          });
+        }
+      } else if (container) {
+        // Container exists - sync status
+        if (container.status === 'running' && session.status === 'stopped') {
+          newStatus = 'running';
+          result.sessionsMarkedRunning++;
+          log.info('Container running but session marked stopped, updating', {
+            sessionId: session.id,
+            previousStatus: session.status,
+          });
+        } else if (container.status === 'stopped' && session.status === 'running') {
+          newStatus = 'stopped';
+          result.sessionsMarkedStopped++;
+          log.info('Container stopped but session marked running, updating', {
+            sessionId: session.id,
+            previousStatus: session.status,
+          });
+        }
+
+        // Also update container ID if it doesn't match (container was recreated)
+        if (session.containerId !== container.containerId) {
+          log.info('Updating session container ID', {
+            sessionId: session.id,
+            oldContainerId: session.containerId,
+            newContainerId: container.containerId,
+          });
+          await prisma.session.update({
+            where: { id: session.id },
+            data: { containerId: container.containerId },
+          });
+          result.sessionsUpdated++;
+        }
+      }
+
+      // Update session status if changed
+      if (newStatus !== null) {
+        await prisma.session.update({
+          where: { id: session.id },
+          data: { status: newStatus },
+        });
+        result.sessionsUpdated++;
+      }
+    }
+
+    // Find orphaned containers (containers with no matching session in DB)
+    const sessionIds = new Set(sessions.map((s) => s.id));
+    for (const container of containers) {
+      if (!sessionIds.has(container.sessionId)) {
+        // This container has no matching session - it's orphaned
+        // Check if session exists at all (might be in 'creating' state)
+        const sessionExists = await prisma.session.findUnique({
+          where: { id: container.sessionId },
+          select: { id: true },
+        });
+
+        if (!sessionExists) {
+          log.info('Found orphaned container, removing', {
+            containerId: container.containerId,
+            sessionId: container.sessionId,
+            status: container.status,
+          });
+
+          try {
+            await removeContainer(container.containerId);
+            result.orphanedContainersCleaned++;
+          } catch (error) {
+            log.warn(
+              'Failed to remove orphaned container',
+              { containerId: container.containerId },
+              toError(error)
+            );
+          }
+        }
+      }
+    }
+
+    log.info('Session reconciliation complete', { ...result });
+    return result;
+  } catch (error) {
+    log.error('Session reconciliation failed', toError(error));
+    throw error;
+  }
+}
+
+/**
+ * Sync a single session's status with its actual container state.
+ * Called when interacting with a session to ensure we have accurate state.
+ * Returns the updated session status if changed, null if no change needed.
+ */
+export async function syncSessionStatus(sessionId: string): Promise<SessionStatus | null> {
+  const session = await prisma.session.findUnique({
+    where: { id: sessionId },
+  });
+
+  if (!session || !session.containerId) {
+    return null;
+  }
+
+  // Skip sessions in transitional states
+  if (session.status === 'creating') {
+    return null;
+  }
+
+  const containerStatus = await getContainerStatus(session.containerId);
+  let newStatus: SessionStatus | null = null;
+
+  if (containerStatus === 'not_found') {
+    if (session.status === 'running') {
+      newStatus = 'stopped';
+    }
+  } else if (containerStatus === 'running' && session.status === 'stopped') {
+    newStatus = 'running';
+  } else if (containerStatus === 'stopped' && session.status === 'running') {
+    newStatus = 'stopped';
+  }
+
+  if (newStatus !== null) {
+    log.info('Syncing session status with container', {
+      sessionId,
+      previousStatus: session.status,
+      newStatus,
+      containerStatus,
+    });
+
+    await prisma.session.update({
+      where: { id: sessionId },
+      data: { status: newStatus },
+    });
+  }
+
+  return newStatus;
+}
+
+/**
+ * Start background polling for container state changes.
+ * Runs reconciliation every RECONCILIATION_INTERVAL_MS.
+ */
+export function startBackgroundReconciliation(): void {
+  if (reconciliationIntervalId) {
+    log.warn('Background reconciliation already running');
+    return;
+  }
+
+  log.info('Starting background reconciliation', {
+    intervalMs: RECONCILIATION_INTERVAL_MS,
+  });
+
+  reconciliationIntervalId = setInterval(async () => {
+    try {
+      await reconcileSessionsWithPodman();
+    } catch (error) {
+      log.error('Background reconciliation failed', toError(error));
+    }
+  }, RECONCILIATION_INTERVAL_MS);
+
+  // Ensure interval is cleaned up on process exit
+  process.on('beforeExit', () => {
+    stopBackgroundReconciliation();
+  });
+}
+
+/**
+ * Stop background polling for container state changes.
+ */
+export function stopBackgroundReconciliation(): void {
+  if (reconciliationIntervalId) {
+    clearInterval(reconciliationIntervalId);
+    reconciliationIntervalId = null;
+    log.info('Stopped background reconciliation');
+  }
+}


### PR DESCRIPTION
## Summary
- Implements reconciliation between database session states and actual Podman container states at startup
- Adds background polling (every 5 minutes) to detect container state changes
- Syncs session status when accessing sessions to ensure accurate state
- Cleans up orphaned containers (running containers with no matching session in DB)

## Changes
- **New service**: `session-reconciler.ts` with:
  - `reconcileSessionsWithPodman()`: Full reconciliation of all sessions
  - `syncSessionStatus()`: Sync a single session on access
  - `startBackgroundReconciliation()`: Periodic polling
- **podman.ts**: Added `listSessionContainers()` to list all claude-session-* containers
- **instrumentation.ts**: Call reconciliation at server startup and start background polling
- **sessions.ts**: Call `syncSessionStatus()` when fetching or starting sessions
- Comprehensive unit tests for all reconciliation scenarios

## Test plan
- [x] All existing tests pass
- [x] New unit tests cover reconciliation scenarios
- [x] TypeScript compiles without errors
- [x] ESLint passes

Fixes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)