### PR TITLE
Fix links in chat opening in the same window

### DIFF
--- a/src/components/MarkdownContent.test.tsx
+++ b/src/components/MarkdownContent.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MarkdownContent } from './MarkdownContent';
+
+describe('MarkdownContent', () => {
+  it('renders plain text', () => {
+    render(<MarkdownContent content="Hello, world!" />);
+    expect(screen.getByText('Hello, world!')).toBeInTheDocument();
+  });
+
+  it('renders markdown links with target="_blank"', () => {
+    render(<MarkdownContent content="Check out [Google](https://google.com)!" />);
+    const link = screen.getByRole('link', { name: 'Google' });
+    expect(link).toHaveAttribute('href', 'https://google.com');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('renders autolinked URLs with target="_blank"', () => {
+    render(<MarkdownContent content="Visit https://example.com for more info." />);
+    const link = screen.getByRole('link', { name: 'https://example.com' });
+    expect(link).toHaveAttribute('href', 'https://example.com');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('renders bold and italic text', () => {
+    render(<MarkdownContent content="This is **bold** and *italic*." />);
+    expect(screen.getByText('bold')).toBeInTheDocument();
+    expect(screen.getByText('italic')).toBeInTheDocument();
+  });
+
+  it('renders code blocks', () => {
+    render(<MarkdownContent content={'```js\nconst x = 1;\n```'} />);
+    // Code blocks contain the language identifier and code
+    expect(screen.getByText(/const x = 1/)).toBeInTheDocument();
+  });
+
+  it('sanitizes malicious HTML', () => {
+    render(<MarkdownContent content='<script>alert("xss")</script>Hello' />);
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+    // Script should be removed
+    expect(document.querySelector('script')).toBeNull();
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(<MarkdownContent content="Test" className="custom-class" />);
+    expect(container.firstChild).toHaveClass('markdown-content', 'custom-class');
+  });
+});

--- a/src/components/MarkdownContent.tsx
+++ b/src/components/MarkdownContent.tsx
@@ -30,10 +30,15 @@ export function MarkdownContent({ content, className = '' }: MarkdownContentProp
       // marked.parse can return string or Promise<string>, but with sync options it returns string
       const rawHtml = typeof result === 'string' ? result : '';
       // Sanitize HTML to prevent XSS attacks
-      return DOMPurify.sanitize(rawHtml);
+      // Allow target attribute on links so they open in new windows
+      return DOMPurify.sanitize(rawHtml, {
+        ADD_ATTR: ['target'],
+      });
     } catch {
       // Fallback to sanitized plain text if parsing fails
-      return DOMPurify.sanitize(content);
+      return DOMPurify.sanitize(content, {
+        ADD_ATTR: ['target'],
+      });
     }
   }, [content]);
 


### PR DESCRIPTION
## Summary
- Fix DOMPurify stripping `target="_blank"` from links in markdown content
- Links in Claude's chat responses now open in new windows/tabs as expected

## Details
The `MarkdownContent` component was already adding `target="_blank"` and `rel="noopener noreferrer"` to links via the marked renderer, but DOMPurify was stripping the `target` attribute during sanitization. This configures DOMPurify with `ADD_ATTR: ['target']` to preserve the attribute.

## Test plan
- [x] Added tests for `MarkdownContent` component verifying link attributes
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)