### PR TITLE
Add security headers (CSP, HSTS, X-Frame-Options)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,38 @@ const nextConfig = {
   serverExternalPackages: ['dockerode', 'ssh2', 'simple-git'],
   // Empty turbopack config to acknowledge Turbopack is enabled by default
   turbopack: {},
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          { key: 'X-Frame-Options', value: 'DENY' },
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+          {
+            key: 'Strict-Transport-Security',
+            value: 'max-age=31536000; includeSubDomains',
+          },
+          {
+            key: 'Content-Security-Policy',
+            value: [
+              "default-src 'self'",
+              "script-src 'self' 'unsafe-inline'",
+              "style-src 'self' 'unsafe-inline'",
+              "img-src 'self' data: blob:",
+              "font-src 'self' data:",
+              "connect-src 'self'",
+              "manifest-src 'self'",
+              "object-src 'none'",
+              "base-uri 'self'",
+              "form-action 'self'",
+              "frame-ancestors 'none'",
+            ].join('; '),
+          },
+        ],
+      },
+    ];
+  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- Adds security headers to `next.config.js` to protect against common web attacks
- Configures Content-Security-Policy, X-Frame-Options, X-Content-Type-Options, Strict-Transport-Security, and Referrer-Policy
- CSP is tailored to the app's actual resource usage (all self-hosted, no external dependencies)

## Headers Added

| Header | Value | Purpose |
|--------|-------|---------|
| `X-Frame-Options` | `DENY` | Prevents iframe embedding (clickjacking) |
| `X-Content-Type-Options` | `nosniff` | Prevents MIME type sniffing |
| `Referrer-Policy` | `strict-origin-when-cross-origin` | Controls referrer information |
| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` | Forces HTTPS |
| `Content-Security-Policy` | (see below) | Restricts resource loading |

### CSP Directives
- `default-src 'self'` — Only allow same-origin resources by default
- `script-src 'self' 'unsafe-inline'` — Required for theme detection inline script
- `style-src 'self' 'unsafe-inline'` — Required for Tailwind CSS
- `img-src 'self' data: blob:` — Allow same-origin images and data URIs
- `object-src 'none'` — Block plugins (Flash, Java applets)
- `frame-ancestors 'none'` — Prevent embedding in iframes (supplements X-Frame-Options)

Fixes #104

## Test plan
- [x] All 220 existing tests pass
- [ ] Verify app loads correctly in browser with headers active
- [ ] Check browser console for CSP violations
- [ ] Verify SSE streaming still works (covered by connect-src 'self')

🤖 Generated with [Claude Code](https://claude.com/claude-code)