### PR TITLE
Add dark mode with system preference detection and settings control

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -27,6 +27,19 @@ body {
   background: #a1a1a1;
 }
 
+/* Dark mode scrollbar */
+.dark ::-webkit-scrollbar-track {
+  background: #1f1f1f;
+}
+
+.dark ::-webkit-scrollbar-thumb {
+  background: #4a4a4a;
+}
+
+.dark ::-webkit-scrollbar-thumb:hover {
+  background: #5a5a5a;
+}
+
 @layer base {
   :root {
     --background: 0 0% 100%;
@@ -175,7 +188,7 @@ body {
 }
 
 .markdown-content a {
-  @apply text-blue-600 dark:text-blue-400 underline hover:no-underline;
+  @apply text-blue-600 dark:text-red-400 underline hover:no-underline;
 }
 
 .markdown-content ul,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <head>
         <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
         <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
@@ -22,8 +22,26 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <meta name="apple-mobile-web-app-status-bar-style" content="default" />
         <meta name="apple-mobile-web-app-title" content="Abode" />
         <meta name="theme-color" content="#1f2937" />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              (function() {
+                try {
+                  var preference = localStorage.getItem('theme_preference') || 'auto';
+                  var theme = preference;
+                  if (preference === 'auto') {
+                    theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+                  }
+                  if (theme === 'dark') {
+                    document.documentElement.classList.add('dark');
+                  }
+                } catch (e) {}
+              })();
+            `,
+          }}
+        />
       </head>
-      <body className="bg-gray-50 min-h-screen">
+      <body className="bg-background min-h-screen">
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -4,6 +4,7 @@ import { AuthGuard } from '@/components/AuthGuard';
 import { Header } from '@/components/Header';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { AuthSessionsTab } from '@/components/settings/AuthSessionsTab';
+import { AppearanceTab } from '@/components/settings/AppearanceTab';
 
 export default function SettingsPage() {
   return (
@@ -15,10 +16,15 @@ export default function SettingsPage() {
           <div className="px-4 py-6 sm:px-0">
             <h1 className="text-2xl font-bold mb-6">Settings</h1>
 
-            <Tabs defaultValue="sessions">
+            <Tabs defaultValue="appearance">
               <TabsList className="mb-4">
+                <TabsTrigger value="appearance">Appearance</TabsTrigger>
                 <TabsTrigger value="sessions">Sessions</TabsTrigger>
               </TabsList>
+
+              <TabsContent value="appearance">
+                <AppearanceTab />
+              </TabsContent>
 
               <TabsContent value="sessions">
                 <AuthSessionsTab />

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import { trpc, createTRPCClient } from '@/lib/trpc';
 import { AuthProvider } from '@/lib/auth-context';
 import { WorkingProvider } from '@/lib/working-context';
+import { ThemeProvider } from '@/lib/theme-context';
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(() => new QueryClient());
@@ -13,9 +14,11 @@ export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <trpc.Provider client={trpcClient} queryClient={queryClient}>
       <QueryClientProvider client={queryClient}>
-        <AuthProvider>
-          <WorkingProvider>{children}</WorkingProvider>
-        </AuthProvider>
+        <ThemeProvider>
+          <AuthProvider>
+            <WorkingProvider>{children}</WorkingProvider>
+          </AuthProvider>
+        </ThemeProvider>
       </QueryClientProvider>
     </trpc.Provider>
   );

--- a/src/components/settings/AppearanceTab.tsx
+++ b/src/components/settings/AppearanceTab.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useTheme } from '@/lib/theme-context';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Monitor, Sun, Moon } from 'lucide-react';
+
+type ThemePreference = 'auto' | 'light' | 'dark';
+
+const themeOptions: { value: ThemePreference; label: string; icon: React.ReactNode }[] = [
+  { value: 'auto', label: 'Auto (System)', icon: <Monitor className="h-4 w-4" /> },
+  { value: 'light', label: 'Light', icon: <Sun className="h-4 w-4" /> },
+  { value: 'dark', label: 'Dark', icon: <Moon className="h-4 w-4" /> },
+];
+
+export function AppearanceTab() {
+  const { themePreference, setThemePreference } = useTheme();
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Appearance</CardTitle>
+        <CardDescription>Customize how Clawed Abode looks on your device.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="space-y-2">
+          <Label htmlFor="theme-select">Theme</Label>
+          <Select value={themePreference} onValueChange={setThemePreference}>
+            <SelectTrigger id="theme-select" className="w-full sm:w-[200px]">
+              <SelectValue placeholder="Select theme" />
+            </SelectTrigger>
+            <SelectContent>
+              {themeOptions.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  <div className="flex items-center gap-2">
+                    {option.icon}
+                    <span>{option.label}</span>
+                  </div>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <p className="text-sm text-muted-foreground">
+            {themePreference === 'auto'
+              ? 'Automatically switch between light and dark themes based on your system settings.'
+              : themePreference === 'light'
+                ? 'Always use the light theme.'
+                : 'Always use the dark theme.'}
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/theme-context.test.tsx
+++ b/src/lib/theme-context.test.tsx
@@ -1,0 +1,230 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { ThemeProvider, useTheme } from './theme-context';
+
+describe('theme-context', () => {
+  const mockMatchMedia = vi.fn();
+  let mockMediaQueryListeners: ((e: MediaQueryListEvent) => void)[] = [];
+
+  beforeEach(() => {
+    // Reset localStorage
+    localStorage.clear();
+
+    // Reset listeners
+    mockMediaQueryListeners = [];
+
+    // Mock matchMedia
+    mockMatchMedia.mockReturnValue({
+      matches: false,
+      addEventListener: (_: string, listener: (e: MediaQueryListEvent) => void) => {
+        mockMediaQueryListeners.push(listener);
+      },
+      removeEventListener: (_: string, listener: (e: MediaQueryListEvent) => void) => {
+        mockMediaQueryListeners = mockMediaQueryListeners.filter((l) => l !== listener);
+      },
+    });
+    window.matchMedia = mockMatchMedia;
+
+    // Clear dark class
+    document.documentElement.classList.remove('dark');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should default to auto preference', async () => {
+    const { result } = renderHook(() => useTheme(), {
+      wrapper: ThemeProvider,
+    });
+
+    // Wait for microtask to complete
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(result.current.themePreference).toBe('auto');
+  });
+
+  it('should default to light theme when system prefers light', async () => {
+    mockMatchMedia.mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useTheme(), {
+      wrapper: ThemeProvider,
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(result.current.theme).toBe('light');
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+
+  it('should default to dark theme when system prefers dark', async () => {
+    mockMatchMedia.mockReturnValue({
+      matches: true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useTheme(), {
+      wrapper: ThemeProvider,
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(result.current.theme).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('should persist theme preference to localStorage', async () => {
+    const { result } = renderHook(() => useTheme(), {
+      wrapper: ThemeProvider,
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    act(() => {
+      result.current.setThemePreference('dark');
+    });
+
+    expect(localStorage.getItem('theme_preference')).toBe('dark');
+    expect(result.current.themePreference).toBe('dark');
+    expect(result.current.theme).toBe('dark');
+  });
+
+  it('should load theme preference from localStorage', async () => {
+    localStorage.setItem('theme_preference', 'dark');
+
+    const { result } = renderHook(() => useTheme(), {
+      wrapper: ThemeProvider,
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(result.current.themePreference).toBe('dark');
+    expect(result.current.theme).toBe('dark');
+  });
+
+  it('should apply dark class when dark theme is active', async () => {
+    const { result } = renderHook(() => useTheme(), {
+      wrapper: ThemeProvider,
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    act(() => {
+      result.current.setThemePreference('dark');
+    });
+
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('should remove dark class when light theme is active', async () => {
+    document.documentElement.classList.add('dark');
+
+    const { result } = renderHook(() => useTheme(), {
+      wrapper: ThemeProvider,
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    act(() => {
+      result.current.setThemePreference('light');
+    });
+
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+
+  it('should update theme when system preference changes in auto mode', async () => {
+    mockMatchMedia.mockReturnValue({
+      matches: false,
+      addEventListener: (_: string, listener: (e: MediaQueryListEvent) => void) => {
+        mockMediaQueryListeners.push(listener);
+      },
+      removeEventListener: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useTheme(), {
+      wrapper: ThemeProvider,
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(result.current.theme).toBe('light');
+
+    // Simulate system theme change
+    act(() => {
+      mockMediaQueryListeners.forEach((listener) => {
+        listener({ matches: true } as MediaQueryListEvent);
+      });
+    });
+
+    expect(result.current.theme).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('should not update theme when system preference changes in manual mode', async () => {
+    mockMatchMedia.mockReturnValue({
+      matches: false,
+      addEventListener: (_: string, listener: (e: MediaQueryListEvent) => void) => {
+        mockMediaQueryListeners.push(listener);
+      },
+      removeEventListener: (_: string, listener: (e: MediaQueryListEvent) => void) => {
+        mockMediaQueryListeners = mockMediaQueryListeners.filter((l) => l !== listener);
+      },
+    });
+
+    const { result } = renderHook(() => useTheme(), {
+      wrapper: ThemeProvider,
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    // Set to manual light mode
+    act(() => {
+      result.current.setThemePreference('light');
+    });
+
+    // Wait for effect to re-run and register new listener
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    // Simulate system theme change
+    act(() => {
+      mockMediaQueryListeners.forEach((listener) => {
+        listener({ matches: true } as MediaQueryListEvent);
+      });
+    });
+
+    // Should stay in light mode
+    expect(result.current.theme).toBe('light');
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+
+  it('should throw error when useTheme is used outside ThemeProvider', () => {
+    expect(() => {
+      renderHook(() => useTheme());
+    }).toThrow('useTheme must be used within a ThemeProvider');
+  });
+});

--- a/src/lib/theme-context.tsx
+++ b/src/lib/theme-context.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { createContext, useContext, useState, useEffect, useCallback } from 'react';
+
+type Theme = 'light' | 'dark';
+type ThemePreference = 'auto' | 'light' | 'dark';
+
+interface ThemeContextType {
+  theme: Theme;
+  themePreference: ThemePreference;
+  setThemePreference: (preference: ThemePreference) => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+const THEME_KEY = 'theme_preference';
+
+function getSystemTheme(): Theme {
+  if (typeof window === 'undefined') return 'light';
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+function applyTheme(theme: Theme) {
+  if (typeof document === 'undefined') return;
+  const root = document.documentElement;
+  if (theme === 'dark') {
+    root.classList.add('dark');
+  } else {
+    root.classList.remove('dark');
+  }
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [themePreference, setThemePreferenceState] = useState<ThemePreference>('auto');
+  const [theme, setTheme] = useState<Theme>('light');
+  const [isInitialized, setIsInitialized] = useState(false);
+
+  // Initialize from localStorage
+  useEffect(() => {
+    // Using queueMicrotask to avoid synchronous setState in effect (React 19 lint rule)
+    queueMicrotask(() => {
+      const stored = localStorage.getItem(THEME_KEY) as ThemePreference | null;
+      const preference = stored || 'auto';
+      setThemePreferenceState(preference);
+
+      const resolvedTheme = preference === 'auto' ? getSystemTheme() : preference;
+      setTheme(resolvedTheme);
+      applyTheme(resolvedTheme);
+      setIsInitialized(true);
+    });
+  }, []);
+
+  // Listen for system theme changes when in auto mode
+  useEffect(() => {
+    if (!isInitialized) return;
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const handleChange = (e: MediaQueryListEvent) => {
+      if (themePreference === 'auto') {
+        const newTheme = e.matches ? 'dark' : 'light';
+        setTheme(newTheme);
+        applyTheme(newTheme);
+      }
+    };
+
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, [themePreference, isInitialized]);
+
+  const setThemePreference = useCallback((preference: ThemePreference) => {
+    setThemePreferenceState(preference);
+    localStorage.setItem(THEME_KEY, preference);
+
+    const resolvedTheme = preference === 'auto' ? getSystemTheme() : preference;
+    setTheme(resolvedTheme);
+    applyTheme(resolvedTheme);
+  }, []);
+
+  return (
+    <ThemeContext.Provider
+      value={{
+        theme,
+        themePreference,
+        setThemePreference,
+      }}
+    >
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+}

--- a/vitest.component.config.ts
+++ b/vitest.component.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
-    include: ['src/components/**/*.test.tsx'],
+    include: ['src/components/**/*.test.tsx', 'src/lib/**/*.test.tsx'],
     setupFiles: ['./src/test/setup-component.ts'],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Summary
- Add dark mode support with automatic system preference detection
- Add Appearance tab in Settings to manually select Auto/Light/Dark theme
- Update link color in dark mode to red to reduce blue light exposure
- Use inline script to prevent flash of wrong theme on page load

## Test plan
- [ ] Verify dark mode applies correctly when system is set to dark mode
- [ ] Verify settings page shows Appearance tab with theme selector
- [ ] Verify switching between Auto/Light/Dark modes works correctly
- [ ] Verify theme preference persists across page reloads
- [ ] Verify links appear red in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)