### PR TITLE
Add credential watcher to auto-update Claude auth in running containers

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -9,6 +9,7 @@ export async function register() {
     const { reconcileOrphanedProcesses } = await import('@/server/services/claude-runner');
     const { reconcileSessionsWithPodman, startBackgroundReconciliation } =
       await import('@/server/services/session-reconciler');
+    const { startCredentialWatcher } = await import('@/server/services/credential-watcher');
 
     console.log('Starting server - reconciling sessions with Podman...');
 
@@ -50,5 +51,9 @@ export async function register() {
 
     // Start background polling for container state changes
     startBackgroundReconciliation();
+
+    // Start watching Claude auth files for changes
+    // When credentials change on the host, they are automatically pushed to all running containers
+    startCredentialWatcher();
   }
 }

--- a/src/server/services/credential-watcher.test.ts
+++ b/src/server/services/credential-watcher.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+// Create mock objects that will be hoisted
+const { mockPodmanFunctions, mockFs, mockEnv } = vi.hoisted(() => {
+  const mockPodmanFunctions = {
+    listSessionContainers: vi.fn(),
+    copyClaudeAuth: vi.fn(),
+  };
+
+  const mockFs = {
+    watch: vi.fn(),
+    existsSync: vi.fn(),
+    statSync: vi.fn(),
+  };
+
+  const mockEnv = {
+    CLAUDE_AUTH_PATH: '/mock/.claude',
+  };
+
+  return { mockPodmanFunctions, mockFs, mockEnv };
+});
+
+// Mock the podman service
+vi.mock('./podman', () => mockPodmanFunctions);
+
+// Mock fs
+vi.mock('fs', () => mockFs);
+
+// Mock env
+vi.mock('@/lib/env', () => ({
+  env: mockEnv,
+}));
+
+// Mock the logger
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+  toError: (e: unknown) => (e instanceof Error ? e : new Error(String(e))),
+}));
+
+// Import after mocks are set up
+import {
+  startCredentialWatcher,
+  stopCredentialWatcher,
+  pushCredentialsToAllContainers,
+} from './credential-watcher';
+
+describe('credential-watcher service', () => {
+  let watchCallback: ((eventType: string, filename: string | null) => void) | null = null;
+  let watcherInstance: { close: ReturnType<typeof vi.fn>; on: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    watchCallback = null;
+
+    // Create a mock watcher instance
+    watcherInstance = {
+      close: vi.fn(),
+      on: vi.fn(),
+    };
+
+    // Set up the watch mock to capture the callback
+    mockFs.watch.mockImplementation((_path, _options, callback) => {
+      watchCallback = callback;
+      return watcherInstance;
+    });
+
+    // Default to directory exists and is valid
+    mockFs.existsSync.mockReturnValue(true);
+    mockFs.statSync.mockReturnValue({ isDirectory: () => true });
+
+    // Default copyClaudeAuth to succeed
+    mockPodmanFunctions.copyClaudeAuth.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    stopCredentialWatcher();
+    vi.useRealTimers();
+  });
+
+  describe('startCredentialWatcher', () => {
+    it('should start watching the claude auth directory', () => {
+      startCredentialWatcher();
+
+      expect(mockFs.watch).toHaveBeenCalledWith(
+        '/mock/.claude',
+        { persistent: false },
+        expect.any(Function)
+      );
+    });
+
+    it('should warn if watcher is already running', () => {
+      startCredentialWatcher();
+      startCredentialWatcher(); // Should warn but not throw
+
+      // Only one watch should be created
+      expect(mockFs.watch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should skip watching if directory does not exist', () => {
+      mockFs.existsSync.mockReturnValue(false);
+
+      startCredentialWatcher();
+
+      expect(mockFs.watch).not.toHaveBeenCalled();
+    });
+
+    it('should skip watching if path is not a directory', () => {
+      mockFs.statSync.mockReturnValue({ isDirectory: () => false });
+
+      startCredentialWatcher();
+
+      expect(mockFs.watch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('stopCredentialWatcher', () => {
+    it('should close the watcher when stopped', () => {
+      startCredentialWatcher();
+      stopCredentialWatcher();
+
+      expect(watcherInstance.close).toHaveBeenCalled();
+    });
+
+    it('should handle stopping when not running', () => {
+      // Should not throw
+      stopCredentialWatcher();
+    });
+  });
+
+  describe('credential file change handling', () => {
+    it('should debounce rapid file changes', () => {
+      mockPodmanFunctions.listSessionContainers.mockResolvedValue([]);
+
+      startCredentialWatcher();
+
+      // Simulate multiple rapid file changes
+      watchCallback?.('change', '.credentials.json');
+      watchCallback?.('change', '.credentials.json');
+      watchCallback?.('change', '.credentials.json');
+
+      // Before debounce timer, no containers should be queried
+      expect(mockPodmanFunctions.listSessionContainers).not.toHaveBeenCalled();
+
+      // Advance timers past debounce interval
+      vi.advanceTimersByTime(1500);
+
+      // Now the push should have been triggered (but only once)
+      expect(mockPodmanFunctions.listSessionContainers).toHaveBeenCalledTimes(1);
+    });
+
+    it('should ignore non-credential files', () => {
+      mockPodmanFunctions.listSessionContainers.mockResolvedValue([]);
+
+      startCredentialWatcher();
+
+      // Simulate a change to a non-credential file
+      watchCallback?.('change', 'some-other-file.txt');
+
+      // Advance timers
+      vi.advanceTimersByTime(1500);
+
+      // No containers should be queried for non-credential files
+      expect(mockPodmanFunctions.listSessionContainers).not.toHaveBeenCalled();
+    });
+
+    it('should handle .credentials.json and settings.json changes', () => {
+      mockPodmanFunctions.listSessionContainers.mockResolvedValue([]);
+
+      startCredentialWatcher();
+
+      // Advance time to avoid duplicate push check from previous test
+      vi.advanceTimersByTime(2000);
+      mockPodmanFunctions.listSessionContainers.mockClear();
+
+      // Test .credentials.json
+      watchCallback?.('change', '.credentials.json');
+      vi.advanceTimersByTime(1500);
+      expect(mockPodmanFunctions.listSessionContainers).toHaveBeenCalledTimes(1);
+
+      mockPodmanFunctions.listSessionContainers.mockClear();
+
+      // Advance time and test settings.json
+      vi.advanceTimersByTime(2000);
+      watchCallback?.('change', 'settings.json');
+      vi.advanceTimersByTime(1500);
+      expect(mockPodmanFunctions.listSessionContainers).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('pushCredentialsToAllContainers', () => {
+    it('should push credentials to all running containers', async () => {
+      mockPodmanFunctions.listSessionContainers.mockResolvedValue([
+        { containerId: 'container-1', sessionId: 'session-1', status: 'running' },
+        { containerId: 'container-2', sessionId: 'session-2', status: 'running' },
+      ]);
+
+      const result = await pushCredentialsToAllContainers();
+
+      expect(result.updated).toBe(2);
+      expect(result.failed).toBe(0);
+      expect(mockPodmanFunctions.copyClaudeAuth).toHaveBeenCalledTimes(2);
+      expect(mockPodmanFunctions.copyClaudeAuth).toHaveBeenCalledWith('container-1');
+      expect(mockPodmanFunctions.copyClaudeAuth).toHaveBeenCalledWith('container-2');
+    });
+
+    it('should skip stopped containers', async () => {
+      mockPodmanFunctions.listSessionContainers.mockResolvedValue([
+        { containerId: 'container-1', sessionId: 'session-1', status: 'running' },
+        { containerId: 'container-2', sessionId: 'session-2', status: 'stopped' },
+      ]);
+
+      const result = await pushCredentialsToAllContainers();
+
+      expect(result.updated).toBe(1);
+      expect(result.failed).toBe(0);
+      expect(mockPodmanFunctions.copyClaudeAuth).toHaveBeenCalledTimes(1);
+      expect(mockPodmanFunctions.copyClaudeAuth).toHaveBeenCalledWith('container-1');
+    });
+
+    it('should return empty result when no containers exist', async () => {
+      mockPodmanFunctions.listSessionContainers.mockResolvedValue([]);
+
+      const result = await pushCredentialsToAllContainers();
+
+      expect(result).toEqual({ updated: 0, failed: 0 });
+      expect(mockPodmanFunctions.copyClaudeAuth).not.toHaveBeenCalled();
+    });
+
+    it('should count failed container updates', async () => {
+      mockPodmanFunctions.listSessionContainers.mockResolvedValue([
+        { containerId: 'container-1', sessionId: 'session-1', status: 'running' },
+      ]);
+      mockPodmanFunctions.copyClaudeAuth.mockRejectedValue(new Error('Copy failed'));
+
+      const result = await pushCredentialsToAllContainers();
+
+      expect(result.updated).toBe(0);
+      expect(result.failed).toBe(1);
+    });
+  });
+});

--- a/src/server/services/credential-watcher.ts
+++ b/src/server/services/credential-watcher.ts
@@ -1,0 +1,166 @@
+import { watch, type FSWatcher } from 'fs';
+import { existsSync, statSync } from 'fs';
+import { env } from '@/lib/env';
+import { createLogger, toError } from '@/lib/logger';
+import { listSessionContainers, copyClaudeAuth } from './podman';
+
+const log = createLogger('credential-watcher');
+
+// Debounce interval for credential updates (avoid rapid file system events)
+const DEBOUNCE_INTERVAL_MS = 1000;
+
+// Essential credential files to watch
+const CREDENTIAL_FILES = ['.credentials.json', 'settings.json'];
+
+// Track the file watcher
+let watcher: FSWatcher | null = null;
+
+// Track debounce timer
+let debounceTimer: NodeJS.Timeout | null = null;
+
+// Track last push time to avoid duplicate pushes
+let lastPushTime = 0;
+
+/**
+ * Push credentials to all running containers.
+ */
+export async function pushCredentialsToAllContainers(): Promise<{
+  updated: number;
+  failed: number;
+}> {
+  const containers = await listSessionContainers();
+  const runningContainers = containers.filter((c) => c.status === 'running');
+
+  log.info('Pushing credentials to all running containers', {
+    count: runningContainers.length,
+  });
+
+  let updated = 0;
+  let failed = 0;
+
+  for (const container of runningContainers) {
+    try {
+      await copyClaudeAuth(container.containerId);
+      updated++;
+    } catch (error) {
+      log.error('Failed to push credentials to container', toError(error), {
+        containerId: container.containerId,
+        sessionId: container.sessionId,
+      });
+      failed++;
+    }
+  }
+
+  log.info('Finished pushing credentials to containers', { updated, failed });
+  return { updated, failed };
+}
+
+/**
+ * Handle a credential file change event.
+ * Debounces rapid changes to avoid pushing credentials multiple times.
+ */
+function handleCredentialChange(filename: string | null): void {
+  // Only process changes to our credential files
+  if (filename && !CREDENTIAL_FILES.includes(filename)) {
+    return;
+  }
+
+  log.info('Credential file changed', { filename });
+
+  // Clear any existing debounce timer
+  if (debounceTimer) {
+    clearTimeout(debounceTimer);
+  }
+
+  // Set a new debounce timer
+  debounceTimer = setTimeout(async () => {
+    const now = Date.now();
+    // Avoid duplicate pushes within the debounce interval
+    if (now - lastPushTime < DEBOUNCE_INTERVAL_MS) {
+      log.debug('Skipping credential push, too soon after last push');
+      return;
+    }
+
+    lastPushTime = now;
+
+    try {
+      const result = await pushCredentialsToAllContainers();
+      if (result.updated > 0 || result.failed > 0) {
+        log.info('Credential update complete', result);
+      }
+    } catch (error) {
+      log.error('Failed to push credentials after file change', toError(error));
+    }
+  }, DEBOUNCE_INTERVAL_MS);
+}
+
+/**
+ * Start watching the Claude auth directory for changes.
+ * When credential files change, they are automatically pushed to all running containers.
+ */
+export function startCredentialWatcher(): void {
+  if (watcher) {
+    log.warn('Credential watcher already running');
+    return;
+  }
+
+  const claudeAuthDir = env.CLAUDE_AUTH_PATH;
+
+  // Check if the directory exists
+  if (!existsSync(claudeAuthDir)) {
+    log.warn('Claude auth directory does not exist, skipping credential watcher', {
+      path: claudeAuthDir,
+    });
+    return;
+  }
+
+  // Verify it's a directory
+  const stats = statSync(claudeAuthDir);
+  if (!stats.isDirectory()) {
+    log.warn('Claude auth path is not a directory, skipping credential watcher', {
+      path: claudeAuthDir,
+    });
+    return;
+  }
+
+  log.info('Starting credential watcher', { path: claudeAuthDir });
+
+  watcher = watch(claudeAuthDir, { persistent: false }, (eventType, filename) => {
+    log.debug('File system event', { eventType, filename });
+
+    // Only handle 'change' and 'rename' events for our credential files
+    if (eventType === 'change' || eventType === 'rename') {
+      handleCredentialChange(filename);
+    }
+  });
+
+  watcher.on('error', (error) => {
+    log.error('Credential watcher error', toError(error));
+    // Try to restart the watcher
+    stopCredentialWatcher();
+    setTimeout(() => {
+      startCredentialWatcher();
+    }, 5000);
+  });
+
+  // Clean up on process exit
+  process.on('beforeExit', () => {
+    stopCredentialWatcher();
+  });
+}
+
+/**
+ * Stop watching the Claude auth directory.
+ */
+export function stopCredentialWatcher(): void {
+  if (watcher) {
+    watcher.close();
+    watcher = null;
+    log.info('Stopped credential watcher');
+  }
+
+  if (debounceTimer) {
+    clearTimeout(debounceTimer);
+    debounceTimer = null;
+  }
+}

--- a/src/server/services/podman.ts
+++ b/src/server/services/podman.ts
@@ -606,7 +606,7 @@ export async function createAndStartContainer(config: ContainerConfig): Promise<
  * Only copies essential auth files, not the entire .claude directory (which contains
  * large directories like file-history that aren't needed and can cause copy errors).
  */
-async function copyClaudeAuth(containerId: string): Promise<void> {
+export async function copyClaudeAuth(containerId: string): Promise<void> {
   const claudeAuthDir = env.CLAUDE_AUTH_PATH;
 
   // Only use sudo when running inside a container (where bind-mounted files may have


### PR DESCRIPTION
## Summary
- Adds a file watcher that monitors the Claude auth directory (`CLAUDE_AUTH_PATH`) for changes
- When `.credentials.json` or `settings.json` change, automatically pushes updated credentials to all running containers
- Debounces rapid file system events to avoid excessive updates (1 second debounce interval)
- Starts the watcher automatically when the server starts

This allows updating Claude credentials without restarting containers when auth expires.

## Test plan
- [x] Added unit tests for the credential watcher service
- [x] All tests pass
- [x] Build succeeds

Fixes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)