### PR TITLE
Remove HSTS header to allow HTTP on non-standard ports

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -14,10 +14,6 @@ const nextConfig = {
           { key: 'X-Content-Type-Options', value: 'nosniff' },
           { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
           {
-            key: 'Strict-Transport-Security',
-            value: 'max-age=31536000; includeSubDomains',
-          },
-          {
             key: 'Content-Security-Policy',
             value: [
               "default-src 'self'",


### PR DESCRIPTION
## Summary
- Removes the `Strict-Transport-Security` header from `next.config.js`
- HSTS applies to the entire domain across all ports (RFC 6797 §8.3), which prevents browsers from connecting to HTTP dev servers on non-standard ports
- Since the app is behind Tailscale encryption, HSTS provides minimal additional security benefit

## Context
When agents spin up HTTP servers on random ports, Firefox (and other browsers) refuse to connect because the HSTS policy from the main app forces HTTPS on all ports for the domain.

## Test plan
- [x] All 220 tests pass
- [ ] Verify Firefox can connect to HTTP servers on non-standard ports after clearing HSTS cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)