### PR TITLE
Add archive button to session page header

### DIFF
--- a/src/components/SessionActionButton.tsx
+++ b/src/components/SessionActionButton.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Spinner } from '@/components/ui/spinner';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+
+type ButtonVariant = 'default' | 'secondary' | 'ghost' | 'destructive' | 'outline' | 'link';
+
+interface SessionActionButtonProps {
+  action: 'start' | 'stop' | 'archive';
+  onClick: () => void;
+  isPending: boolean;
+  variant?: ButtonVariant;
+  sessionName?: string;
+}
+
+const actionLabels = {
+  start: { label: 'Start', pendingLabel: 'Starting...' },
+  stop: { label: 'Stop', pendingLabel: 'Stopping...' },
+  archive: { label: 'Archive', pendingLabel: 'Archiving...' },
+} as const;
+
+const archiveConfirmTitle = 'Archive session?';
+const archiveConfirmDescription = (name: string) =>
+  `This will archive the session "${name}" and remove its workspace. You can still view the message history in archived sessions.`;
+
+/**
+ * Reusable button component for session actions (start, stop, archive).
+ * Archive action shows a confirmation dialog before proceeding.
+ */
+export function SessionActionButton({
+  action,
+  onClick,
+  isPending,
+  variant = 'default',
+  sessionName,
+}: SessionActionButtonProps) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const { label, pendingLabel } = actionLabels[action];
+
+  // Archive requires confirmation dialog
+  if (action === 'archive') {
+    if (isPending) {
+      return (
+        <Button variant={variant} size="sm" disabled className="text-muted-foreground">
+          <Spinner size="sm" className="mr-2" />
+          {pendingLabel}
+        </Button>
+      );
+    }
+
+    return (
+      <AlertDialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <AlertDialogTrigger asChild>
+          <Button variant={variant} size="sm" className="text-muted-foreground">
+            {label}
+          </Button>
+        </AlertDialogTrigger>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{archiveConfirmTitle}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {archiveConfirmDescription(sessionName ?? 'this session')}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                onClick();
+                setDialogOpen(false);
+              }}
+            >
+              Archive
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    );
+  }
+
+  // Start/Stop are simple buttons
+  return (
+    <Button size="sm" variant={variant} onClick={onClick} disabled={isPending}>
+      {isPending ? pendingLabel : label}
+    </Button>
+  );
+}

