### PR TITLE
Add Settings page with auth sessions management

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tanstack/react-query": "^5.90.19",
     "@trpc/client": "^11.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-tabs':
+        specifier: ^1.1.13
+        version: 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-tooltip':
         specifier: ^1.2.8
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1088,6 +1091,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-roving-focus@1.1.11':
+    resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-scroll-area@1.2.10':
     resolution: {integrity: sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==}
     peerDependencies:
@@ -1143,6 +1159,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-tabs@1.1.13':
+    resolution: {integrity: sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-tooltip@1.2.8':
@@ -4530,6 +4559,23 @@ snapshots:
       '@types/react': 19.2.8
       '@types/react-dom': 19.2.3(@types/react@19.2.8)
 
+  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
   '@radix-ui/react-scroll-area@1.2.10(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/number': 1.1.1
@@ -4598,6 +4644,22 @@ snapshots:
       react: 19.2.3
     optionalDependencies:
       '@types/react': 19.2.8
+
+  '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
 
   '@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { AuthGuard } from '@/components/AuthGuard';
+import { Header } from '@/components/Header';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { AuthSessionsTab } from '@/components/settings/AuthSessionsTab';
+
+export default function SettingsPage() {
+  return (
+    <AuthGuard>
+      <div className="min-h-screen bg-background">
+        <Header />
+
+        <main className="max-w-2xl mx-auto py-6 sm:px-6 lg:px-8">
+          <div className="px-4 py-6 sm:px-0">
+            <h1 className="text-2xl font-bold mb-6">Settings</h1>
+
+            <Tabs defaultValue="sessions">
+              <TabsList className="mb-4">
+                <TabsTrigger value="sessions">Sessions</TabsTrigger>
+              </TabsList>
+
+              <TabsContent value="sessions">
+                <AuthSessionsTab />
+              </TabsContent>
+            </Tabs>
+          </div>
+        </main>
+      </div>
+    </AuthGuard>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,6 +6,7 @@ import { useWorkingContext } from '@/lib/working-context';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { Logo } from '@/components/Logo';
+import { Settings } from 'lucide-react';
 
 export function Header() {
   const { isAuthenticated, logout } = useAuth();
@@ -36,9 +37,17 @@ export function Header() {
           </Link>
 
           {isAuthenticated && (
-            <Button variant="ghost" size="sm" onClick={logout}>
-              Sign out
-            </Button>
+            <div className="flex items-center gap-2">
+              <Button variant="ghost" size="sm" asChild>
+                <Link href="/settings" className="flex items-center gap-1.5">
+                  <Settings className="h-4 w-4" />
+                  <span className="hidden sm:inline">Settings</span>
+                </Link>
+              </Button>
+              <Button variant="ghost" size="sm" onClick={logout}>
+                Sign out
+              </Button>
+            </div>
           )}
         </div>
       </div>

--- a/src/components/settings/AuthSessionsTab.tsx
+++ b/src/components/settings/AuthSessionsTab.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Spinner } from '@/components/ui/spinner';
+import { useAuthSessions } from '@/hooks/useAuthSessions';
+import { AuthSessionListItem } from './AuthSessionListItem';
+import { trpc } from '@/lib/trpc';
+
+/**
+ * Tab component for managing auth sessions.
+ * Shows active sessions with ability to expire them, and a toggle to show expired sessions.
+ */
+export function AuthSessionsTab() {
+  const [showExpired, setShowExpired] = useState(false);
+  const { sessions, isLoading, refetch } = useAuthSessions();
+
+  const deleteMutation = trpc.auth.deleteSession.useMutation({
+    onSuccess: () => {
+      refetch();
+    },
+  });
+
+  const handleExpireSession = async (sessionId: string) => {
+    await deleteMutation.mutateAsync({ sessionId });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-12">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  const now = new Date();
+  const activeSessions = sessions.filter((s) => new Date(s.expiresAt) > now);
+  const expiredSessions = sessions.filter((s) => new Date(s.expiresAt) <= now);
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader className="py-4">
+          <CardTitle className="text-base">Active Sessions</CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          {activeSessions.length > 0 ? (
+            <ul className="divide-y divide-border">
+              {activeSessions.map((session) => (
+                <AuthSessionListItem
+                  key={session.id}
+                  session={session}
+                  isExpired={false}
+                  onExpire={handleExpireSession}
+                />
+              ))}
+            </ul>
+          ) : (
+            <div className="p-6 text-center text-muted-foreground">No active sessions found.</div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Toggle for expired sessions */}
+      <div className="flex justify-center">
+        <Button variant="ghost" size="sm" onClick={() => setShowExpired(!showExpired)}>
+          {showExpired ? 'Hide expired sessions' : 'Show expired sessions'}
+        </Button>
+      </div>
+
+      {/* Expired sessions section */}
+      {showExpired && expiredSessions.length > 0 && (
+        <Card>
+          <CardHeader className="py-3">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Expired Sessions
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="p-0">
+            <ul className="divide-y divide-border">
+              {expiredSessions.map((session) => (
+                <AuthSessionListItem
+                  key={session.id}
+                  session={session}
+                  isExpired={true}
+                  onExpire={handleExpireSession}
+                />
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+      )}
+
+      {showExpired && expiredSessions.length === 0 && (
+        <div className="text-center text-sm text-muted-foreground">No expired sessions</div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import * as React from 'react';
+import * as TabsPrimitive from '@radix-ui/react-tabs';
+
+import { cn } from '@/lib/utils';
+
+const Tabs = TabsPrimitive.Root;
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      'inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground',
+      className
+    )}
+    {...props}
+  />
+));
+TabsList.displayName = TabsPrimitive.List.displayName;
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      'inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow',
+      className
+    )}
+    {...props}
+  />
+));
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      'mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+      className
+    )}
+    {...props}
+  />
+));
+TabsContent.displayName = TabsPrimitive.Content.displayName;
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/src/hooks/useAuthSessions.ts
+++ b/src/hooks/useAuthSessions.ts
@@ -1,0 +1,33 @@
+'use client';
+
+import { trpc } from '@/lib/trpc';
+
+export interface AuthSession {
+  id: string;
+  createdAt: Date;
+  expiresAt: Date;
+  lastActivityAt: Date;
+  ipAddress: string | null;
+  userAgent: string | null;
+  isCurrent: boolean;
+}
+
+export interface UseAuthSessionsResult {
+  sessions: AuthSession[];
+  isLoading: boolean;
+  refetch: () => void;
+}
+
+/**
+ * Hook for fetching the list of auth sessions.
+ * Separates data fetching logic from presentation.
+ */
+export function useAuthSessions(): UseAuthSessionsResult {
+  const { data, isLoading, refetch } = trpc.auth.listSessions.useQuery();
+
+  return {
+    sessions: data?.sessions ?? [],
+    isLoading,
+    refetch,
+  };
+}


### PR DESCRIPTION
## Summary
- Adds a new Settings page accessible via a gear icon in the header (next to Sign out button)
- Settings page uses a tabbed interface with "Sessions" as the first tab
- Sessions tab displays all auth sessions with device info, IP address, last activity, and expiration
- Active sessions can be expired with a confirmation dialog (except current session)
- Toggle to show/hide expired sessions (similar to how archived Claude sessions work)

## Test plan
- [ ] Click Settings icon in header, verify it navigates to /settings
- [ ] Verify current session is labeled and doesn't have an Expire button
- [ ] Click Expire on another session (if available), verify confirmation dialog appears
- [ ] Confirm expiration, verify session is removed from active list
- [ ] Click "Show expired sessions" toggle, verify expired sessions appear in separate section
- [ ] Verify responsive design (icon-only on mobile, icon + text on larger screens)

Generated with [Claude Code](https://claude.ai/code)