### PR TITLE
Lock PWA orientation to portrait mode

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -6,7 +6,7 @@
   "display": "standalone",
   "background_color": "#f9fafb",
   "theme_color": "#1f2937",
-  "orientation": "any",
+  "orientation": "portrait",
   "icons": [
     {
       "src": "/favicon-192x192.png",


### PR DESCRIPTION
## Summary
- Changed PWA manifest `orientation` from `"any"` to `"portrait"` to prevent auto-rotation

## Test plan
- [ ] Install/update the PWA on a mobile device
- [ ] Verify the app stays in portrait mode when the device is rotated

🤖 Generated with [Claude Code](https://claude.com/claude-code)