### PR TITLE
Consistently handle container and execution errors

### DIFF
--- a/src/server/routers/sessions.ts
+++ b/src/server/routers/sessions.ts
@@ -8,6 +8,7 @@ import {
   removeContainer,
   cloneRepoInVolume,
   removeWorkspaceFromVolume,
+  verifyContainerHealth,
 } from '../services/podman';
 import { syncSessionStatus } from '../services/session-reconciler';
 import { sseEvents } from '../services/events';
@@ -56,6 +57,11 @@ async function setupSession(
       githubToken,
     });
     log.info('Container started', { sessionId, containerId });
+
+    // Verify container is healthy before marking session as running
+    await updateStatus('Verifying container health...');
+    await verifyContainerHealth(containerId);
+    log.info('Container health verified', { sessionId, containerId });
 
     // Update session with container info
     const session = await prisma.session.update({


### PR DESCRIPTION
This commit improves error detection and reporting for container and execution failures throughout the codebase. Key changes:

1. New container diagnostic functions in podman.ts:
   - getContainerState(): Returns detailed container state including exit code, error message, OOM status, and timestamps
   - getContainerLogs(): Retrieves recent container logs for debugging
   - verifyContainerHealth(): Validates container is fully initialized and Claude CLI is available before marking session as running

2. Improved exit code handling:
   - ExecStatus now includes notFound flag for clearer state tracking
   - isErrorExitCode() helper to check for non-zero/non-null exit codes
   - describeExitCode() provides human-readable exit code descriptions including signal names (SIGKILL, SIGSEGV, SIGTERM, SIGINT)

3. Error message creation for user visibility:
   - createErrorMessage() creates system error messages stored in DB and emitted via SSE for real-time UI updates
   - Includes exit codes and truncated container logs when available
   - checkContainerHealthAndReport() checks container state and creates error message if container has failed

4. Enhanced runClaudeCommand error handling:
   - Checks container status before and during execution
   - Reports non-zero exit codes (except SIGINT for interrupts)
   - Includes container logs in error messages for debugging

5. Improved processOutputFileWithExecId:
   - Periodically checks container status during output processing
   - Detects and reports container failures during execution
   - Reports Claude process errors with exit code descriptions

6. Session setup verification:
   - Container health is verified after setup before marking session as running, catching initialization failures early

7. Enhanced reconnection handling:
   - Better logging and error reporting when reconnecting to processes
   - Handles exec not found gracefully with notFound flag
   - Reports process exit errors discovered during reconnection

Fixes #129