### PR TITLE
Fix sessions showing as stopped on server restart

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -9,16 +9,8 @@ export async function register() {
   // which would cause Next.js to analyze server-side dependencies for Edge Runtime
   if (process.env.NEXT_RUNTIME === 'nodejs') {
     const { reconcileOrphanedProcesses } = await import('@/server/services/claude-runner');
-    const { reconcileSessionsWithPodman, startBackgroundReconciliation, migrateToSockets } =
+    const { reconcileSessionsWithPodman, startBackgroundReconciliation } =
       await import('@/server/services/session-reconciler');
-
-    // One-time migration: stop all running sessions for socket migration
-    console.log('Running socket migration...');
-    try {
-      await migrateToSockets();
-    } catch (err) {
-      console.error('Error running socket migration:', err);
-    }
 
     console.log('Starting server - reconciling sessions with Podman...');
 

--- a/src/server/services/session-reconciler.ts
+++ b/src/server/services/session-reconciler.ts
@@ -1,10 +1,5 @@
 import { prisma } from '@/lib/prisma';
-import {
-  getContainerStatus,
-  listSessionContainers,
-  removeContainer,
-  stopContainer,
-} from './podman';
+import { getContainerStatus, listSessionContainers, removeContainer } from './podman';
 import { createLogger, toError } from '@/lib/logger';
 import type { SessionStatus } from '@/lib/types';
 
@@ -276,55 +271,4 @@ export function stopBackgroundReconciliation(): void {
     reconciliationIntervalId = null;
     log.info('Stopped background reconciliation');
   }
-}
-
-/**
- * One-time migration: Stop all running sessions after upgrading to Unix sockets.
- * This is called on startup to handle the migration from TCP ports to Unix sockets.
- * All running sessions need to be stopped and restarted with the new socket configuration.
- */
-export async function migrateToSockets(): Promise<void> {
-  log.info('Running one-time migration to Unix sockets');
-
-  const runningSessions = await prisma.session.findMany({
-    where: { status: 'running' },
-  });
-
-  if (runningSessions.length === 0) {
-    log.info('No running sessions to migrate');
-    return;
-  }
-
-  log.info('Stopping running sessions for socket migration', {
-    count: runningSessions.length,
-  });
-
-  for (const session of runningSessions) {
-    if (session.containerId) {
-      try {
-        await stopContainer(session.containerId);
-        log.info('Stopped container for migration', {
-          sessionId: session.id,
-          containerId: session.containerId,
-        });
-      } catch (error) {
-        // Container may already be stopped or removed
-        log.warn(
-          'Failed to stop container during migration',
-          { sessionId: session.id, containerId: session.containerId },
-          toError(error)
-        );
-      }
-    }
-
-    await prisma.session.update({
-      where: { id: session.id },
-      data: {
-        status: 'stopped',
-        statusMessage: 'Session stopped due to system upgrade. Please restart.',
-      },
-    });
-  }
-
-  log.info('Socket migration complete', { sessionsStopped: runningSessions.length });
 }


### PR DESCRIPTION
## Summary

- Remove `migrateToSockets()` which was a one-time migration function that incorrectly ran on **every** server startup, stopping all running containers and marking all sessions as stopped
- The existing `reconcileSessionsWithPodman()` already correctly syncs DB state with actual container state, so running sessions now survive server restarts and are properly reconnected

## Root cause

`migrateToSockets()` was called unconditionally in `src/instrumentation.ts` on every server start. It was originally written to handle migrating from TCP ports to Unix sockets (a one-time event), but had no guard to prevent repeated execution. On each restart it would:
1. Find all sessions with `status='running'`
2. Stop their containers via `stopContainer()`
3. Update their DB status to `stopped` with message "Session stopped due to system upgrade. Please restart."

After this, `reconcileSessionsWithPodman()` would run and confirm the sessions as stopped (since they were just stopped).

## Test plan

- [x] All 216 existing tests pass
- [ ] Start a session, restart the server process, verify the session remains running and is reconnected

🤖 Generated with [Claude Code](https://claude.com/claude-code)