### PR TITLE
Improve session header layout for mobile

### DIFF
--- a/src/components/SessionHeader.tsx
+++ b/src/components/SessionHeader.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
-import { SessionStatusBadge } from '@/components/SessionStatusBadge';
+import { SessionStatusToggle } from '@/components/SessionStatusToggle';
 import { SessionActionButton } from '@/components/SessionActionButton';
 
 interface SessionHeaderProps {
@@ -36,9 +36,9 @@ export function SessionHeader({
 
   return (
     <div className="border-b bg-background px-4 py-3">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-4">
-          <Button variant="ghost" size="icon" asChild>
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-3 min-w-0">
+          <Button variant="ghost" size="icon" className="shrink-0" asChild>
             <Link href="/">
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path
@@ -50,29 +50,20 @@ export function SessionHeader({
               </svg>
             </Link>
           </Button>
-          <div>
-            <h1 className="font-semibold">{session.name}</h1>
-            <p className="text-sm text-muted-foreground">
-              {repoName} · {session.branch}
-            </p>
+          <div className="min-w-0">
+            <h1 className="font-semibold break-words">{session.name}</h1>
+            <p className="text-sm text-muted-foreground truncate">{repoName}</p>
           </div>
         </div>
 
-        <div className="flex items-center gap-3">
-          <span className="text-sm text-muted-foreground">Container:</span>
-          <SessionStatusBadge status={session.status} />
-
-          {session.status === 'stopped' && (
-            <SessionActionButton action="start" onClick={onStart} isPending={isStarting} />
-          )}
-          {session.status === 'running' && (
-            <SessionActionButton
-              action="stop"
-              onClick={onStop}
-              isPending={isStopping}
-              variant="secondary"
-            />
-          )}
+        <div className="flex flex-col items-end gap-1 shrink-0">
+          <SessionStatusToggle
+            status={session.status}
+            onStart={onStart}
+            onStop={onStop}
+            isStarting={isStarting}
+            isStopping={isStopping}
+          />
           {(session.status === 'stopped' || session.status === 'running') && onArchive && (
             <SessionActionButton
               action="archive"

--- a/src/components/SessionStatusToggle.tsx
+++ b/src/components/SessionStatusToggle.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Spinner } from '@/components/ui/spinner';
+import { SessionStatusBadge } from '@/components/SessionStatusBadge';
+
+interface SessionStatusToggleProps {
+  status: string;
+  onStart: () => void;
+  onStop: () => void;
+  isStarting: boolean;
+  isStopping: boolean;
+}
+
+/**
+ * Combined status display and toggle button.
+ * When the container is running or stopped, renders as a clickable button
+ * that shows the status and toggles it on click.
+ * For other statuses (creating, error, archived), renders a static badge.
+ */
+export function SessionStatusToggle({
+  status,
+  onStart,
+  onStop,
+  isStarting,
+  isStopping,
+}: SessionStatusToggleProps) {
+  if (status === 'running') {
+    return (
+      <Button size="sm" variant="default" onClick={onStop} disabled={isStopping}>
+        {isStopping ? (
+          <>
+            <Spinner size="sm" className="mr-2" />
+            Stopping...
+          </>
+        ) : (
+          'Running'
+        )}
+      </Button>
+    );
+  }
+
+  if (status === 'stopped') {
+    return (
+      <Button size="sm" variant="secondary" onClick={onStart} disabled={isStarting}>
+        {isStarting ? (
+          <>
+            <Spinner size="sm" className="mr-2" />
+            Starting...
+          </>
+        ) : (
+          'Stopped'
+        )}
+      </Button>
+    );
+  }
+
+  // For non-toggleable statuses (creating, error, archived), show a static badge
+  return <SessionStatusBadge status={status} />;
+}


### PR DESCRIPTION
## Summary
- Removed the branch name from the session header to save horizontal space on mobile
- Session name now wraps with `break-words` and the left side uses `min-w-0` to allow text truncation instead of pushing content off-screen
- Replaced the separate "Container:" label, status badge, and start/stop buttons with a single `SessionStatusToggle` button that displays the current state and toggles it on click (e.g., clicking "Running" stops the container, clicking "Stopped" starts it)
- Right side now stacks the status toggle and archive button vertically with `flex-col`

## Test plan
- [ ] Open a session on mobile or narrow browser window — header should not overflow
- [ ] Long session names should wrap instead of pushing buttons off-screen
- [ ] "Running" button should stop the container when clicked
- [ ] "Stopped" button should start the container when clicked
- [ ] Archive button should still show confirmation dialog
- [ ] Non-toggleable states (creating, error, archived) should show a static badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)