--- a/src/components/SessionHeader.tsx
+++ b/src/components/SessionHeader.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { SessionStatusBadge } from '@/components/SessionStatusBadge';
+import { SessionActionButton } from '@/components/SessionActionButton';
 
 interface SessionHeaderProps {
   session: {
@@ -16,16 +17,20 @@ interface SessionHeaderProps {
   };
   onStart: () => void;
   onStop: () => void;
+  onArchive?: () => void;
   isStarting: boolean;
   isStopping: boolean;
+  isArchiving?: boolean;
 }
 
 export function SessionHeader({
   session,
   onStart,
   onStop,
+  onArchive,
   isStarting,
   isStopping,
+  isArchiving = false,
 }: SessionHeaderProps) {
   const repoName = session.repoUrl.replace('https://github.com/', '').replace('.git', '');
 
@@ -58,14 +63,24 @@ export function SessionHeader({
           <SessionStatusBadge status={session.status} />
 
           {session.status === 'stopped' && (
-            <Button size="sm" onClick={onStart} disabled={isStarting}>
-              {isStarting ? 'Starting...' : 'Start'}
-            </Button>
+            <SessionActionButton action="start" onClick={onStart} isPending={isStarting} />
           )}
           {session.status === 'running' && (
-            <Button variant="secondary" size="sm" onClick={onStop} disabled={isStopping}>
-              {isStopping ? 'Stopping...' : 'Stop'}
-            </Button>
+            <SessionActionButton
+              action="stop"
+              onClick={onStop}
+              isPending={isStopping}
+              variant="secondary"
+            />
+          )}
+          {(session.status === 'stopped' || session.status === 'running') && onArchive && (
+            <SessionActionButton
+              action="archive"
+              onClick={onArchive}
+              isPending={isArchiving}
+              variant="secondary"
+              sessionName={session.name}
+            />
           )}
         </div>
       </div>

--- a/src/components/SessionListItem.tsx
+++ b/src/components/SessionListItem.tsx
@@ -1,21 +1,8 @@
 'use client';
 
-import { useState } from 'react';
 import Link from 'next/link';
-import { Button } from '@/components/ui/button';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from '@/components/ui/alert-dialog';
 import { SessionStatusBadge } from '@/components/SessionStatusBadge';
-import { Spinner } from '@/components/ui/spinner';
+import { SessionActionButton } from '@/components/SessionActionButton';
 import type { Session } from '@/hooks/useSessionList';
 import type { SessionActions } from '@/hooks/useSessionActions';
 
@@ -29,19 +16,12 @@ export interface SessionListItemProps {
  * Receives session data and actions as props, making it easily testable.
  */
 export function SessionListItem({ session, actions }: SessionListItemProps) {
-  const [archiveDialogOpen, setArchiveDialogOpen] = useState(false);
-
   const repoName = session.repoUrl.replace('https://github.com/', '').replace('.git', '');
 
   const isArchiving = actions.isArchiving(session.id);
   const isStarting = actions.isStarting(session.id);
   const isStopping = actions.isStopping(session.id);
   const isArchived = session.status === 'archived';
-
-  const handleArchive = () => {
-    actions.archive(session.id);
-    setArchiveDialogOpen(false);
-  };
 
   return (
     <li
@@ -69,52 +49,28 @@ export function SessionListItem({ session, actions }: SessionListItemProps) {
             {!isArchived && (
               <>
                 {session.status === 'stopped' && (
-                  <Button
-                    variant="ghost"
-                    size="sm"
+                  <SessionActionButton
+                    action="start"
                     onClick={() => actions.start(session.id)}
-                    disabled={isStarting}
-                  >
-                    {isStarting ? 'Starting...' : 'Start'}
-                  </Button>
+                    isPending={isStarting}
+                    variant="ghost"
+                  />
                 )}
                 {session.status === 'running' && (
-                  <Button
-                    variant="ghost"
-                    size="sm"
+                  <SessionActionButton
+                    action="stop"
                     onClick={() => actions.stop(session.id)}
-                    disabled={isStopping}
-                  >
-                    {isStopping ? 'Stopping...' : 'Stop'}
-                  </Button>
+                    isPending={isStopping}
+                    variant="ghost"
+                  />
                 )}
-                {isArchiving ? (
-                  <Button variant="ghost" size="sm" disabled className="text-muted-foreground">
-                    <Spinner size="sm" className="mr-2" />
-                    Archiving...
-                  </Button>
-                ) : (
-                  <AlertDialog open={archiveDialogOpen} onOpenChange={setArchiveDialogOpen}>
-                    <AlertDialogTrigger asChild>
-                      <Button variant="ghost" size="sm" className="text-muted-foreground">
-                        Archive
-                      </Button>
-                    </AlertDialogTrigger>
-                    <AlertDialogContent>
-                      <AlertDialogHeader>
-                        <AlertDialogTitle>Archive session?</AlertDialogTitle>
-                        <AlertDialogDescription>
-                          This will archive the session &quot;{session.name}&quot; and remove its
-                          workspace. You can still view the message history in archived sessions.
-                        </AlertDialogDescription>
-                      </AlertDialogHeader>
-                      <AlertDialogFooter>
-                        <AlertDialogCancel>Cancel</AlertDialogCancel>
-                        <AlertDialogAction onClick={handleArchive}>Archive</AlertDialogAction>
-                      </AlertDialogFooter>
-                    </AlertDialogContent>
-                  </AlertDialog>
-                )}
+                <SessionActionButton
+                  action="archive"
+                  onClick={() => actions.archive(session.id)}
+                  isPending={isArchiving}
+                  variant="ghost"
+                  sessionName={session.name}
+                />
               </>
             )}
           </div>


### PR DESCRIPTION
## Summary
- Create a shared `SessionActionButton` component for start/stop/archive actions
- Add Archive button to session page header (next to Start/Stop buttons)
- Refactor `SessionListItem` to use the shared button component, reducing duplication

## Test plan
- [ ] Verify Archive button appears on session page when session is running or stopped
- [ ] Verify clicking Archive shows confirmation dialog
- [ ] Verify confirming archive archives the session and shows archived state
- [ ] Verify Start/Stop buttons still work correctly on session page
- [ ] Verify session list still works correctly with the shared component

🤖 Generated with [Claude Code](https://claude.com/claude-code)