### PR TITLE
Refactor SessionList to separate data fetching from presentation

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { AuthGuard } from '@/components/AuthGuard';
 import { Header } from '@/components/Header';
-import { SessionList } from '@/components/SessionList';
+import { SessionListContainer } from '@/components/SessionListContainer';
 import { Button } from '@/components/ui/button';
 
 export default function HomePage() {
@@ -21,7 +21,7 @@ export default function HomePage() {
               </Button>
             </div>
 
-            <SessionList />
+            <SessionListContainer />
           </div>
         </main>
       </div>

--- a/src/components/SessionList.test.tsx
+++ b/src/components/SessionList.test.tsx
@@ -1,36 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { trpc } from '@/lib/trpc';
-
-// Mock the trpc module
-vi.mock('@/lib/trpc', () => ({
-  trpc: {
-    sessions: {
-      list: {
-        useQuery: vi.fn(),
-      },
-      start: {
-        useMutation: vi.fn(() => ({
-          mutate: vi.fn(),
-          isPending: false,
-        })),
-      },
-      stop: {
-        useMutation: vi.fn(() => ({
-          mutate: vi.fn(),
-          isPending: false,
-        })),
-      },
-      delete: {
-        useMutation: vi.fn(() => ({
-          mutate: vi.fn(),
-          isPending: false,
-        })),
-      },
-    },
-  },
-}));
+import { SessionList } from './SessionList';
+import type { Session } from '@/hooks/useSessionList';
+import type { SessionActions } from '@/hooks/useSessionActions';
 
 // Mock next/link
 vi.mock('next/link', () => ({
@@ -39,40 +11,31 @@ vi.mock('next/link', () => ({
   ),
 }));
 
-// Import component after mocks are set up
-import { SessionList } from './SessionList';
-
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-      },
-    },
-  });
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+function createMockActions(overrides: Partial<SessionActions> = {}): SessionActions {
+  return {
+    start: vi.fn(),
+    stop: vi.fn(),
+    archive: vi.fn(),
+    isStarting: () => false,
+    isStopping: () => false,
+    isArchiving: () => false,
+    ...overrides,
   };
 }
 
 describe('SessionList', () => {
-  const mockUseQuery = vi.mocked(trpc.sessions.list.useQuery);
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   describe('loading state', () => {
     it('shows spinner while loading', () => {
-      mockUseQuery.mockReturnValue({
-        data: undefined,
-        isLoading: true,
-        refetch: vi.fn(),
-      } as unknown as ReturnType<typeof trpc.sessions.list.useQuery>);
+      render(
+        <SessionList
+          sessions={[]}
+          isLoading={true}
+          actions={createMockActions()}
+          showArchived={false}
+          onToggleArchived={vi.fn()}
+        />
+      );
 
-      render(<SessionList />, { wrapper: createWrapper() });
-
-      // Check for spinner (via role or class)
       const spinner = document.querySelector('[class*="animate-spin"]');
       expect(spinner).toBeInTheDocument();
     });
@@ -80,26 +43,30 @@ describe('SessionList', () => {
 
   describe('empty state', () => {
     it('shows empty state message when no sessions', () => {
-      mockUseQuery.mockReturnValue({
-        data: { sessions: [] },
-        isLoading: false,
-        refetch: vi.fn(),
-      } as unknown as ReturnType<typeof trpc.sessions.list.useQuery>);
-
-      render(<SessionList />, { wrapper: createWrapper() });
+      render(
+        <SessionList
+          sessions={[]}
+          isLoading={false}
+          actions={createMockActions()}
+          showArchived={false}
+          onToggleArchived={vi.fn()}
+        />
+      );
 
       expect(screen.getByText('No sessions yet')).toBeInTheDocument();
       expect(screen.getByText('Get started by creating a new session.')).toBeInTheDocument();
     });
 
     it('shows "New Session" link in empty state', () => {
-      mockUseQuery.mockReturnValue({
-        data: { sessions: [] },
-        isLoading: false,
-        refetch: vi.fn(),
-      } as unknown as ReturnType<typeof trpc.sessions.list.useQuery>);
-
-      render(<SessionList />, { wrapper: createWrapper() });
+      render(
+        <SessionList
+          sessions={[]}
+          isLoading={false}
+          actions={createMockActions()}
+          showArchived={false}
+          onToggleArchived={vi.fn()}
+        />
+      );
 
       const newSessionLink = screen.getByRole('link', { name: /new session/i });
       expect(newSessionLink).toBeInTheDocument();
@@ -108,7 +75,7 @@ describe('SessionList', () => {
   });
 
   describe('sessions list', () => {
-    const mockSessions = [
+    const mockSessions: Session[] = [
       {
         id: 'session-1',
         name: 'Test Session 1',
@@ -128,26 +95,30 @@ describe('SessionList', () => {
     ];
 
     it('renders list of sessions', () => {
-      mockUseQuery.mockReturnValue({
-        data: { sessions: mockSessions },
-        isLoading: false,
-        refetch: vi.fn(),
-      } as unknown as ReturnType<typeof trpc.sessions.list.useQuery>);
-
-      render(<SessionList />, { wrapper: createWrapper() });
+      render(
+        <SessionList
+          sessions={mockSessions}
+          isLoading={false}
+          actions={createMockActions()}
+          showArchived={false}
+          onToggleArchived={vi.fn()}
+        />
+      );
 
       expect(screen.getByText('Test Session 1')).toBeInTheDocument();
       expect(screen.getByText('Test Session 2')).toBeInTheDocument();
     });
 
     it('links to individual session pages', () => {
-      mockUseQuery.mockReturnValue({
-        data: { sessions: mockSessions },
-        isLoading: false,
-        refetch: vi.fn(),
-      } as unknown as ReturnType<typeof trpc.sessions.list.useQuery>);
-
-      render(<SessionList />, { wrapper: createWrapper() });
+      render(
+        <SessionList
+          sessions={mockSessions}
+          isLoading={false}
+          actions={createMockActions()}
+          showArchived={false}
+          onToggleArchived={vi.fn()}
+        />
+      );
 
       const sessionLinks = screen.getAllByRole('link');
       const session1Link = sessionLinks.find((link) =>
@@ -157,44 +128,18 @@ describe('SessionList', () => {
     });
 
     it('renders sessions in order', () => {
-      mockUseQuery.mockReturnValue({
-        data: { sessions: mockSessions },
-        isLoading: false,
-        refetch: vi.fn(),
-      } as unknown as ReturnType<typeof trpc.sessions.list.useQuery>);
-
-      render(<SessionList />, { wrapper: createWrapper() });
+      render(
+        <SessionList
+          sessions={mockSessions}
+          isLoading={false}
+          actions={createMockActions()}
+          showArchived={false}
+          onToggleArchived={vi.fn()}
+        />
+      );
 
       const sessionNames = screen.getAllByRole('listitem');
       expect(sessionNames).toHaveLength(2);
-    });
-  });
-
-  describe('data handling', () => {
-    it('handles undefined data gracefully', () => {
-      mockUseQuery.mockReturnValue({
-        data: undefined,
-        isLoading: false,
-        refetch: vi.fn(),
-      } as unknown as ReturnType<typeof trpc.sessions.list.useQuery>);
-
-      render(<SessionList />, { wrapper: createWrapper() });
-
-      // Should show empty state when data is undefined
-      expect(screen.getByText('No sessions yet')).toBeInTheDocument();
-    });
-
-    it('handles null sessions array gracefully', () => {
-      mockUseQuery.mockReturnValue({
-        data: { sessions: null },
-        isLoading: false,
-        refetch: vi.fn(),
-      } as unknown as ReturnType<typeof trpc.sessions.list.useQuery>);
-
-      render(<SessionList />, { wrapper: createWrapper() });
-
-      // Should show empty state
-      expect(screen.getByText('No sessions yet')).toBeInTheDocument();
     });
   });
 });

--- a/src/components/SessionList.tsx
+++ b/src/components/SessionList.tsx
@@ -1,28 +1,32 @@
 'use client';
 
-import { useState } from 'react';
 import Link from 'next/link';
-import { trpc } from '@/lib/trpc';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Spinner } from '@/components/ui/spinner';
 import { SessionListItem } from '@/components/SessionListItem';
+import type { Session } from '@/hooks/useSessionList';
+import type { SessionActions } from '@/hooks/useSessionActions';
 
-interface Session {
-  id: string;
-  name: string;
-  repoUrl: string;
-  branch: string;
-  status: string;
-  updatedAt: Date;
+export interface SessionListProps {
+  sessions: Session[];
+  isLoading: boolean;
+  actions: SessionActions;
+  showArchived: boolean;
+  onToggleArchived: () => void;
 }
 
-export function SessionList() {
-  const [showArchived, setShowArchived] = useState(false);
-  const { data, isLoading, refetch } = trpc.sessions.list.useQuery({
-    includeArchived: showArchived,
-  });
-
+/**
+ * Pure presentation component for displaying a list of sessions.
+ * Receives data and actions as props, making it easily testable.
+ */
+export function SessionList({
+  sessions,
+  isLoading,
+  actions,
+  showArchived,
+  onToggleArchived,
+}: SessionListProps) {
   if (isLoading) {
     return (
       <div className="flex justify-center py-12">
@@ -30,8 +34,6 @@ export function SessionList() {
       </div>
     );
   }
-
-  const sessions: Session[] = data?.sessions ?? [];
 
   // Separate active and archived sessions for display
   const activeSessions = sessions.filter((s) => s.status !== 'archived');
@@ -48,7 +50,7 @@ export function SessionList() {
           <Button asChild>
             <Link href="/new">New Session</Link>
           </Button>
-          <Button variant="ghost" size="sm" onClick={() => setShowArchived(true)}>
+          <Button variant="ghost" size="sm" onClick={onToggleArchived}>
             Show archived sessions
           </Button>
         </CardContent>
@@ -63,7 +65,7 @@ export function SessionList() {
           {activeSessions.length > 0 ? (
             <ul className="divide-y divide-border">
               {activeSessions.map((session) => (
-                <SessionListItem key={session.id} session={session} onMutationSuccess={refetch} />
+                <SessionListItem key={session.id} session={session} actions={actions} />
               ))}
             </ul>
           ) : (
@@ -79,7 +81,7 @@ export function SessionList() {
 
       {/* Toggle for archived sessions */}
       <div className="flex justify-center">
-        <Button variant="ghost" size="sm" onClick={() => setShowArchived(!showArchived)}>
+        <Button variant="ghost" size="sm" onClick={onToggleArchived}>
           {showArchived ? 'Hide archived sessions' : 'Show archived sessions'}
         </Button>
       </div>
@@ -95,7 +97,7 @@ export function SessionList() {
           <CardContent className="p-0">
             <ul className="divide-y divide-border">
               {archivedSessions.map((session) => (
-                <SessionListItem key={session.id} session={session} onMutationSuccess={refetch} />
+                <SessionListItem key={session.id} session={session} actions={actions} />
               ))}
             </ul>
           </CardContent>

--- a/src/components/SessionListContainer.tsx
+++ b/src/components/SessionListContainer.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useState } from 'react';
+import { SessionList } from '@/components/SessionList';
+import { useSessionList } from '@/hooks/useSessionList';
+import { useSessionActions } from '@/hooks/useSessionActions';
+
+/**
+ * Container component that wires up data fetching hooks with the SessionList presentation component.
+ * This is the component that should be used in pages - it handles all tRPC interactions internally.
+ */
+export function SessionListContainer() {
+  const [showArchived, setShowArchived] = useState(false);
+  const { sessions, isLoading, refetch } = useSessionList({ includeArchived: showArchived });
+  const actions = useSessionActions(refetch);
+
+  return (
+    <SessionList
+      sessions={sessions}
+      isLoading={isLoading}
+      actions={actions}
+      showArchived={showArchived}
+      onToggleArchived={() => setShowArchived(!showArchived)}
+    />
+  );
+}

--- a/src/hooks/useSessionActions.ts
+++ b/src/hooks/useSessionActions.ts
@@ -1,0 +1,45 @@
+'use client';
+
+import { trpc } from '@/lib/trpc';
+
+export interface SessionActions {
+  start: (sessionId: string) => void;
+  stop: (sessionId: string) => void;
+  archive: (sessionId: string) => void;
+  isStarting: (sessionId: string) => boolean;
+  isStopping: (sessionId: string) => boolean;
+  isArchiving: (sessionId: string) => boolean;
+}
+
+/**
+ * Hook for session mutation actions (start, stop, archive).
+ * Separates mutation logic from presentation.
+ *
+ * @param onSuccess - Callback to run after any successful mutation (e.g., refetch list)
+ */
+export function useSessionActions(onSuccess?: () => void): SessionActions {
+  const startMutation = trpc.sessions.start.useMutation({
+    onSuccess,
+  });
+
+  const stopMutation = trpc.sessions.stop.useMutation({
+    onSuccess,
+  });
+
+  // The API endpoint is "delete" but it now archives instead of permanently deleting
+  const archiveMutation = trpc.sessions.delete.useMutation({
+    onSuccess,
+  });
+
+  return {
+    start: (sessionId: string) => startMutation.mutate({ sessionId }),
+    stop: (sessionId: string) => stopMutation.mutate({ sessionId }),
+    archive: (sessionId: string) => archiveMutation.mutate({ sessionId }),
+    isStarting: (sessionId: string) =>
+      startMutation.isPending && startMutation.variables?.sessionId === sessionId,
+    isStopping: (sessionId: string) =>
+      stopMutation.isPending && stopMutation.variables?.sessionId === sessionId,
+    isArchiving: (sessionId: string) =>
+      archiveMutation.isPending && archiveMutation.variables?.sessionId === sessionId,
+  };
+}

--- a/src/hooks/useSessionList.ts
+++ b/src/hooks/useSessionList.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { trpc } from '@/lib/trpc';
+
+export interface Session {
+  id: string;
+  name: string;
+  repoUrl: string;
+  branch: string;
+  status: string;
+  updatedAt: Date;
+}
+
+export interface UseSessionListOptions {
+  includeArchived?: boolean;
+}
+
+export interface UseSessionListResult {
+  sessions: Session[];
+  isLoading: boolean;
+  refetch: () => void;
+}
+
+/**
+ * Hook for fetching the list of sessions.
+ * Separates data fetching logic from presentation.
+ *
+ * @param options.includeArchived - Whether to include archived sessions in the result
+ */
+export function useSessionList(options: UseSessionListOptions = {}): UseSessionListResult {
+  const { includeArchived = false } = options;
+
+  const { data, isLoading, refetch } = trpc.sessions.list.useQuery({
+    includeArchived,
+  });
+
+  return {
+    sessions: data?.sessions ?? [],
+    isLoading,
+    refetch,
+  };
+}


### PR DESCRIPTION
## Summary
- Extract custom hooks (`useSessionList`, `useSessionActions`) to separate data fetching from presentation
- Convert `SessionList` and `SessionListItem` to pure presentation components that receive data/actions as props
- Create `SessionListContainer` to wire hooks with presentation components
- Simplify tests to test presentation logic directly with props instead of mocking tRPC hooks

## Test plan
- [x] Component tests pass (`pnpm test:component`)
- [x] ESLint passes (`pnpm lint`)
- [ ] Manual testing: Verify session list loads and actions (start/stop/delete) work correctly

Fixes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)