### PR TITLE
Add configurable network mode for session containers

### DIFF
--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -407,6 +407,7 @@ The application uses Podman CLI commands to manage containers, routing them thro
 
 Runner containers are created with:
 
+- **Network mode**: Configurable via `CONTAINER_NETWORK_MODE` (default: `host`). Host networking allows containers to connect to services started via podman-compose on localhost. See [issue #147](https://github.com/brendanlong/clawed-burrow/issues/147) for details.
 - **Workspace**: Session's dedicated volume mounted at `/workspace`
 - **Claude auth**: Copied into container after start (not bind-mounted, for security and to avoid permission issues)
 - **Podman socket**: Bind-mounted for container-in-container support (read-only)
@@ -433,10 +434,13 @@ async function startSessionContainer(session: Session, githubToken?: string): Pr
   }
 
   // Create container with CDI for GPU access
+  // Network mode defaults to 'host' to allow connecting to podman-compose services
   const createArgs = [
     'create',
     '--name',
     `claude-session-${session.id}`,
+    '--network',
+    env.CONTAINER_NETWORK_MODE, // 'host', 'bridge', or 'pasta'
     '--security-opt',
     'label=disable',
     '--device',

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -43,6 +43,15 @@ const envSchema = z.object({
   // --dangerously-skip-permissions mode)
   // Example: {"mcpServers":{"memory":{"command":"npx","args":["@anthropic/mcp-server-memory"]}}}
   CLAUDE_CONFIG_JSON: z.string().optional(),
+  // Network mode for Claude session containers
+  // - "host": Share host's network namespace. Allows containers to connect to
+  //   services started via podman-compose on localhost. Recommended when agents
+  //   need to run and connect to containerized services.
+  // - "bridge" (default): Standard container networking with NAT. More isolated
+  //   but containers cannot easily connect to podman-compose services.
+  // - "pasta": Rootless Podman's default. Similar limitations to bridge.
+  // See: https://github.com/brendanlong/clawed-burrow/issues/147
+  CONTAINER_NETWORK_MODE: z.enum(['host', 'bridge', 'pasta']).default('host'),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/src/server/services/podman.ts
+++ b/src/server/services/podman.ts
@@ -531,10 +531,20 @@ export async function createAndStartContainer(config: ContainerConfig): Promise<
 
     // GPU access via CDI (Container Device Interface) - requires nvidia-container-toolkit
     // and CDI specs generated via: nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+    //
+    // Network mode is configurable via CONTAINER_NETWORK_MODE:
+    // - "host": Share host's network namespace. Allows containers to connect to
+    //   services started via podman-compose on localhost. Recommended when agents
+    //   need to run and connect to containerized services.
+    // - "bridge": Standard container networking with NAT.
+    // - "pasta": Rootless Podman's default.
+    // See: https://github.com/brendanlong/clawed-burrow/issues/147
     const createArgs = [
       'create',
       '--name',
       containerName,
+      '--network',
+      env.CONTAINER_NETWORK_MODE,
       '--security-opt',
       'label=disable',
       '--device',


### PR DESCRIPTION
## Summary

- Add `CONTAINER_NETWORK_MODE` environment variable to configure networking for Claude session containers
- Default to `host` networking, which allows containers to connect to services started via podman-compose on localhost
- Support `host`, `bridge`, and `pasta` network modes

## Problem

Claude session containers using rootless Podman's default `pasta` networking cannot connect to services started via `podman-compose` inside the container. Port mappings like `0.0.0.0:5432` are on the container's network namespace, but `localhost` inside the container doesn't reach them.

## Solution

Use `--network=host` by default so the container shares the host's network namespace. This allows:
- Containers to connect to `localhost:PORT` for services started via podman-compose
- Simpler networking setup for development workflows

Users who prefer isolation can set `CONTAINER_NETWORK_MODE=bridge` or `CONTAINER_NETWORK_MODE=pasta`.

Fixes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)