### PR TITLE
Stream within-message outputs for real-time feedback

### DIFF
--- a/src/server/services/claude-runner.test.ts
+++ b/src/server/services/claude-runner.test.ts
@@ -953,6 +953,7 @@ describe('claude-runner service', () => {
       expect(command).toContain('--output-format');
       expect(command).toContain('stream-json');
       expect(command).toContain('--verbose');
+      expect(command).toContain('--include-partial-messages');
       expect(command).toContain('--dangerously-skip-permissions');
       expect(command).toContain('--append-system-prompt');
     });


### PR DESCRIPTION
## Summary

- Add support for Claude's `--include-partial-messages` flag to stream incremental updates during long-running operations
- Process `stream_event` messages to build partial content from text and tool_use deltas
- Emit SSE updates for partial messages to provide real-time feedback in the UI
- Update client to replace existing messages with the same ID (enabling progressive updates)

## Implementation Details

The implementation accumulates `content_block_delta` events into partial assistant messages, emitting SSE updates as content arrives. When the final `assistant` message comes through, it replaces the partial version. Stream events are not saved to the database - only final messages are persisted.

Key changes:
- `claude-runner.ts`: New partial message tracking system that processes `stream_event` messages
- `page.tsx`: Client now replaces messages with the same ID instead of deduplicating
- Uses `message.id` as the primary identifier for assistant messages to ensure partial and final messages share the same ID

## Test plan

- [x] All existing tests pass
- [x] Test for `--include-partial-messages` flag added
- [x] TypeScript type checking passes
- [ ] Manual testing with actual Claude session to verify streaming works

Fixes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)