### PR TITLE
Sanitize markdown and terminal output to prevent XSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "dockerode": "^4.0.9",
+    "dompurify": "^3.3.1",
     "event-source-polyfill": "^1.0.31",
     "lucide-react": "^0.562.0",
     "marked": "^17.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       dockerode:
         specifier: ^4.0.9
         version: 4.0.9
+      dompurify:
+        specifier: ^3.3.1
+        version: 3.3.1
       event-source-polyfill:
         specifier: ^1.0.31
         version: 1.0.31
@@ -1499,6 +1502,9 @@ packages:
   '@types/ssh2@1.15.5':
     resolution: {integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/uuid@10.0.0':
     resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
 
@@ -2080,6 +2086,9 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dompurify@3.3.1:
+    resolution: {integrity: sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -4882,6 +4891,9 @@ snapshots:
     dependencies:
       '@types/node': 18.19.130
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/uuid@10.0.0': {}
 
   '@typescript-eslint/eslint-plugin@8.53.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
@@ -5505,6 +5517,10 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dompurify@3.3.1:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dunder-proto@1.0.1:
     dependencies:

--- a/src/components/MarkdownContent.tsx
+++ b/src/components/MarkdownContent.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo } from 'react';
 import { marked, Renderer } from 'marked';
+import DOMPurify from 'dompurify';
 
 interface MarkdownContentProps {
   content: string;
@@ -27,10 +28,12 @@ export function MarkdownContent({ content, className = '' }: MarkdownContentProp
     try {
       const result = marked.parse(content);
       // marked.parse can return string or Promise<string>, but with sync options it returns string
-      return typeof result === 'string' ? result : '';
+      const rawHtml = typeof result === 'string' ? result : '';
+      // Sanitize HTML to prevent XSS attacks
+      return DOMPurify.sanitize(rawHtml);
     } catch {
-      // Fallback to plain text if parsing fails
-      return content;
+      // Fallback to sanitized plain text if parsing fails
+      return DOMPurify.sanitize(content);
     }
   }, [content]);
 

--- a/src/lib/terminal-output.ts
+++ b/src/lib/terminal-output.ts
@@ -1,4 +1,5 @@
 import AnsiToHtml from 'ansi-to-html';
+import DOMPurify from 'dompurify';
 
 // Singleton converter instance with sensible defaults
 const converter = new AnsiToHtml({
@@ -80,16 +81,19 @@ export function stripAnsi(text: string): string {
  * Process terminal output for display:
  * 1. Handle carriage returns (progress bars)
  * 2. Convert ANSI color codes to HTML spans
+ * 3. Sanitize HTML to prevent XSS attacks
  *
- * Returns HTML string that should be rendered with dangerouslySetInnerHTML.
- * The output is safe because we use escapeXML: true in the converter.
+ * Returns sanitized HTML string that can be rendered with dangerouslySetInnerHTML.
  */
 export function processTerminalOutput(text: string): string {
   // First, simulate terminal carriage return behavior
   const processed = processCarriageReturns(text);
 
   // Then convert ANSI codes to HTML
-  return converter.toHtml(processed);
+  const html = converter.toHtml(processed);
+
+  // Sanitize the output to prevent XSS (defense in depth)
+  return DOMPurify.sanitize(html);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add DOMPurify to sanitize HTML output from the marked library in `MarkdownContent.tsx`
- Add DOMPurify sanitization to terminal output in `terminal-output.ts` as defense-in-depth
- This prevents XSS attacks from malicious markdown content or terminal output from compromised git repos

## Security Impact
Mitigates MEDIUM-HIGH severity XSS vulnerabilities where:
- Malicious markdown like `<img src=x onerror="alert('XSS')">` could execute JavaScript
- Terminal output from compromised repos could include malicious scripts

## Test plan
- [x] All existing tests pass
- [x] Build completes successfully
- [ ] Manual testing: verify markdown formatting (code blocks, links, formatting) still works
- [ ] Manual testing: verify ANSI color codes in terminal output still render correctly

Fixes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)