### PR TITLE
Mark auth sessions as revoked instead of deleting them

### DIFF
--- a/prisma/migrations/20260127073625_add_revoked_at_to_auth_session/migration.sql
+++ b/prisma/migrations/20260127073625_add_revoked_at_to_auth_session/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "AuthSession" ADD COLUMN "revokedAt" DATETIME;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,11 +8,12 @@ datasource db {
 }
 
 model AuthSession {
-  id             String   @id @default(uuid())
-  token          String   @unique
+  id             String    @id @default(uuid())
+  token          String    @unique
   expiresAt      DateTime
-  lastActivityAt DateTime @default(now())
-  createdAt      DateTime @default(now())
+  lastActivityAt DateTime  @default(now())
+  createdAt      DateTime  @default(now())
+  revokedAt      DateTime? // When the session was revoked (null if not revoked)
   ipAddress      String?
   userAgent      String?
 

--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -27,7 +27,7 @@ export async function createContext(opts: { headers: Headers }): Promise<Context
 
   const session = await prisma.authSession.findUnique({
     where: { token },
-    select: { id: true, expiresAt: true, lastActivityAt: true },
+    select: { id: true, expiresAt: true, lastActivityAt: true, revokedAt: true },
   });
 
   if (!session) {
@@ -35,6 +35,11 @@ export async function createContext(opts: { headers: Headers }): Promise<Context
   }
 
   const now = new Date();
+
+  // Check if session has been revoked
+  if (session.revokedAt) {
+    return { sessionId: null, rotatedToken: null };
+  }
 
   // Check if session has expired
   if (session.expiresAt < now) {


### PR DESCRIPTION
## Summary

Auth sessions are now marked with a `revokedAt` timestamp instead of being deleted. This preserves session history for viewing in settings, similar to how we handle archived Claude Code sessions.

## Changes

- Added `revokedAt` field to `AuthSession` schema with database migration
- Updated `logout`, `logoutAll`, and `deleteSession` endpoints to mark sessions as revoked instead of deleting
- Updated auth middleware in `createContext` to reject revoked sessions
- Updated `listSessions` to include `revokedAt` field for UI display
- Updated all integration tests to verify revocation behavior instead of deletion

## Test plan

- [x] All existing tests pass
- [x] Integration tests verify sessions are marked as revoked, not deleted
- [x] Auth middleware correctly rejects revoked sessions
- [x] `listSessions` includes revoked sessions with `revokedAt` timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)