### PR TITLE
Optimize session startup by ~20 seconds

### DIFF
--- a/src/server/services/podman.test.ts
+++ b/src/server/services/podman.test.ts
@@ -70,6 +70,9 @@ function createMockProcess(): ChildProcess & {
   (stderr as unknown as { pipe: (dest: NodeJS.WritableStream) => NodeJS.WritableStream }).pipe =
     vi.fn((dest) => dest);
 
+  // Add mock unref method for background processes
+  (proc as unknown as { unref: () => void }).unref = vi.fn();
+
   proc.stdout = stdout as unknown as typeof proc.stdout;
   proc.stderr = stderr as unknown as typeof proc.stderr;
   return proc;


### PR DESCRIPTION
## Summary
- Run temp container cleanup in background using `podman rm -f` (SIGKILL) instead of `podman stop` (10s timeout) + `podman rm` - saves ~20 seconds total from two temp containers
- Run container setup tasks (auth, git creds, pnpm, gradle, permissions) in parallel instead of sequentially - saves ~0.5 seconds

## Details

### Background container cleanup
The biggest optimization comes from the container cleanup. Previously, we used:
```
await runPodmanIgnoreErrors(['stop', containerId]);  // 10 second timeout
await runPodmanIgnoreErrors(['rm', '-f', containerId]);
```

This was done twice during session startup (once for the git cache container, once for the clone container), adding ~20 seconds of waiting.

Since these are temporary containers with `--rm` flag and we don't need graceful shutdown (they're just running `tail -f /dev/null`), we now use:
```
runPodmanBackground(['rm', '-f', containerId]);  // Fire-and-forget, SIGKILL
```

This runs in the background without blocking, and uses SIGKILL for instant termination.

### Parallel setup tasks
The container setup previously ran 6+ sequential `podman exec` commands. These are now run in parallel with `Promise.all()`:
- Copy Claude auth files
- Configure pnpm store
- Configure Gradle cache  
- Fix sudo permissions
- Configure git credentials (if token provided)
- Fix podman socket permissions (if mounted)

## Test plan
- [x] All existing tests pass
- [ ] Test session creation to verify startup is faster
- [ ] Verify sessions work correctly after the parallelized setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)