### PR TITLE
Add rate limiting to login endpoint to prevent brute-force attacks

### DIFF
--- a/src/lib/rate-limiter.test.ts
+++ b/src/lib/rate-limiter.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { RateLimiter, DEFAULT_RATE_LIMIT_CONFIG } from './rate-limiter';
+
+describe('RateLimiter', () => {
+  let limiter: RateLimiter;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    limiter = new RateLimiter();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('check', () => {
+    it('should allow first request from unknown IP', () => {
+      const result = limiter.check('192.168.1.1');
+      expect(result.allowed).toBe(true);
+      expect(result.remainingAttempts).toBe(DEFAULT_RATE_LIMIT_CONFIG.maxAttempts);
+      expect(result.retryAfterMs).toBeNull();
+    });
+
+    it('should allow requests when under the limit', () => {
+      // Record a few failures
+      limiter.recordFailure('192.168.1.1');
+      limiter.recordFailure('192.168.1.1');
+
+      const result = limiter.check('192.168.1.1');
+      expect(result.allowed).toBe(true);
+      expect(result.remainingAttempts).toBe(DEFAULT_RATE_LIMIT_CONFIG.maxAttempts - 2);
+    });
+
+    it('should block requests during lockout', () => {
+      // Exhaust all attempts
+      for (let i = 0; i < DEFAULT_RATE_LIMIT_CONFIG.maxAttempts; i++) {
+        limiter.recordFailure('192.168.1.1');
+      }
+
+      const result = limiter.check('192.168.1.1');
+      expect(result.allowed).toBe(false);
+      expect(result.remainingAttempts).toBe(0);
+      expect(result.retryAfterMs).toBe(DEFAULT_RATE_LIMIT_CONFIG.lockoutDurationMs);
+    });
+
+    it('should allow requests after lockout expires', () => {
+      // Exhaust all attempts
+      for (let i = 0; i < DEFAULT_RATE_LIMIT_CONFIG.maxAttempts; i++) {
+        limiter.recordFailure('192.168.1.1');
+      }
+
+      // Fast forward past lockout
+      vi.advanceTimersByTime(DEFAULT_RATE_LIMIT_CONFIG.lockoutDurationMs + 1);
+
+      const result = limiter.check('192.168.1.1');
+      expect(result.allowed).toBe(true);
+      expect(result.remainingAttempts).toBe(DEFAULT_RATE_LIMIT_CONFIG.maxAttempts);
+    });
+
+    it('should track different IPs independently', () => {
+      // Lock out IP1
+      for (let i = 0; i < DEFAULT_RATE_LIMIT_CONFIG.maxAttempts; i++) {
+        limiter.recordFailure('192.168.1.1');
+      }
+
+      // IP2 should still be allowed
+      const result = limiter.check('192.168.1.2');
+      expect(result.allowed).toBe(true);
+      expect(result.remainingAttempts).toBe(DEFAULT_RATE_LIMIT_CONFIG.maxAttempts);
+    });
+  });
+
+  describe('recordFailure', () => {
+    it('should increment attempt count', () => {
+      let result = limiter.recordFailure('192.168.1.1');
+      expect(result.remainingAttempts).toBe(DEFAULT_RATE_LIMIT_CONFIG.maxAttempts - 1);
+
+      result = limiter.recordFailure('192.168.1.1');
+      expect(result.remainingAttempts).toBe(DEFAULT_RATE_LIMIT_CONFIG.maxAttempts - 2);
+    });
+
+    it('should trigger lockout at max attempts', () => {
+      let result;
+      for (let i = 0; i < DEFAULT_RATE_LIMIT_CONFIG.maxAttempts - 1; i++) {
+        result = limiter.recordFailure('192.168.1.1');
+        expect(result.allowed).toBe(true);
+      }
+
+      result = limiter.recordFailure('192.168.1.1');
+      expect(result.allowed).toBe(false);
+      expect(result.remainingAttempts).toBe(0);
+      expect(result.retryAfterMs).toBe(DEFAULT_RATE_LIMIT_CONFIG.lockoutDurationMs);
+    });
+
+    it('should reset attempts when window expires', () => {
+      // Record some failures
+      limiter.recordFailure('192.168.1.1');
+      limiter.recordFailure('192.168.1.1');
+
+      // Fast forward past window
+      vi.advanceTimersByTime(DEFAULT_RATE_LIMIT_CONFIG.windowMs + 1);
+
+      // Should have full attempts again
+      const result = limiter.recordFailure('192.168.1.1');
+      expect(result.remainingAttempts).toBe(DEFAULT_RATE_LIMIT_CONFIG.maxAttempts - 1);
+    });
+  });
+
+  describe('exponential backoff', () => {
+    it('should double lockout duration after each lockout', () => {
+      // First lockout - 15 minutes
+      for (let i = 0; i < DEFAULT_RATE_LIMIT_CONFIG.maxAttempts; i++) {
+        limiter.recordFailure('192.168.1.1');
+      }
+      let result = limiter.check('192.168.1.1');
+      expect(result.retryAfterMs).toBe(DEFAULT_RATE_LIMIT_CONFIG.lockoutDurationMs);
+
+      // Wait for lockout to expire
+      vi.advanceTimersByTime(DEFAULT_RATE_LIMIT_CONFIG.lockoutDurationMs + 1);
+
+      // Second lockout - 30 minutes
+      for (let i = 0; i < DEFAULT_RATE_LIMIT_CONFIG.maxAttempts; i++) {
+        limiter.recordFailure('192.168.1.1');
+      }
+      result = limiter.check('192.168.1.1');
+      expect(result.retryAfterMs).toBe(DEFAULT_RATE_LIMIT_CONFIG.lockoutDurationMs * 2);
+
+      // Wait for lockout to expire
+      vi.advanceTimersByTime(DEFAULT_RATE_LIMIT_CONFIG.lockoutDurationMs * 2 + 1);
+
+      // Third lockout - 60 minutes
+      for (let i = 0; i < DEFAULT_RATE_LIMIT_CONFIG.maxAttempts; i++) {
+        limiter.recordFailure('192.168.1.1');
+      }
+      result = limiter.check('192.168.1.1');
+      expect(result.retryAfterMs).toBe(DEFAULT_RATE_LIMIT_CONFIG.lockoutDurationMs * 4);
+    });
+
+    it('should cap lockout at 2 hours', () => {
+      // Trigger many lockouts
+      for (let lockout = 0; lockout < 10; lockout++) {
+        for (let i = 0; i < DEFAULT_RATE_LIMIT_CONFIG.maxAttempts; i++) {
+          limiter.recordFailure('192.168.1.1');
+        }
+
+        const result = limiter.check('192.168.1.1');
+        expect(result.retryAfterMs).toBeLessThanOrEqual(2 * 60 * 60 * 1000);
+
+        // Wait for lockout to expire
+        vi.advanceTimersByTime(result.retryAfterMs! + 1);
+      }
+    });
+  });
+
+  describe('recordSuccess', () => {
+    it('should reset attempt count on success', () => {
+      // Record some failures
+      limiter.recordFailure('192.168.1.1');
+      limiter.recordFailure('192.168.1.1');
+
+      // Record success
+      limiter.recordSuccess('192.168.1.1');
+
+      // Should have full attempts again
+      const result = limiter.check('192.168.1.1');
+      expect(result.allowed).toBe(true);
+      expect(result.remainingAttempts).toBe(DEFAULT_RATE_LIMIT_CONFIG.maxAttempts);
+    });
+
+    it('should keep lockout count for exponential backoff', () => {
+      // First lockout
+      for (let i = 0; i < DEFAULT_RATE_LIMIT_CONFIG.maxAttempts; i++) {
+        limiter.recordFailure('192.168.1.1');
+      }
+
+      // Wait for lockout to expire
+      vi.advanceTimersByTime(DEFAULT_RATE_LIMIT_CONFIG.lockoutDurationMs + 1);
+
+      // Successful login
+      limiter.recordSuccess('192.168.1.1');
+
+      // More failures - should still use exponential backoff
+      for (let i = 0; i < DEFAULT_RATE_LIMIT_CONFIG.maxAttempts; i++) {
+        limiter.recordFailure('192.168.1.1');
+      }
+
+      const result = limiter.check('192.168.1.1');
+      // Second lockout should be doubled
+      expect(result.retryAfterMs).toBe(DEFAULT_RATE_LIMIT_CONFIG.lockoutDurationMs * 2);
+    });
+
+    it('should handle success for unknown IP', () => {
+      // Should not throw
+      limiter.recordSuccess('192.168.1.1');
+
+      const result = limiter.check('192.168.1.1');
+      expect(result.allowed).toBe(true);
+    });
+  });
+
+  describe('reset', () => {
+    it('should clear data for specific IP', () => {
+      // Record failures for two IPs
+      for (let i = 0; i < DEFAULT_RATE_LIMIT_CONFIG.maxAttempts; i++) {
+        limiter.recordFailure('192.168.1.1');
+        limiter.recordFailure('192.168.1.2');
+      }
+
+      // Reset only IP1
+      limiter.reset('192.168.1.1');
+
+      // IP1 should be allowed, IP2 still locked
+      expect(limiter.check('192.168.1.1').allowed).toBe(true);
+      expect(limiter.check('192.168.1.2').allowed).toBe(false);
+    });
+  });
+
+  describe('resetAll', () => {
+    it('should clear all rate limit data', () => {
+      // Lock out multiple IPs
+      for (let i = 0; i < DEFAULT_RATE_LIMIT_CONFIG.maxAttempts; i++) {
+        limiter.recordFailure('192.168.1.1');
+        limiter.recordFailure('192.168.1.2');
+      }
+
+      limiter.resetAll();
+
+      expect(limiter.check('192.168.1.1').allowed).toBe(true);
+      expect(limiter.check('192.168.1.2').allowed).toBe(true);
+      expect(limiter.size).toBe(0);
+    });
+  });
+
+  describe('cleanup', () => {
+    it('should remove expired entries', () => {
+      // Record some failures
+      limiter.recordFailure('192.168.1.1');
+      limiter.recordFailure('192.168.1.2');
+
+      expect(limiter.size).toBe(2);
+
+      // Fast forward past window
+      vi.advanceTimersByTime(DEFAULT_RATE_LIMIT_CONFIG.windowMs + 1);
+
+      const cleaned = limiter.cleanup();
+      expect(cleaned).toBe(2);
+      expect(limiter.size).toBe(0);
+    });
+
+    it('should keep locked out entries until lockout expires', () => {
+      // Use a custom limiter with lockout longer than window to test this scenario
+      const customLimiter = new RateLimiter({
+        maxAttempts: 3,
+        windowMs: 5000, // 5 seconds
+        lockoutDurationMs: 30000, // 30 seconds - longer than window
+      });
+
+      // Lock out an IP
+      for (let i = 0; i < 3; i++) {
+        customLimiter.recordFailure('192.168.1.1');
+      }
+
+      // Fast forward past window but not past lockout
+      vi.advanceTimersByTime(6000); // 6 seconds - past 5s window but not 30s lockout
+
+      const cleaned = customLimiter.cleanup();
+      expect(cleaned).toBe(0);
+      expect(customLimiter.size).toBe(1);
+
+      // Fast forward past lockout
+      vi.advanceTimersByTime(25000); // Total 31 seconds - past lockout
+
+      const cleanedAfter = customLimiter.cleanup();
+      expect(cleanedAfter).toBe(1);
+      expect(customLimiter.size).toBe(0);
+    });
+  });
+
+  describe('custom config', () => {
+    it('should allow custom max attempts', () => {
+      const customLimiter = new RateLimiter({ maxAttempts: 3 });
+
+      customLimiter.recordFailure('192.168.1.1');
+      customLimiter.recordFailure('192.168.1.1');
+
+      expect(customLimiter.check('192.168.1.1').remainingAttempts).toBe(1);
+
+      customLimiter.recordFailure('192.168.1.1');
+
+      expect(customLimiter.check('192.168.1.1').allowed).toBe(false);
+    });
+
+    it('should allow custom lockout duration', () => {
+      const customLimiter = new RateLimiter({
+        maxAttempts: 2,
+        lockoutDurationMs: 5000, // 5 seconds
+      });
+
+      customLimiter.recordFailure('192.168.1.1');
+      customLimiter.recordFailure('192.168.1.1');
+
+      const result = customLimiter.check('192.168.1.1');
+      expect(result.retryAfterMs).toBe(5000);
+    });
+  });
+});

