### PR TITLE
Use router.replace instead of push when creating session

### DIFF
--- a/src/app/new/page.tsx
+++ b/src/app/new/page.tsx
@@ -369,7 +369,7 @@ function NewSessionForm() {
 
   const createMutation = trpc.sessions.create.useMutation({
     onSuccess: (data) => {
-      router.push(`/session/${data.session.id}`);
+      router.replace(`/session/${data.session.id}`);
     },
     onError: (err) => {
       setError(err.message);


### PR DESCRIPTION
## Summary
- Changed `router.push` to `router.replace` when navigating to a newly created session
- This makes the browser back button return to the session list instead of the create session form

The previous behavior had the history stack: session list → create session → session view. Pressing back would return to the create session form. The new behavior replaces the create session entry, so back returns directly to the session list, which is more natural since the user has already completed the session creation flow.

## Test plan
- [x] Run existing tests - all pass
- [ ] Manual test: Create a session, then press the browser back button. Should return to the session list, not the create session form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)