### PR TITLE
Add postgresql-client to container image

### DIFF
--- a/docker/Dockerfile.claude-code
+++ b/docker/Dockerfile.claude-code
@@ -39,6 +39,8 @@ RUN apt-get update && apt-get install -y \
     # Network tools
     wget \
     openssh-client \
+    # Database clients for schema operations
+    postgresql-client \
     && rm -rf /var/lib/apt/lists/* \
     && ln -sf /usr/bin/python3 /usr/bin/python
 


### PR DESCRIPTION
## Summary
- Adds `postgresql-client` package to the container image to provide `pg_dump` command
- Fixes #146

## Test plan
- [ ] Rebuild container image and verify `pg_dump` is available
- [ ] Run integration tests that require `pg_dump` to verify they work

🤖 Generated with [Claude Code](https://claude.com/claude-code)