--- a/src/lib/rate-limiter.ts
+++ b/src/lib/rate-limiter.ts
@@ -1,0 +1,222 @@
+/**
+ * Simple in-memory rate limiter for login attempts.
+ * Uses IP-based tracking with exponential backoff after failed attempts.
+ */
+
+export interface RateLimitConfig {
+  maxAttempts: number; // Max attempts before lockout
+  lockoutDurationMs: number; // Base lockout duration in ms
+  windowMs: number; // Time window for tracking attempts
+}
+
+export interface RateLimitEntry {
+  attempts: number;
+  firstAttemptAt: number;
+  lockedUntil: number | null;
+  lockoutCount: number; // Number of times locked out (for exponential backoff)
+}
+
+export interface RateLimitResult {
+  allowed: boolean;
+  remainingAttempts: number;
+  retryAfterMs: number | null;
+}
+
+export const DEFAULT_RATE_LIMIT_CONFIG: RateLimitConfig = {
+  maxAttempts: 5,
+  lockoutDurationMs: 15 * 60 * 1000, // 15 minutes
+  windowMs: 15 * 60 * 1000, // 15 minute window
+};
+
+export class RateLimiter {
+  private entries: Map<string, RateLimitEntry> = new Map();
+  private config: RateLimitConfig;
+
+  constructor(config: Partial<RateLimitConfig> = {}) {
+    this.config = { ...DEFAULT_RATE_LIMIT_CONFIG, ...config };
+  }
+
+  /**
+   * Check if a request is allowed for the given key (typically IP address).
+   * Call this BEFORE attempting authentication.
+   */
+  check(key: string): RateLimitResult {
+    const now = Date.now();
+    const entry = this.entries.get(key);
+
+    // No previous attempts - allow
+    if (!entry) {
+      return {
+        allowed: true,
+        remainingAttempts: this.config.maxAttempts,
+        retryAfterMs: null,
+      };
+    }
+
+    // Check if currently locked out
+    if (entry.lockedUntil !== null && now < entry.lockedUntil) {
+      return {
+        allowed: false,
+        remainingAttempts: 0,
+        retryAfterMs: entry.lockedUntil - now,
+      };
+    }
+
+    // Check if lockout has expired - reset lockout but keep lockout count for exponential backoff
+    if (entry.lockedUntil !== null && now >= entry.lockedUntil) {
+      entry.lockedUntil = null;
+      entry.attempts = 0;
+      entry.firstAttemptAt = now;
+      // Keep lockoutCount for exponential backoff - don't reset it here
+    }
+
+    // Check if window has expired AND we're not in an active lockout sequence
+    // Only reset lockoutCount if enough time has passed since the last lockout ended
+    if (now - entry.firstAttemptAt > this.config.windowMs && entry.lockedUntil === null) {
+      entry.attempts = 0;
+      entry.firstAttemptAt = now;
+      entry.lockoutCount = 0; // Reset exponential backoff after clean window
+    }
+
+    const remainingAttempts = Math.max(0, this.config.maxAttempts - entry.attempts);
+
+    return {
+      allowed: remainingAttempts > 0,
+      remainingAttempts,
+      retryAfterMs: null,
+    };
+  }
+
+  /**
+   * Record a failed authentication attempt for the given key.
+   * Call this AFTER a failed authentication.
+   */
+  recordFailure(key: string): RateLimitResult {
+    const now = Date.now();
+    let entry = this.entries.get(key);
+
+    if (!entry) {
+      entry = {
+        attempts: 0,
+        firstAttemptAt: now,
+        lockedUntil: null,
+        lockoutCount: 0,
+      };
+      this.entries.set(key, entry);
+    }
+
+    // Check if lockout has expired - reset attempts but keep lockout count
+    if (entry.lockedUntil !== null && now >= entry.lockedUntil) {
+      entry.lockedUntil = null;
+      entry.attempts = 0;
+      entry.firstAttemptAt = now;
+      // Keep lockoutCount for exponential backoff - don't reset it here
+    }
+
+    // Check if window has expired AND we're not in an active lockout sequence
+    // Only reset lockoutCount if enough time has passed since the last lockout ended
+    if (now - entry.firstAttemptAt > this.config.windowMs && entry.lockedUntil === null) {
+      entry.attempts = 0;
+      entry.firstAttemptAt = now;
+      entry.lockoutCount = 0;
+    }
+
+    entry.attempts++;
+
+    // Check if we've hit the limit
+    if (entry.attempts >= this.config.maxAttempts) {
+      // Calculate lockout duration with exponential backoff
+      // 15 min -> 30 min -> 60 min -> 120 min, capped at 2 hours
+      const backoffMultiplier = Math.pow(2, entry.lockoutCount);
+      const lockoutDuration = Math.min(
+        this.config.lockoutDurationMs * backoffMultiplier,
+        2 * 60 * 60 * 1000 // Max 2 hours
+      );
+      entry.lockedUntil = now + lockoutDuration;
+      entry.lockoutCount++;
+
+      return {
+        allowed: false,
+        remainingAttempts: 0,
+        retryAfterMs: lockoutDuration,
+      };
+    }
+
+    return {
+      allowed: true,
+      remainingAttempts: this.config.maxAttempts - entry.attempts,
+      retryAfterMs: null,
+    };
+  }
+
+  /**
+   * Record a successful authentication for the given key.
+   * Resets the attempt counter but keeps lockout history for a grace period.
+   */
+  recordSuccess(key: string): void {
+    const entry = this.entries.get(key);
+    if (entry) {
+      entry.attempts = 0;
+      entry.lockedUntil = null;
+      // Reset firstAttemptAt to start a fresh window, but keep lockoutCount
+      // This prevents attackers from resetting backoff by getting one success
+      entry.firstAttemptAt = Date.now();
+    }
+  }
+
+  /**
+   * Clear rate limit data for a specific key (useful for testing or admin reset).
+   */
+  reset(key: string): void {
+    this.entries.delete(key);
+  }
+
+  /**
+   * Clear all rate limit data (useful for testing or server restart).
+   */
+  resetAll(): void {
+    this.entries.clear();
+  }
+
+  /**
+   * Clean up expired entries to prevent memory leaks.
+   * Call this periodically (e.g., every hour).
+   */
+  cleanup(): number {
+    const now = Date.now();
+    let cleaned = 0;
+
+    for (const [key, entry] of this.entries) {
+      // Remove entries that are unlocked and whose window has expired
+      const windowExpired = now - entry.firstAttemptAt > this.config.windowMs;
+      const notLockedOut = entry.lockedUntil === null || now >= entry.lockedUntil;
+
+      if (windowExpired && notLockedOut) {
+        this.entries.delete(key);
+        cleaned++;
+      }
+    }
+
+    return cleaned;
+  }
+
+  /**
+   * Get the current number of tracked entries (useful for monitoring).
+   */
+  get size(): number {
+    return this.entries.size;
+  }
+}
+
+// Singleton instance for the login rate limiter
+export const loginRateLimiter = new RateLimiter();
+
+// Start cleanup interval (every hour)
+if (typeof setInterval !== 'undefined') {
+  setInterval(
+    () => {
+      loginRateLimiter.cleanup();
+    },
+    60 * 60 * 1000
+  );
+}


### PR DESCRIPTION
## Summary

- Adds IP-based rate limiting to the login endpoint to prevent brute-force password attacks
- Implements exponential backoff (15 min → 30 min → 1 hour → 2 hour max) for repeated lockouts
- Includes comprehensive unit tests for the rate limiter module

## Implementation Details

- Created `src/lib/rate-limiter.ts` with a `RateLimiter` class that tracks failed attempts per IP
- 5 failed attempts triggers a 15-minute lockout
- Each subsequent lockout doubles the duration (capped at 2 hours)
- Successful login resets attempts but preserves backoff multiplier to prevent gaming
- Automatic cleanup of expired entries runs hourly to prevent memory leaks

## Test plan

- [x] Rate limiter unit tests pass (19 tests)
- [x] All existing tests still pass (250 total)
- [ ] Manual test: verify rate limiting kicks in after 5 failed attempts
- [ ] Manual test: verify successful login resets attempt counter

Fixes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)