### PR TITLE
Fix secret values being overwritten with masked placeholder on update

### DIFF
--- a/src/components/settings/GlobalSettingsTab.tsx
+++ b/src/components/settings/GlobalSettingsTab.tsx
@@ -591,9 +591,7 @@ function GlobalMcpServerForm({
       const env = envVars.reduce(
         (acc, { key, value, isSecret }) => {
           if (key) {
-            const existingEnv = existingServer?.env[key];
-            const finalValue = existingEnv?.isSecret && !value ? existingEnv.value : value;
-            acc[key] = { value: finalValue, isSecret };
+            acc[key] = { value, isSecret };
           }
           return acc;
         },
@@ -618,9 +616,7 @@ function GlobalMcpServerForm({
       const headersRecord = headers.reduce(
         (acc, { key, value, isSecret }) => {
           if (key) {
-            const existingHeader = existingServer?.headers?.[key];
-            const finalValue = existingHeader?.isSecret && !value ? existingHeader.value : value;
-            acc[key] = { value: finalValue, isSecret };
+            acc[key] = { value, isSecret };
           }
           return acc;
         },

--- a/src/components/settings/RepoSettingsEditor.tsx
+++ b/src/components/settings/RepoSettingsEditor.tsx
@@ -707,9 +707,7 @@ function McpServerForm({
       const env = envVars.reduce(
         (acc, { key, value, isSecret }) => {
           if (key) {
-            const existingEnv = existingServer?.env[key];
-            const finalValue = existingEnv?.isSecret && !value ? existingEnv.value : value;
-            acc[key] = { value: finalValue, isSecret };
+            acc[key] = { value, isSecret };
           }
           return acc;
         },
@@ -735,9 +733,7 @@ function McpServerForm({
       const headersRecord = headers.reduce(
         (acc, { key, value, isSecret }) => {
           if (key) {
-            const existingHeader = existingServer?.headers?.[key];
-            const finalValue = existingHeader?.isSecret && !value ? existingHeader.value : value;
-            acc[key] = { value: finalValue, isSecret };
+            acc[key] = { value, isSecret };
           }
           return acc;
         },


### PR DESCRIPTION
## Summary
- When editing an MCP server or env var config without changing a secret value, the masked `••••••••` placeholder was being encrypted and stored as the new value, corrupting the secret
- This caused MCP servers like Lion Reader to fail with `Cannot convert argument to a ByteString because the character at index 0 has a value of 8226` errors (the bullet character `•` is non-ASCII)
- The fix preserves existing encrypted DB values when a secret field is submitted with an empty value (indicating the user didn't change it)
- Also removes the frontend fallback that was sending the masked display value as the actual secret

## Test plan
- [x] Added integration tests for env var secret preservation (global + per-repo)
- [x] Added integration tests for MCP server header secret preservation (global + per-repo)  
- [x] Added integration tests for MCP server env var secret preservation (global + per-repo)
- [x] All 230 unit tests pass
- [x] All 154 integration tests pass (including 6 new tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)