### PR TITLE
Add support for HTTP and SSE MCP servers

### DIFF
--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -467,9 +467,12 @@ Users can configure per-repository settings that are automatically applied when 
 - **Favorites**: Mark repositories as favorites so they appear at the top of the repo selector
 - **Custom System Prompt**: Additional instructions appended to the default system prompt for all sessions using this repository
 - **Environment Variables**: Custom env vars passed to the container (e.g., API keys, config values)
-- **MCP Servers**: Configure [MCP servers](https://modelcontextprotocol.io/) for Claude to use
+- **MCP Servers**: Configure [MCP servers](https://modelcontextprotocol.io/) for Claude to use, supporting three transport types:
+  - **Stdio**: Traditional command-based servers (e.g., `npx @anthropic/mcp-server-memory`)
+  - **HTTP**: Streamable HTTP MCP servers with optional auth headers
+  - **SSE**: Server-Sent Events MCP servers with optional auth headers
 
-**Secret Encryption**: Environment variables and MCP server env vars can be marked as "secret", which:
+**Secret Encryption**: Environment variables, MCP server env vars, and HTTP/SSE header values can be marked as "secret", which:
 
 - Encrypts the value at rest using AES-256-GCM with the `ENCRYPTION_KEY` env var
 - Displays masked values (`••••••••`) in the UI

--- a/prisma/migrations/20260208034305_add_http_mcp_server_support/migration.sql
+++ b/prisma/migrations/20260208034305_add_http_mcp_server_support/migration.sql
@@ -1,0 +1,24 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_McpServer" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "repoSettingsId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "type" TEXT NOT NULL DEFAULT 'stdio',
+    "command" TEXT NOT NULL DEFAULT '',
+    "args" TEXT,
+    "env" TEXT,
+    "url" TEXT,
+    "headers" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "McpServer_repoSettingsId_fkey" FOREIGN KEY ("repoSettingsId") REFERENCES "RepoSettings" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_McpServer" ("args", "command", "createdAt", "env", "id", "name", "repoSettingsId", "updatedAt") SELECT "args", "command", "createdAt", "env", "id", "name", "repoSettingsId", "updatedAt" FROM "McpServer";
+DROP TABLE "McpServer";
+ALTER TABLE "new_McpServer" RENAME TO "McpServer";
+CREATE INDEX "McpServer_repoSettingsId_idx" ON "McpServer"("repoSettingsId");
+CREATE UNIQUE INDEX "McpServer_repoSettingsId_name_key" ON "McpServer"("repoSettingsId", "name");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -91,9 +91,12 @@ model McpServer {
   repoSettingsId String
   repoSettings   RepoSettings @relation(fields: [repoSettingsId], references: [id], onDelete: Cascade)
   name           String // Server name (key in mcpServers object)
-  command        String // e.g., "npx"
-  args           String? // JSON array, e.g., '["@anthropic/mcp-server-memory"]'
-  env            String? // JSON object: { "KEY": { "value": "...", "isSecret": true } }
+  type           String       @default("stdio") // "stdio", "http", or "sse"
+  command        String       @default("") // For stdio: e.g., "npx" (empty for http/sse)
+  args           String? // For stdio: JSON array, e.g., '["@anthropic/mcp-server-memory"]'
+  env            String? // For stdio: JSON object: { "KEY": { "value": "...", "isSecret": true } }
+  url            String? // For http/sse: server URL
+  headers        String? // For http/sse: JSON object of headers, { "KEY": { "value": "...", "isSecret": true } }
   createdAt      DateTime     @default(now())
   updatedAt      DateTime     @updatedAt
 

--- a/src/components/settings/RepoSettingsEditor.tsx
+++ b/src/components/settings/RepoSettingsEditor.tsx
@@ -15,6 +15,13 @@ import { Switch } from '@/components/ui/switch';
 import { Spinner } from '@/components/ui/spinner';
 import { Separator } from '@/components/ui/separator';
 import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { trpc } from '@/lib/trpc';
 import { Plus, Trash2, Eye, EyeOff, Star, FileText } from 'lucide-react';
 import {
@@ -439,9 +446,12 @@ function EnvVarForm({
 interface McpServer {
   id: string;
   name: string;
+  type: 'stdio' | 'http' | 'sse';
   command: string;
   args: string[];
   env: Record<string, { value: string; isSecret: boolean }>;
+  url?: string;
+  headers: Record<string, { value: string; isSecret: boolean }>;
 }
 
 function McpServersSection({
@@ -481,9 +491,16 @@ function McpServersSection({
           {mcpServers.map((server) => (
             <li key={server.id} className="flex items-center gap-2 p-2 rounded-md bg-muted/50">
               <div className="flex-1 min-w-0">
-                <div className="font-mono text-sm">{server.name}</div>
+                <div className="font-mono text-sm flex items-center gap-2">
+                  {server.name}
+                  <span className="text-xs text-muted-foreground font-sans uppercase">
+                    {server.type}
+                  </span>
+                </div>
                 <div className="text-xs text-muted-foreground truncate">
-                  {server.command} {server.args.join(' ')}
+                  {server.type === 'stdio'
+                    ? `${server.command} ${server.args.join(' ')}`
+                    : server.url}
                 </div>
               </div>
               <Button variant="ghost" size="sm" onClick={() => setEditingId(server.id)}>
@@ -546,6 +563,89 @@ function McpServersSection({
   );
 }
 
+type McpServerType = 'stdio' | 'http' | 'sse';
+
+/** Shared key-value list editor for env vars and headers with secret support */
+function KeyValueListEditor({
+  label,
+  entries,
+  existingEntries,
+  onChange,
+  keyPlaceholder = 'KEY',
+  keyTransform,
+}: {
+  label: string;
+  entries: Array<{ key: string; value: string; isSecret: boolean }>;
+  existingEntries?: Record<string, { value: string; isSecret: boolean }>;
+  onChange: (entries: Array<{ key: string; value: string; isSecret: boolean }>) => void;
+  keyPlaceholder?: string;
+  keyTransform?: (key: string) => string;
+}) {
+  const addEntry = () => {
+    onChange([...entries, { key: '', value: '', isSecret: false }]);
+  };
+
+  const removeEntry = (index: number) => {
+    onChange(entries.filter((_, i) => i !== index));
+  };
+
+  const updateEntry = (
+    index: number,
+    field: 'key' | 'value' | 'isSecret',
+    value: string | boolean
+  ) => {
+    onChange(entries.map((entry, i) => (i === index ? { ...entry, [field]: value } : entry)));
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <Label>{label}</Label>
+        <Button type="button" variant="outline" size="sm" onClick={addEntry}>
+          <Plus className="h-4 w-4" />
+        </Button>
+      </div>
+      {entries.map((entry, index) => (
+        <div key={index} className="flex items-center gap-2">
+          <Input
+            value={entry.key}
+            onChange={(e) =>
+              updateEntry(
+                index,
+                'key',
+                keyTransform ? keyTransform(e.target.value) : e.target.value
+              )
+            }
+            placeholder={keyPlaceholder}
+            className="flex-1"
+          />
+          <Input
+            type={entry.isSecret ? 'password' : 'text'}
+            value={entry.value}
+            onChange={(e) => updateEntry(index, 'value', e.target.value)}
+            placeholder={existingEntries?.[entry.key]?.isSecret ? '(unchanged)' : 'value'}
+            className="flex-1"
+          />
+          <Switch
+            checked={entry.isSecret}
+            onCheckedChange={(checked) => updateEntry(index, 'isSecret', checked)}
+            title="Secret"
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => removeEntry(index)}
+            className="text-destructive"
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 function McpServerForm({
   repoFullName,
   existingServer,
@@ -558,11 +658,24 @@ function McpServerForm({
   onSuccess: () => void;
 }) {
   const [name, setName] = useState(existingServer?.name ?? '');
+  const [serverType, setServerType] = useState<McpServerType>(existingServer?.type ?? 'stdio');
+  // Stdio fields
   const [command, setCommand] = useState(existingServer?.command ?? '');
   const [args, setArgs] = useState(existingServer?.args.join(' ') ?? '');
   const [envVars, setEnvVars] = useState<Array<{ key: string; value: string; isSecret: boolean }>>(
     existingServer?.env
       ? Object.entries(existingServer.env).map(([key, { value, isSecret }]) => ({
+          key,
+          value: isSecret ? '' : value,
+          isSecret,
+        }))
+      : []
+  );
+  // HTTP/SSE fields
+  const [url, setUrl] = useState(existingServer?.url ?? '');
+  const [headers, setHeaders] = useState<Array<{ key: string; value: string; isSecret: boolean }>>(
+    existingServer?.headers
+      ? Object.entries(existingServer.headers).map(([key, { value, isSecret }]) => ({
           key,
           value: isSecret ? '' : value,
           isSecret,
@@ -576,22 +689,6 @@ function McpServerForm({
     onError: (err) => setError(err.message),
   });
 
-  const addEnvVar = () => {
-    setEnvVars([...envVars, { key: '', value: '', isSecret: false }]);
-  };
-
-  const removeEnvVar = (index: number) => {
-    setEnvVars(envVars.filter((_, i) => i !== index));
-  };
-
-  const updateEnvVar = (
-    index: number,
-    field: 'key' | 'value' | 'isSecret',
-    value: string | boolean
-  ) => {
-    setEnvVars(envVars.map((env, i) => (i === index ? { ...env, [field]: value } : env)));
-  };
-
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
@@ -601,33 +698,62 @@ function McpServerForm({
       return;
     }
 
-    if (!command) {
-      setError('Command is required');
-      return;
+    if (serverType === 'stdio') {
+      if (!command) {
+        setError('Command is required');
+        return;
+      }
+
+      const env = envVars.reduce(
+        (acc, { key, value, isSecret }) => {
+          if (key) {
+            const existingEnv = existingServer?.env[key];
+            const finalValue = existingEnv?.isSecret && !value ? existingEnv.value : value;
+            acc[key] = { value: finalValue, isSecret };
+          }
+          return acc;
+        },
+        {} as Record<string, { value: string; isSecret: boolean }>
+      );
+
+      mutation.mutate({
+        repoFullName,
+        mcpServer: {
+          name,
+          type: 'stdio',
+          command,
+          args: args.split(/\s+/).filter(Boolean),
+          env: Object.keys(env).length > 0 ? env : undefined,
+        },
+      });
+    } else {
+      if (!url) {
+        setError('URL is required');
+        return;
+      }
+
+      const headersRecord = headers.reduce(
+        (acc, { key, value, isSecret }) => {
+          if (key) {
+            const existingHeader = existingServer?.headers?.[key];
+            const finalValue = existingHeader?.isSecret && !value ? existingHeader.value : value;
+            acc[key] = { value: finalValue, isSecret };
+          }
+          return acc;
+        },
+        {} as Record<string, { value: string; isSecret: boolean }>
+      );
+
+      mutation.mutate({
+        repoFullName,
+        mcpServer: {
+          name,
+          type: serverType,
+          url,
+          headers: Object.keys(headersRecord).length > 0 ? headersRecord : undefined,
+        },
+      });
     }
-
-    const env = envVars.reduce(
-      (acc, { key, value, isSecret }) => {
-        if (key) {
-          // For existing secrets with empty value, keep the old value
-          const existingEnv = existingServer?.env[key];
-          const finalValue = existingEnv?.isSecret && !value ? existingEnv.value : value;
-          acc[key] = { value: finalValue, isSecret };
-        }
-        return acc;
-      },
-      {} as Record<string, { value: string; isSecret: boolean }>
-    );
-
-    mutation.mutate({
-      repoFullName,
-      mcpServer: {
-        name,
-        command,
-        args: args.split(/\s+/).filter(Boolean),
-        env: Object.keys(env).length > 0 ? env : undefined,
-      },
-    });
   };
 
   return (
@@ -644,64 +770,75 @@ function McpServerForm({
       </div>
 
       <div className="space-y-2">
-        <Label htmlFor="mcp-command">Command</Label>
-        <Input
-          id="mcp-command"
-          value={command}
-          onChange={(e) => setCommand(e.target.value)}
-          placeholder="npx"
-        />
+        <Label htmlFor="mcp-type">Type</Label>
+        <Select
+          value={serverType}
+          onValueChange={(value) => setServerType(value as McpServerType)}
+          disabled={!!existingServer}
+        >
+          <SelectTrigger id="mcp-type">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="stdio">Stdio (command)</SelectItem>
+            <SelectItem value="http">HTTP</SelectItem>
+            <SelectItem value="sse">SSE (Server-Sent Events)</SelectItem>
+          </SelectContent>
+        </Select>
       </div>
 
-      <div className="space-y-2">
-        <Label htmlFor="mcp-args">Arguments (space-separated)</Label>
-        <Input
-          id="mcp-args"
-          value={args}
-          onChange={(e) => setArgs(e.target.value)}
-          placeholder="@anthropic/mcp-server-memory"
-        />
-      </div>
-
-      <div className="space-y-2">
-        <div className="flex items-center justify-between">
-          <Label>Environment Variables</Label>
-          <Button type="button" variant="outline" size="sm" onClick={addEnvVar}>
-            <Plus className="h-4 w-4" />
-          </Button>
-        </div>
-        {envVars.map((env, index) => (
-          <div key={index} className="flex items-center gap-2">
+      {serverType === 'stdio' ? (
+        <>
+          <div className="space-y-2">
+            <Label htmlFor="mcp-command">Command</Label>
             <Input
-              value={env.key}
-              onChange={(e) => updateEnvVar(index, 'key', e.target.value.toUpperCase())}
-              placeholder="KEY"
-              className="flex-1"
+              id="mcp-command"
+              value={command}
+              onChange={(e) => setCommand(e.target.value)}
+              placeholder="npx"
             />
-            <Input
-              type={env.isSecret ? 'password' : 'text'}
-              value={env.value}
-              onChange={(e) => updateEnvVar(index, 'value', e.target.value)}
-              placeholder={existingServer?.env[env.key]?.isSecret ? '(unchanged)' : 'value'}
-              className="flex-1"
-            />
-            <Switch
-              checked={env.isSecret}
-              onCheckedChange={(checked) => updateEnvVar(index, 'isSecret', checked)}
-              title="Secret"
-            />
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={() => removeEnvVar(index)}
-              className="text-destructive"
-            >
-              <Trash2 className="h-4 w-4" />
-            </Button>
           </div>
-        ))}
-      </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="mcp-args">Arguments (space-separated)</Label>
+            <Input
+              id="mcp-args"
+              value={args}
+              onChange={(e) => setArgs(e.target.value)}
+              placeholder="@anthropic/mcp-server-memory"
+            />
+          </div>
+
+          <KeyValueListEditor
+            label="Environment Variables"
+            entries={envVars}
+            existingEntries={existingServer?.env}
+            onChange={setEnvVars}
+            keyPlaceholder="KEY"
+            keyTransform={(key) => key.toUpperCase()}
+          />
+        </>
+      ) : (
+        <>
+          <div className="space-y-2">
+            <Label htmlFor="mcp-url">URL</Label>
+            <Input
+              id="mcp-url"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              placeholder="https://mcp.example.com/sse"
+            />
+          </div>
+
+          <KeyValueListEditor
+            label="Headers"
+            entries={headers}
+            existingEntries={existingServer?.headers}
+            onChange={setHeaders}
+            keyPlaceholder="Header-Name"
+          />
+        </>
+      )}
 
       {error && <p className="text-sm text-destructive">{error}</p>}
 


### PR DESCRIPTION
## Summary
- Adds support for HTTP and SSE transport types for MCP server configuration, in addition to the existing stdio type
- HTTP/SSE servers are configured via URL + optional headers (with secret encryption support for auth tokens)
- UI updated with server type selector that conditionally shows relevant fields (command/args/env for stdio, URL/headers for HTTP/SSE)

Closes #180

## Changes
- **Database**: Added `type`, `url`, and `headers` columns to `McpServer` model with a Prisma migration
- **Validation**: Changed MCP server input to a Zod discriminated union (`stdio` vs `http`/`sse`)
- **Backend**: Updated `repo-settings.ts`, `repoSettings.ts` router, and `claude-runner.ts` to handle all three transport types
- **UI**: Added type selector, shared `KeyValueListEditor` component for env vars and headers, conditional field rendering
- **Tests**: Added 7 new integration tests for HTTP/SSE MCP server CRUD, header encryption/decryption, and validation
- **Design doc**: Updated to document the three transport types

## Test plan
- [x] All 220 unit tests pass (`pnpm test:run`)
- [x] All 134 integration tests pass (`pnpm test:integration`)
- [x] TypeScript type check passes (`pnpm tsc --noEmit`)
- [ ] Manual test: Create an HTTP MCP server with auth headers and verify it works in a session
- [ ] Manual test: Create an SSE MCP server and verify it connects

🤖 Generated with [Claude Code](https://claude.com/claude-code)