### PR TITLE
Fix branch not resetting when switching repos in new session form

### DIFF
--- a/src/app/new/page.tsx
+++ b/src/app/new/page.tsx
@@ -386,9 +386,10 @@ function NewSessionForm() {
     }
   }, []);
 
-  // Handle repo selection: also reset issue and name
+  // Handle repo selection: reset branch, issue, and name
   const handleRepoSelect = useCallback((repo: Repo) => {
     setSelectedRepo(repo);
+    setSelectedBranch('');
     setSelectedIssue(null);
     setSessionName('');
   }, []);


### PR DESCRIPTION
## Summary
- When selecting a different repository in the new session form, the branch selection was not being cleared, so the previous repo's branch remained selected
- This could result in creating a session with a non-existent branch (e.g. selecting "master" on a repo that uses "main")
- Fix: clear `selectedBranch` in `handleRepoSelect`, which also re-triggers the default branch auto-selection in `BranchSelector`'s `useEffect`
- The create button was already wired to be disabled when no branch is selected (`!selectedBranch`), so it correctly disables during the brief loading period after switching repos

## Test plan
- [ ] Select a repo that uses `main` as default branch — verify `main` is auto-selected
- [ ] Switch to a repo that uses `master` — verify branch resets and `master` is auto-selected
- [ ] Switch repos and verify the Create button is disabled until the new branch loads
- [ ] Verify the create button remains disabled if branches fail to load

🤖 Generated with [Claude Code](https://claude.com/claude-code)