### PR TITLE
Add support for configuring skills per repository

### DIFF
--- a/agent-service/src/index.ts
+++ b/agent-service/src/index.ts
@@ -1,7 +1,7 @@
 import http from 'node:http';
 import fs from 'node:fs';
 import { MessageStore } from './message-store.js';
-import { QueryRunner, type QueryOptions } from './query-runner.js';
+import { QueryRunner, type QueryOptions, type SkillDefinition } from './query-runner.js';
 import type { SDKMessage, McpServerConfig, SlashCommand } from '@anthropic-ai/claude-agent-sdk';
 import type { PartialAssistantMessage } from './stream-accumulator.js';
 
@@ -59,6 +59,7 @@ async function handleQuery(req: http.IncomingMessage, res: http.ServerResponse):
     resume?: boolean;
     cwd?: string;
     mcpServers?: Record<string, McpServerConfig>;
+    skills?: SkillDefinition[];
   };
 
   if (!body.prompt || typeof body.prompt !== 'string') {
@@ -116,6 +117,7 @@ async function handleQuery(req: http.IncomingMessage, res: http.ServerResponse):
     model: CLAUDE_MODEL || undefined,
     cwd: body.cwd,
     mcpServers: body.mcpServers,
+    skills: body.skills,
   };
 
   try {

--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -52,9 +52,10 @@ The database schema is defined in [`prisma/schema.prisma`](../prisma/schema.pris
 - **Session**: Claude Code sessions tied to git clones (includes `agentPort` for the agent service)
 - **Message**: Chat messages with sequence numbers for cursor-based pagination
 - **AuthSession**: Login sessions with tokens and audit info
-- **RepoSettings**: Per-repository settings (favorites, env vars, MCP servers)
+- **RepoSettings**: Per-repository settings (favorites, env vars, MCP servers, skills)
 - **EnvVar**: Environment variables for a repository (encrypted if secret)
 - **McpServer**: MCP server configurations for a repository
+- **Skill**: Custom slash commands (skills) for a repository
 
 ### Session Archiving
 
@@ -471,6 +472,7 @@ Users can configure per-repository settings that are automatically applied when 
   - **Stdio**: Traditional command-based servers (e.g., `npx @anthropic/mcp-server-memory`)
   - **HTTP**: Streamable HTTP MCP servers with optional auth headers
   - **SSE**: Server-Sent Events MCP servers with optional auth headers
+- **Skills**: Custom slash commands that define instructions for Claude. Each skill creates a `/<name>` command that Claude can invoke. Skills are stored in the database and written to the container's filesystem (`~/.claude/skills/<name>/SKILL.md`) at query time. The skill content supports YAML frontmatter and markdown instructions, with `$ARGUMENTS` for passed arguments.
 
 **Secret Encryption**: Environment variables, MCP server env vars, and HTTP/SSE header values can be marked as "secret", which:
 

--- a/prisma/migrations/20260208042820_add_skills_support/migration.sql
+++ b/prisma/migrations/20260208042820_add_skills_support/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "Skill" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "repoSettingsId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL DEFAULT '',
+    "content" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Skill_repoSettingsId_fkey" FOREIGN KEY ("repoSettingsId") REFERENCES "RepoSettings" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "Skill_repoSettingsId_idx" ON "Skill"("repoSettingsId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Skill_repoSettingsId_name_key" ON "Skill"("repoSettingsId", "name");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -54,7 +54,7 @@ model Message {
   @@index([sessionId, sequence])
 }
 
-// Per-repository settings for favorites, env vars, and MCP servers
+// Per-repository settings for favorites, env vars, MCP servers, and skills
 model RepoSettings {
   id                 String   @id @default(uuid())
   repoFullName       String   @unique // e.g., "owner/repo"
@@ -66,6 +66,7 @@ model RepoSettings {
 
   envVars    EnvVar[]
   mcpServers McpServer[]
+  skills     Skill[]
 
   @@index([isFavorite])
 }
@@ -97,6 +98,22 @@ model McpServer {
   env            String? // For stdio: JSON object: { "KEY": { "value": "...", "isSecret": true } }
   url            String? // For http/sse: server URL
   headers        String? // For http/sse: JSON object of headers, { "KEY": { "value": "...", "isSecret": true } }
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
+
+  @@unique([repoSettingsId, name])
+  @@index([repoSettingsId])
+}
+
+// Skills (slash commands) for a repository
+// Each skill is a SKILL.md file that defines a custom slash command for Claude
+model Skill {
+  id             String       @id @default(uuid())
+  repoSettingsId String
+  repoSettings   RepoSettings @relation(fields: [repoSettingsId], references: [id], onDelete: Cascade)
+  name           String // Skill name (used as directory name and slash command), e.g., "review-pr"
+  description    String       @default("") // Short description shown in autocomplete
+  content        String // The SKILL.md content (markdown with optional YAML frontmatter)
   createdAt      DateTime     @default(now())
   updatedAt      DateTime     @updatedAt
 

--- a/src/components/settings/RepositoriesTab.tsx
+++ b/src/components/settings/RepositoriesTab.tsx
@@ -45,8 +45,8 @@ export function RepositoriesTab() {
         <CardHeader>
           <CardTitle>Repository Settings</CardTitle>
           <CardDescription>
-            Configure per-repository favorites, environment variables, and MCP servers. These
-            settings are applied when creating new sessions for the repository.
+            Configure per-repository favorites, environment variables, MCP servers, and skills.
+            These settings are applied when creating new sessions for the repository.
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -65,10 +65,13 @@ export function RepositoriesTab() {
                     )}
                     <span className="font-mono text-sm truncate">{setting.repoFullName}</span>
                     <span className="text-xs text-muted-foreground shrink-0">
-                      {setting.envVarCount > 0 && `${setting.envVarCount} env vars`}
-                      {setting.envVarCount > 0 && setting.mcpServerCount > 0 && ', '}
-                      {setting.mcpServerCount > 0 && `${setting.mcpServerCount} MCP servers`}
-                      {setting.envVarCount === 0 && setting.mcpServerCount === 0 && 'No settings'}
+                      {[
+                        setting.envVarCount > 0 ? `${setting.envVarCount} env vars` : null,
+                        setting.mcpServerCount > 0 ? `${setting.mcpServerCount} MCP servers` : null,
+                        setting.skillCount > 0 ? `${setting.skillCount} skills` : null,
+                      ]
+                        .filter(Boolean)
+                        .join(', ') || 'No settings'}
                     </span>
                   </div>
                   <div className="flex items-center gap-1">

--- a/src/server/routers/claude.ts
+++ b/src/server/routers/claude.ts
@@ -74,6 +74,7 @@ export const claudeRouter = router({
         customSystemPrompt: repoSettings?.customSystemPrompt,
         globalSettings,
         mcpServers: repoSettings?.mcpServers,
+        skills: repoSettings?.skills,
       }).catch((err) => {
         log.error('Claude command failed', toError(err), { sessionId: input.sessionId });
       });

--- a/src/server/services/agent-client.ts
+++ b/src/server/services/agent-client.ts
@@ -98,6 +98,7 @@ export interface AgentClient {
     resume?: boolean;
     cwd?: string;
     mcpServers?: Record<string, unknown>;
+    skills?: Array<{ name: string; description: string; content: string }>;
   }): AsyncGenerator<AgentStreamEvent>;
 
   /**
@@ -214,6 +215,7 @@ export function createAgentClient(socketPath: string): AgentClient {
           resume: options.resume ?? false,
           cwd: options.cwd,
           mcpServers: options.mcpServers,
+          skills: options.skills,
         })
       );
 

--- a/src/server/services/claude-runner.ts
+++ b/src/server/services/claude-runner.ts
@@ -232,6 +232,12 @@ export interface RunClaudeCommandOptions {
     | { name: string; type: 'http'; url: string; headers?: Record<string, string> }
     | { name: string; type: 'sse'; url: string; headers?: Record<string, string> }
   >;
+  /** Skills (slash commands) to make available to the agent */
+  skills?: Array<{
+    name: string;
+    description: string;
+    content: string;
+  }>;
 }
 
 /**
@@ -368,6 +374,7 @@ export async function runClaudeCommand(options: RunClaudeCommandOptions): Promis
       resume: shouldResume,
       cwd: workingDir,
       mcpServers: mcpServersRecord,
+      skills: options.skills,
     })) {
       // Handle commands update - emit via SSE for frontend autocomplete
       if (agentEvent.kind === 'commands') {

--- a/src/server/services/repo-settings.ts
+++ b/src/server/services/repo-settings.ts
@@ -54,12 +54,22 @@ export type ContainerMcpServer =
   | ContainerSseMcpServer;
 
 /**
+ * Skill configuration for container
+ */
+export interface ContainerSkill {
+  name: string;
+  description: string;
+  content: string; // The SKILL.md content
+}
+
+/**
  * Repo settings ready for container creation
  */
 export interface ContainerRepoSettings {
   customSystemPrompt: string | null;
   envVars: ContainerEnvVar[];
   mcpServers: ContainerMcpServer[];
+  skills: ContainerSkill[];
 }
 
 /**
@@ -71,7 +81,7 @@ export async function getRepoSettingsForContainer(
 ): Promise<ContainerRepoSettings | null> {
   const settings = await prisma.repoSettings.findUnique({
     where: { repoFullName },
-    include: { envVars: true, mcpServers: true },
+    include: { envVars: true, mcpServers: true, skills: true },
   });
 
   if (!settings) {
@@ -128,9 +138,17 @@ export async function getRepoSettingsForContainer(
     } as ContainerStdioMcpServer;
   });
 
+  // Map skills (no decryption needed)
+  const skills: ContainerSkill[] = settings.skills.map((skill) => ({
+    name: skill.name,
+    description: skill.description,
+    content: skill.content,
+  }));
+
   return {
     customSystemPrompt: settings.customSystemPrompt,
     envVars,
     mcpServers,
+    skills,
   };
 }

--- a/src/test/setup-test-db.ts
+++ b/src/test/setup-test-db.ts
@@ -105,5 +105,6 @@ export async function clearTestDb(): Promise<void> {
   // Repo settings tables
   await testPrisma.envVar.deleteMany();
   await testPrisma.mcpServer.deleteMany();
+  await testPrisma.skill.deleteMany();
   await testPrisma.repoSettings.deleteMany();
 }


### PR DESCRIPTION
## Summary
- Adds a new `Skill` model to the database for storing custom slash commands per repository
- Skills are written to the container filesystem (`~/.claude/skills/<name>/SKILL.md`) at query time and discovered by the Claude Agent SDK via the `user` setting source
- Full CRUD UI in the repository settings editor with validation for skill names (lowercase, hyphens, no leading/trailing hyphens)
- Skills support YAML frontmatter and markdown content with `$ARGUMENTS` for passed arguments

## Changes
- **Database**: New `Skill` model with name, description, content fields (unique per repo)
- **API**: `setSkill` and `deleteSkill` tRPC procedures in `repoSettings` router
- **Service layer**: Skills passed through `ContainerRepoSettings` → `claude-runner` → `agent-client` → agent service
- **Agent service**: Writes skills to `~/.claude/skills/` before each query; `settingSources` includes `'user'` so SDK discovers them
- **UI**: New Skills section in `RepoSettingsEditor` with add/edit/delete functionality
- **Tests**: 10 new integration tests covering skill CRUD, validation, container settings, and list counts

## Test plan
- [x] All 220 unit tests pass
- [x] All 144 integration tests pass (including 10 new skill tests)
- [x] Next.js build succeeds
- [x] ESLint passes
- [ ] Manual testing: Create a skill, verify it appears as a `/name` command in a session

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)