### PR TITLE
Archive deleted sessions instead of permanently deleting

### DIFF
--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -55,13 +55,24 @@ interface Session {
   branch: string; // Branch name
   repoPath: string; // Relative path to repo within workspace (e.g., "my-repo")
   containerId: string | null; // Docker container ID when running
-  status: 'creating' | 'running' | 'stopped' | 'error';
+  status: 'creating' | 'running' | 'stopped' | 'error' | 'archived';
   statusMessage: string | null; // Progress message during creation or error details
   initialPrompt: string | null; // Optional prompt to auto-send when session starts (e.g., from GitHub issue)
   createdAt: Date;
   updatedAt: Date;
+  archivedAt: Date | null; // When the session was archived (null if not archived)
 }
 ```
+
+### Session Archiving
+
+When a session is deleted, it is archived rather than permanently removed. This preserves the message history for later viewing. Archived sessions:
+
+- Have status set to `archived` and archivedAt timestamp recorded
+- Have their container removed and workspace volume deleted
+- Keep all messages in the database for viewing
+- Are excluded from the session list by default (toggle available to show them)
+- Are read-only: no start/stop controls, no prompt input
 
 ### Data Storage
 

--- a/prisma/migrations/20260124215400_add_archived_at_to_session/migration.sql
+++ b/prisma/migrations/20260124215400_add_archived_at_to_session/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Session" ADD COLUMN "archivedAt" DATETIME;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,11 +28,12 @@ model Session {
   workspacePath String         // Path to workspace directory on host (contains the repo)
   repoPath      String         @default("") // Path to repo relative to workspace (e.g., "my-repo")
   containerId   String?
-  status        String         @default("creating") // creating, running, stopped, error
+  status        String         @default("creating") // creating, running, stopped, error, archived
   statusMessage String?        // Human-readable progress message during creation
   initialPrompt String?        // Optional prompt to send when session starts (e.g., from GitHub issue)
   createdAt     DateTime       @default(now())
   updatedAt     DateTime       @updatedAt
+  archivedAt    DateTime?      // When the session was archived (null if not archived)
   messages      Message[]
   claudeProcess ClaudeProcess?
 

--- a/src/app/session/[id]/page.tsx
+++ b/src/app/session/[id]/page.tsx
@@ -443,8 +443,12 @@ function SessionView({ sessionId }: { sessionId: string }) {
     );
   }
 
-  // Show creation progress or error state
-  if (session.status === 'creating' || session.status === 'error') {
+  // Show creation progress, error state, or archived state
+  if (
+    session.status === 'creating' ||
+    session.status === 'error' ||
+    session.status === 'archived'
+  ) {
     return (
       <div className="flex-1 flex flex-col min-h-0">
         <SessionHeader
@@ -454,27 +458,42 @@ function SessionView({ sessionId }: { sessionId: string }) {
           isStarting={false}
           isStopping={false}
         />
-        <div className="flex-1 flex flex-col items-center justify-center gap-4">
-          {session.status === 'creating' && (
-            <>
-              <Spinner size="lg" />
-              <p className="text-muted-foreground">
-                {session.statusMessage || 'Setting up session...'}
-              </p>
-            </>
-          )}
-          {session.status === 'error' && (
-            <>
-              <div className="text-destructive text-lg">Setup Failed</div>
-              <p className="text-muted-foreground max-w-md text-center">
-                {session.statusMessage || 'An unknown error occurred'}
-              </p>
-              <Button variant="outline" asChild className="mt-4">
-                <Link href="/">Back to sessions</Link>
-              </Button>
-            </>
-          )}
-        </div>
+        {session.status === 'creating' && (
+          <div className="flex-1 flex flex-col items-center justify-center gap-4">
+            <Spinner size="lg" />
+            <p className="text-muted-foreground">
+              {session.statusMessage || 'Setting up session...'}
+            </p>
+          </div>
+        )}
+        {session.status === 'error' && (
+          <div className="flex-1 flex flex-col items-center justify-center gap-4">
+            <div className="text-destructive text-lg">Setup Failed</div>
+            <p className="text-muted-foreground max-w-md text-center">
+              {session.statusMessage || 'An unknown error occurred'}
+            </p>
+            <Button variant="outline" asChild className="mt-4">
+              <Link href="/">Back to sessions</Link>
+            </Button>
+          </div>
+        )}
+        {session.status === 'archived' && (
+          <>
+            <MessageList
+              messages={messages}
+              isLoading={messagesLoading || isFetchingMore}
+              hasMore={hasMore}
+              onLoadMore={fetchMore}
+              tokenUsage={tokenUsage}
+              onSendResponse={() => {}}
+              isClaudeRunning={false}
+            />
+            <div className="border-t bg-muted/50 px-4 py-3 text-center text-sm text-muted-foreground">
+              This session has been archived. You can view the message history but cannot send new
+              prompts.
+            </div>
+          </>
+        )}
       </div>
     );
   }

--- a/src/components/SessionList.tsx
+++ b/src/components/SessionList.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import Link from 'next/link';
 import { trpc } from '@/lib/trpc';
 import { Button } from '@/components/ui/button';
@@ -17,7 +18,10 @@ interface Session {
 }
 
 export function SessionList() {
-  const { data, isLoading, refetch } = trpc.sessions.list.useQuery();
+  const [showArchived, setShowArchived] = useState(false);
+  const { data, isLoading, refetch } = trpc.sessions.list.useQuery({
+    includeArchived: showArchived,
+  });
 
   if (isLoading) {
     return (
@@ -29,16 +33,23 @@ export function SessionList() {
 
   const sessions: Session[] = data?.sessions ?? [];
 
-  if (sessions.length === 0) {
+  // Separate active and archived sessions for display
+  const activeSessions = sessions.filter((s) => s.status !== 'archived');
+  const archivedSessions = sessions.filter((s) => s.status === 'archived');
+
+  if (sessions.length === 0 && !showArchived) {
     return (
       <Card>
         <CardHeader className="text-center">
           <CardTitle>No sessions yet</CardTitle>
           <CardDescription>Get started by creating a new session.</CardDescription>
         </CardHeader>
-        <CardContent className="flex justify-center">
+        <CardContent className="flex flex-col items-center gap-4">
           <Button asChild>
             <Link href="/new">New Session</Link>
+          </Button>
+          <Button variant="ghost" size="sm" onClick={() => setShowArchived(true)}>
+            Show archived sessions
           </Button>
         </CardContent>
       </Card>
@@ -46,14 +57,54 @@ export function SessionList() {
   }
 
   return (
-    <Card>
-      <CardContent className="p-0">
-        <ul className="divide-y divide-border">
-          {sessions.map((session) => (
-            <SessionListItem key={session.id} session={session} onMutationSuccess={refetch} />
-          ))}
-        </ul>
-      </CardContent>
-    </Card>
+    <div className="space-y-4">
+      <Card>
+        <CardContent className="p-0">
+          {activeSessions.length > 0 ? (
+            <ul className="divide-y divide-border">
+              {activeSessions.map((session) => (
+                <SessionListItem key={session.id} session={session} onMutationSuccess={refetch} />
+              ))}
+            </ul>
+          ) : (
+            <div className="p-6 text-center text-muted-foreground">
+              No active sessions.{' '}
+              <Link href="/new" className="text-primary hover:underline">
+                Create one
+              </Link>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Toggle for archived sessions */}
+      <div className="flex justify-center">
+        <Button variant="ghost" size="sm" onClick={() => setShowArchived(!showArchived)}>
+          {showArchived ? 'Hide archived sessions' : 'Show archived sessions'}
+        </Button>
+      </div>
+
+      {/* Archived sessions section */}
+      {showArchived && archivedSessions.length > 0 && (
+        <Card>
+          <CardHeader className="py-3">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Archived Sessions
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="p-0">
+            <ul className="divide-y divide-border">
+              {archivedSessions.map((session) => (
+                <SessionListItem key={session.id} session={session} onMutationSuccess={refetch} />
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+      )}
+
+      {showArchived && archivedSessions.length === 0 && (
+        <div className="text-center text-sm text-muted-foreground">No archived sessions</div>
+      )}
+    </div>
   );
 }

--- a/src/components/SessionStatusBadge.tsx
+++ b/src/components/SessionStatusBadge.tsx
@@ -1,12 +1,13 @@
 import { Badge } from '@/components/ui/badge';
 
-type SessionStatus = 'running' | 'stopped' | 'creating' | 'error';
+type SessionStatus = 'running' | 'stopped' | 'creating' | 'error' | 'archived';
 
 const statusVariants: Record<SessionStatus, 'default' | 'secondary' | 'destructive' | 'outline'> = {
   running: 'default',
   stopped: 'secondary',
   creating: 'outline',
   error: 'destructive',
+  archived: 'outline',
 };
 
 export function SessionStatusBadge({ status }: { status: string }) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -4,6 +4,7 @@ export const SessionStatus = {
   running: 'running',
   stopped: 'stopped',
   error: 'error',
+  archived: 'archived',
 } as const;
 
 export type SessionStatus = (typeof SessionStatus)[keyof typeof SessionStatus];
@@ -31,6 +32,7 @@ export interface Session {
   initialPrompt: string | null;
   createdAt: Date;
   updatedAt: Date;
+  archivedAt: Date | null;
 }
 
 // Message interface

--- a/src/server/services/session-reconciler.ts
+++ b/src/server/services/session-reconciler.ts
@@ -49,11 +49,11 @@ export async function reconcileSessionsWithPodman(): Promise<ReconciliationResul
 
   try {
     // Get all sessions from DB that have container IDs
-    // (ignore 'creating' sessions as they may be in the process of starting)
+    // (ignore 'creating' and 'archived' sessions - creating may be in progress, archived are inactive)
     const sessions = await prisma.session.findMany({
       where: {
         status: {
-          notIn: ['creating'],
+          notIn: ['creating', 'archived'],
         },
       },
     });
@@ -199,8 +199,8 @@ export async function syncSessionStatus(sessionId: string): Promise<SessionStatu
     return null;
   }
 
-  // Skip sessions in transitional states
-  if (session.status === 'creating') {
+  // Skip sessions in transitional or archived states
+  if (session.status === 'creating' || session.status === 'archived') {
     return null;
   }
 


### PR DESCRIPTION
## Summary

- When a session is deleted, it is now archived rather than permanently removed
- Session status is set to 'archived' and archivedAt timestamp is recorded
- Container is removed and workspace volume is deleted (freeing resources)
- Messages are preserved in the database for later viewing
- Archived sessions are excluded from the session list by default
- A toggle is available to show archived sessions
- Archived sessions are read-only: no start/stop controls, no prompt input

This allows users to still view the message history of past sessions while keeping the session list clean and freeing up storage resources.

Fixes #124

## Test plan

- [x] All unit tests pass (`pnpm test:run`)
- [x] All integration tests pass (`pnpm test:integration`)
- [x] TypeScript type check passes (`pnpm tsc --noEmit`)
- [ ] Manual testing: Create a session, then archive it via the UI
- [ ] Manual testing: Toggle "Show archived sessions" to see archived sessions
- [ ] Manual testing: Open an archived session and verify it's read-only
- [ ] Manual testing: Verify archived sessions cannot be started/stopped

🤖 Generated with [Claude Code](https://claude.com/claude-code)