### PR TITLE
Fix slow repository clones by removing --dissociate flag

### DIFF
--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -413,6 +413,7 @@ Runner containers are created with:
 - **Podman socket**: Bind-mounted for container-in-container support (read-only)
 - **pnpm store**: Named volume mounted at `/pnpm-store` for shared package cache
 - **Gradle cache**: Named volume mounted at `/gradle-cache` for shared build cache
+- **Git cache**: Named volume mounted at `/cache` (read-only) for git alternates support
 
 ```typescript
 async function startSessionContainer(session: Session, githubToken?: string): Promise<string> {
@@ -426,6 +427,8 @@ async function startSessionContainer(session: Session, githubToken?: string): Pr
     'clawed-abode-pnpm-store:/pnpm-store',
     '-v',
     'clawed-abode-gradle-cache:/gradle-cache',
+    '-v',
+    'clawed-abode-git-cache:/cache:ro',
   ];
 
   // Mount host's podman socket for container-in-container support (read-only)

--- a/src/server/services/podman.ts
+++ b/src/server/services/podman.ts
@@ -512,6 +512,8 @@ export async function createAndStartContainer(config: ContainerConfig): Promise<
     volumeArgs.push('-v', `${env.PNPM_STORE_VOLUME}:/pnpm-store`);
     // Mount shared Gradle cache volume
     volumeArgs.push('-v', `${env.GRADLE_CACHE_VOLUME}:/gradle-cache`);
+    // Mount git cache volume (read-only) for alternates support
+    volumeArgs.push('-v', `${env.GIT_CACHE_VOLUME}:/cache:ro`);
 
     // Mount host's podman socket for container-in-container support (read-only)
     if (env.PODMAN_SOCKET_PATH) {


### PR DESCRIPTION
## Summary

- Remove `--dissociate` flag from git clone to fix slow clones (35+ seconds)
- Mount git cache volume in session containers for alternates support
- Update documentation to reflect the use of git alternates

## Problem

Repository clones were taking 35+ seconds despite having an up-to-date cache. Investigation revealed that the `--dissociate` flag was causing git to copy all objects from the reference cache into the new clone, defeating the purpose of caching.

## Solution

1. **Remove `--dissociate` flag**: Clones now use git's alternates mechanism, which creates a reference to the cache instead of copying objects. This makes clones nearly instant.

2. **Mount cache in session containers**: The git cache volume is now mounted (read-only) in session containers so that `.git/objects/info/alternates` works correctly throughout the session lifetime.

## Benefits

- **Nearly instant clones**: Only checkout and alternates setup happens, no object copying
- **Significant disk savings**: Objects are shared across all clones of the same repo
- **Safe for concurrent access**: Git's alternates mechanism handles this natively

## Trade-offs

The only trade-off is that clones depend on the cache volume remaining available. Since we control both the cache and the clones, and the cache is never deleted in normal operation, this is not a concern.

## Test plan

- [ ] Create a new session for a large repository (e.g., lion-reader)
- [ ] Verify clone completes in under 5 seconds (vs 35+ seconds before)
- [ ] Verify git operations work correctly in the session (status, commit, push, etc.)
- [ ] Create a second session for the same repository
- [ ] Verify the second clone is also fast (cache reuse working)

🤖 Generated with [Claude Code](https://claude.com/claude-code)