### PR TITLE
Extract shared settings components from GlobalSettingsTab and RepoSettingsEditor

### DIFF
--- a/src/components/settings/GlobalSettingsTab.tsx
+++ b/src/components/settings/GlobalSettingsTab.tsx
@@ -1,52 +1,52 @@
 'use client';
 
-import { useState } from 'react';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Switch } from '@/components/ui/switch';
-import { Spinner } from '@/components/ui/spinner';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
+import { Spinner } from '@/components/ui/spinner';
 import { trpc } from '@/lib/trpc';
-import { Plus, Trash2, Eye, EyeOff, Plug, Check, X } from 'lucide-react';
+import { EnvVarSection } from './shared/EnvVarSection';
+import { McpServerSection } from './shared/McpServerSection';
+import type { EnvVarMutations } from './shared/EnvVarSection';
+import type { McpServerMutations } from './shared/McpServerSection';
 
-interface EnvVar {
-  id: string;
-  name: string;
-  value: string;
-  isSecret: boolean;
+function useGlobalEnvVarMutations(onUpdate: () => void): EnvVarMutations {
+  const utils = trpc.useUtils();
+  const deleteMutation = trpc.globalSettings.deleteEnvVar.useMutation({ onSuccess: onUpdate });
+  const setMutation = trpc.globalSettings.setEnvVar.useMutation();
+
+  return {
+    deleteEnvVar: async (name) => {
+      await deleteMutation.mutateAsync({ name });
+    },
+    setEnvVar: async (envVar) => {
+      await setMutation.mutateAsync({ envVar });
+    },
+    getSecretValue: async (name) => {
+      return await utils.globalSettings.getEnvVarValue.fetch({ name });
+    },
+  };
 }
 
-interface McpServer {
-  id: string;
-  name: string;
-  type: 'stdio' | 'http' | 'sse';
-  command: string;
-  args: string[];
-  env: Record<string, { value: string; isSecret: boolean }>;
-  url?: string;
-  headers: Record<string, { value: string; isSecret: boolean }>;
+function useGlobalMcpServerMutations(onUpdate: () => void): McpServerMutations {
+  const deleteMutation = trpc.globalSettings.deleteMcpServer.useMutation({ onSuccess: onUpdate });
+  const setMutation = trpc.globalSettings.setMcpServer.useMutation();
+  const validateMutation = trpc.globalSettings.validateMcpServer.useMutation();
+
+  return {
+    deleteMcpServer: async (name) => {
+      await deleteMutation.mutateAsync({ name });
+    },
+    setMcpServer: async (mcpServer) => {
+      await setMutation.mutateAsync({ mcpServer });
+    },
+    validateMcpServer: async (name) => {
+      return await validateMutation.mutateAsync({ name });
+    },
+  };
 }
 
 export function GlobalEnvVarsCard() {
   const { data, isLoading, refetch } = trpc.globalSettings.getWithSettings.useQuery();
+  const mutations = useGlobalEnvVarMutations(refetch);
 
   if (isLoading) {
     return (
@@ -77,7 +77,14 @@ export function GlobalEnvVarsCard() {
         </CardDescription>
       </CardHeader>
       <CardContent>
-        <GlobalEnvVarsSection envVars={data?.envVars ?? []} onUpdate={refetch} />
+        <EnvVarSection
+          envVars={data?.envVars ?? []}
+          mutations={mutations}
+          onUpdate={refetch}
+          emptyMessage="No global environment variables configured."
+          deleteDescriptionPrefix="This will delete the global environment variable"
+          idPrefix="global-env"
+        />
       </CardContent>
     </Card>
   );
@@ -85,6 +92,7 @@ export function GlobalEnvVarsCard() {
 
 export function GlobalMcpServersCard() {
   const { data, isLoading, refetch } = trpc.globalSettings.getWithSettings.useQuery();
+  const mutations = useGlobalMcpServerMutations(refetch);
 
   if (isLoading) {
     return (
@@ -115,677 +123,15 @@ export function GlobalMcpServersCard() {
         </CardDescription>
       </CardHeader>
       <CardContent>
-        <GlobalMcpServersSection mcpServers={data?.mcpServers ?? []} onUpdate={refetch} />
+        <McpServerSection
+          mcpServers={data?.mcpServers ?? []}
+          mutations={mutations}
+          onUpdate={refetch}
+          emptyMessage="No global MCP servers configured."
+          deleteDescriptionPrefix="This will delete the global MCP server"
+          idPrefix="global-mcp"
+        />
       </CardContent>
     </Card>
-  );
-}
-
-function GlobalEnvVarsSection({ envVars, onUpdate }: { envVars: EnvVar[]; onUpdate: () => void }) {
-  const [showForm, setShowForm] = useState(false);
-  const [editingId, setEditingId] = useState<string | null>(null);
-  const [deleteEnvVar, setDeleteEnvVar] = useState<string | null>(null);
-  const [revealedSecrets, setRevealedSecrets] = useState<Map<string, string>>(new Map());
-  const [loadingSecret, setLoadingSecret] = useState<string | null>(null);
-
-  const deleteMutation = trpc.globalSettings.deleteEnvVar.useMutation({
-    onSuccess: () => {
-      onUpdate();
-      setDeleteEnvVar(null);
-    },
-  });
-
-  const utils = trpc.useUtils();
-
-  const toggleSecretVisibility = async (name: string) => {
-    if (revealedSecrets.has(name)) {
-      setRevealedSecrets((prev) => {
-        const next = new Map(prev);
-        next.delete(name);
-        return next;
-      });
-    } else {
-      setLoadingSecret(name);
-      try {
-        const result = await utils.globalSettings.getEnvVarValue.fetch({ name });
-        setRevealedSecrets((prev) => {
-          const next = new Map(prev);
-          next.set(name, result.value);
-          return next;
-        });
-      } finally {
-        setLoadingSecret(null);
-      }
-    }
-  };
-
-  return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <h3 className="font-medium">Environment Variables</h3>
-        <Button variant="outline" size="sm" onClick={() => setShowForm(true)}>
-          <Plus className="h-4 w-4 mr-1" />
-          Add
-        </Button>
-      </div>
-
-      {envVars.length === 0 && !showForm ? (
-        <p className="text-sm text-muted-foreground">No global environment variables configured.</p>
-      ) : (
-        <ul className="space-y-2">
-          {envVars.map((envVar) => (
-            <li key={envVar.id} className="flex items-center gap-2 p-2 rounded-md bg-muted/50">
-              <div className="flex-1 min-w-0">
-                <div className="font-mono text-sm">{envVar.name}</div>
-                <div className="text-xs text-muted-foreground flex items-center gap-1">
-                  {envVar.isSecret ? (
-                    <>
-                      <span>
-                        {revealedSecrets.has(envVar.name)
-                          ? revealedSecrets.get(envVar.name)
-                          : '••••••••'}
-                      </span>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="h-5 w-5 p-0"
-                        onClick={() => toggleSecretVisibility(envVar.name)}
-                        disabled={loadingSecret === envVar.name}
-                      >
-                        {loadingSecret === envVar.name ? (
-                          <Spinner size="sm" className="h-3 w-3" />
-                        ) : revealedSecrets.has(envVar.name) ? (
-                          <EyeOff className="h-3 w-3" />
-                        ) : (
-                          <Eye className="h-3 w-3" />
-                        )}
-                      </Button>
-                    </>
-                  ) : (
-                    <span className="truncate">{envVar.value}</span>
-                  )}
-                </div>
-              </div>
-              <Button variant="ghost" size="sm" onClick={() => setEditingId(envVar.id)}>
-                Edit
-              </Button>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => setDeleteEnvVar(envVar.name)}
-                className="text-destructive hover:text-destructive"
-              >
-                <Trash2 className="h-4 w-4" />
-              </Button>
-            </li>
-          ))}
-        </ul>
-      )}
-
-      {(showForm || editingId) && (
-        <GlobalEnvVarForm
-          existingEnvVar={editingId ? envVars.find((e) => e.id === editingId) : undefined}
-          onClose={() => {
-            setShowForm(false);
-            setEditingId(null);
-          }}
-          onSuccess={() => {
-            setShowForm(false);
-            setEditingId(null);
-            onUpdate();
-          }}
-        />
-      )}
-
-      <AlertDialog open={!!deleteEnvVar} onOpenChange={(open) => !open && setDeleteEnvVar(null)}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete environment variable?</AlertDialogTitle>
-            <AlertDialogDescription>
-              This will delete the global environment variable <strong>{deleteEnvVar}</strong>.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() => deleteEnvVar && deleteMutation.mutate({ name: deleteEnvVar })}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            >
-              Delete
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    </div>
-  );
-}
-
-function GlobalEnvVarForm({
-  existingEnvVar,
-  onClose,
-  onSuccess,
-}: {
-  existingEnvVar?: EnvVar;
-  onClose: () => void;
-  onSuccess: () => void;
-}) {
-  const [name, setName] = useState(existingEnvVar?.name ?? '');
-  const [value, setValue] = useState(existingEnvVar?.isSecret ? '' : (existingEnvVar?.value ?? ''));
-  const [isSecret, setIsSecret] = useState(existingEnvVar?.isSecret ?? false);
-  const [error, setError] = useState<string | null>(null);
-
-  const mutation = trpc.globalSettings.setEnvVar.useMutation({
-    onSuccess,
-    onError: (err) => setError(err.message),
-  });
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    setError(null);
-
-    if (!name.match(/^[A-Za-z_][A-Za-z0-9_]*$/)) {
-      setError(
-        'Name must start with a letter or underscore and contain only alphanumeric characters and underscores'
-      );
-      return;
-    }
-
-    if (!existingEnvVar?.isSecret && !value) {
-      setError('Value is required');
-      return;
-    }
-
-    mutation.mutate({
-      envVar: {
-        name,
-        value: existingEnvVar?.isSecret && !value ? existingEnvVar.value : value,
-        isSecret,
-      },
-    });
-  };
-
-  return (
-    <form onSubmit={handleSubmit} className="space-y-4 p-4 border rounded-md">
-      <div className="space-y-2">
-        <Label htmlFor="global-env-name">Name</Label>
-        <Input
-          id="global-env-name"
-          value={name}
-          onChange={(e) => setName(e.target.value.toUpperCase())}
-          placeholder="MY_API_KEY"
-          disabled={!!existingEnvVar}
-        />
-      </div>
-
-      <div className="space-y-2">
-        <Label htmlFor="global-env-value">Value</Label>
-        <Input
-          id="global-env-value"
-          type={isSecret ? 'password' : 'text'}
-          value={value}
-          onChange={(e) => setValue(e.target.value)}
-          placeholder={existingEnvVar?.isSecret ? '(unchanged)' : 'Enter value'}
-        />
-      </div>
-
-      <div className="flex items-center gap-2">
-        <Switch id="global-env-secret" checked={isSecret} onCheckedChange={setIsSecret} />
-        <Label htmlFor="global-env-secret">Secret (encrypted at rest)</Label>
-      </div>
-
-      {error && <p className="text-sm text-destructive">{error}</p>}
-
-      <div className="flex justify-end gap-2">
-        <Button type="button" variant="outline" onClick={onClose}>
-          Cancel
-        </Button>
-        <Button type="submit" disabled={mutation.isPending}>
-          {mutation.isPending ? <Spinner size="sm" /> : existingEnvVar ? 'Update' : 'Add'}
-        </Button>
-      </div>
-    </form>
-  );
-}
-
-type McpServerType = 'stdio' | 'http' | 'sse';
-
-function GlobalMcpServersSection({
-  mcpServers,
-  onUpdate,
-}: {
-  mcpServers: McpServer[];
-  onUpdate: () => void;
-}) {
-  const [showForm, setShowForm] = useState(false);
-  const [editingId, setEditingId] = useState<string | null>(null);
-  const [deleteMcpServer, setDeleteMcpServer] = useState<string | null>(null);
-  const [validationResults, setValidationResults] = useState<
-    Map<string, { success: boolean; error?: string; tools?: string[] }>
-  >(new Map());
-
-  const deleteMutation = trpc.globalSettings.deleteMcpServer.useMutation({
-    onSuccess: () => {
-      onUpdate();
-      setDeleteMcpServer(null);
-    },
-  });
-
-  const validateMutation = trpc.globalSettings.validateMcpServer.useMutation({
-    onSuccess: (result, variables) => {
-      setValidationResults((prev) => new Map(prev).set(variables.name, result));
-    },
-    onError: (err, variables) => {
-      setValidationResults((prev) =>
-        new Map(prev).set(variables.name, { success: false, error: err.message })
-      );
-    },
-  });
-
-  return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <h3 className="font-medium">MCP Servers</h3>
-        <Button variant="outline" size="sm" onClick={() => setShowForm(true)}>
-          <Plus className="h-4 w-4 mr-1" />
-          Add
-        </Button>
-      </div>
-
-      {mcpServers.length === 0 && !showForm ? (
-        <p className="text-sm text-muted-foreground">No global MCP servers configured.</p>
-      ) : (
-        <ul className="space-y-2">
-          {mcpServers.map((server) => {
-            const result = validationResults.get(server.name);
-            const isTesting =
-              validateMutation.isPending && validateMutation.variables?.name === server.name;
-            return (
-              <li key={server.id} className="space-y-1">
-                <div className="flex items-center gap-2 p-2 rounded-md bg-muted/50">
-                  <div className="flex-1 min-w-0">
-                    <div className="font-mono text-sm flex items-center gap-2">
-                      {server.name}
-                      <span className="text-xs text-muted-foreground font-sans uppercase">
-                        {server.type}
-                      </span>
-                    </div>
-                    <div className="text-xs text-muted-foreground truncate">
-                      {server.type === 'stdio'
-                        ? `${server.command} ${server.args.join(' ')}`
-                        : server.url}
-                    </div>
-                  </div>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => validateMutation.mutate({ name: server.name })}
-                    disabled={isTesting}
-                    title="Test connection"
-                  >
-                    {isTesting ? (
-                      <Spinner size="sm" className="h-4 w-4" />
-                    ) : (
-                      <Plug className="h-4 w-4" />
-                    )}
-                  </Button>
-                  <Button variant="ghost" size="sm" onClick={() => setEditingId(server.id)}>
-                    Edit
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => setDeleteMcpServer(server.name)}
-                    className="text-destructive hover:text-destructive"
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </Button>
-                </div>
-                {result && (
-                  <div
-                    className={`text-xs px-2 py-1 rounded flex items-center gap-1 ${
-                      result.success
-                        ? 'text-green-700 bg-green-50 dark:text-green-400 dark:bg-green-950'
-                        : 'text-red-700 bg-red-50 dark:text-red-400 dark:bg-red-950'
-                    }`}
-                  >
-                    {result.success ? (
-                      <>
-                        <Check className="h-3 w-3" />
-                        Connected
-                        {result.tools && result.tools.length > 0
-                          ? ` \u2014 ${result.tools.length} tool${result.tools.length === 1 ? '' : 's'}`
-                          : ''}
-                      </>
-                    ) : (
-                      <>
-                        <X className="h-3 w-3" />
-                        {result.error}
-                      </>
-                    )}
-                  </div>
-                )}
-              </li>
-            );
-          })}
-        </ul>
-      )}
-
-      {(showForm || editingId) && (
-        <GlobalMcpServerForm
-          existingServer={editingId ? mcpServers.find((s) => s.id === editingId) : undefined}
-          onClose={() => {
-            setShowForm(false);
-            setEditingId(null);
-          }}
-          onSuccess={() => {
-            setShowForm(false);
-            setEditingId(null);
-            onUpdate();
-          }}
-        />
-      )}
-
-      <AlertDialog
-        open={!!deleteMcpServer}
-        onOpenChange={(open) => !open && setDeleteMcpServer(null)}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete MCP server?</AlertDialogTitle>
-            <AlertDialogDescription>
-              This will delete the global MCP server <strong>{deleteMcpServer}</strong>.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() => deleteMcpServer && deleteMutation.mutate({ name: deleteMcpServer })}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            >
-              Delete
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    </div>
-  );
-}
-
-/** Shared key-value list editor for env vars and headers with secret support */
-function KeyValueListEditor({
-  label,
-  entries,
-  existingEntries,
-  onChange,
-  keyPlaceholder = 'KEY',
-  keyTransform,
-}: {
-  label: string;
-  entries: Array<{ key: string; value: string; isSecret: boolean }>;
-  existingEntries?: Record<string, { value: string; isSecret: boolean }>;
-  onChange: (entries: Array<{ key: string; value: string; isSecret: boolean }>) => void;
-  keyPlaceholder?: string;
-  keyTransform?: (key: string) => string;
-}) {
-  const addEntry = () => {
-    onChange([...entries, { key: '', value: '', isSecret: false }]);
-  };
-
-  const removeEntry = (index: number) => {
-    onChange(entries.filter((_, i) => i !== index));
-  };
-
-  const updateEntry = (
-    index: number,
-    field: 'key' | 'value' | 'isSecret',
-    value: string | boolean
-  ) => {
-    onChange(entries.map((entry, i) => (i === index ? { ...entry, [field]: value } : entry)));
-  };
-
-  return (
-    <div className="space-y-2">
-      <div className="flex items-center justify-between">
-        <Label>{label}</Label>
-        <Button type="button" variant="outline" size="sm" onClick={addEntry}>
-          <Plus className="h-4 w-4" />
-        </Button>
-      </div>
-      {entries.map((entry, index) => (
-        <div key={index} className="flex items-center gap-2">
-          <Input
-            value={entry.key}
-            onChange={(e) =>
-              updateEntry(
-                index,
-                'key',
-                keyTransform ? keyTransform(e.target.value) : e.target.value
-              )
-            }
-            placeholder={keyPlaceholder}
-            className="flex-1"
-          />
-          <Input
-            type={entry.isSecret ? 'password' : 'text'}
-            value={entry.value}
-            onChange={(e) => updateEntry(index, 'value', e.target.value)}
-            placeholder={existingEntries?.[entry.key]?.isSecret ? '(unchanged)' : 'value'}
-            className="flex-1"
-          />
-          <Switch
-            checked={entry.isSecret}
-            onCheckedChange={(checked) => updateEntry(index, 'isSecret', checked)}
-            title="Secret"
-          />
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={() => removeEntry(index)}
-            className="text-destructive"
-          >
-            <Trash2 className="h-4 w-4" />
-          </Button>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-function GlobalMcpServerForm({
-  existingServer,
-  onClose,
-  onSuccess,
-}: {
-  existingServer?: McpServer;
-  onClose: () => void;
-  onSuccess: () => void;
-}) {
-  const [name, setName] = useState(existingServer?.name ?? '');
-  const [serverType, setServerType] = useState<McpServerType>(existingServer?.type ?? 'stdio');
-  const [command, setCommand] = useState(existingServer?.command ?? '');
-  const [args, setArgs] = useState(existingServer?.args.join(' ') ?? '');
-  const [envVars, setEnvVars] = useState<Array<{ key: string; value: string; isSecret: boolean }>>(
-    existingServer?.env
-      ? Object.entries(existingServer.env).map(([key, { value, isSecret }]) => ({
-          key,
-          value: isSecret ? '' : value,
-          isSecret,
-        }))
-      : []
-  );
-  const [url, setUrl] = useState(existingServer?.url ?? '');
-  const [headers, setHeaders] = useState<Array<{ key: string; value: string; isSecret: boolean }>>(
-    existingServer?.headers
-      ? Object.entries(existingServer.headers).map(([key, { value, isSecret }]) => ({
-          key,
-          value: isSecret ? '' : value,
-          isSecret,
-        }))
-      : []
-  );
-  const [error, setError] = useState<string | null>(null);
-
-  const mutation = trpc.globalSettings.setMcpServer.useMutation({
-    onSuccess,
-    onError: (err) => setError(err.message),
-  });
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    setError(null);
-
-    if (!name) {
-      setError('Name is required');
-      return;
-    }
-
-    if (serverType === 'stdio') {
-      if (!command) {
-        setError('Command is required');
-        return;
-      }
-
-      const env = envVars.reduce(
-        (acc, { key, value, isSecret }) => {
-          if (key) {
-            acc[key] = { value, isSecret };
-          }
-          return acc;
-        },
-        {} as Record<string, { value: string; isSecret: boolean }>
-      );
-
-      mutation.mutate({
-        mcpServer: {
-          name,
-          type: 'stdio',
-          command,
-          args: args.split(/\s+/).filter(Boolean),
-          env: Object.keys(env).length > 0 ? env : undefined,
-        },
-      });
-    } else {
-      if (!url) {
-        setError('URL is required');
-        return;
-      }
-
-      const headersRecord = headers.reduce(
-        (acc, { key, value, isSecret }) => {
-          if (key) {
-            acc[key] = { value, isSecret };
-          }
-          return acc;
-        },
-        {} as Record<string, { value: string; isSecret: boolean }>
-      );
-
-      mutation.mutate({
-        mcpServer: {
-          name,
-          type: serverType,
-          url,
-          headers: Object.keys(headersRecord).length > 0 ? headersRecord : undefined,
-        },
-      });
-    }
-  };
-
-  return (
-    <form onSubmit={handleSubmit} className="space-y-4 p-4 border rounded-md">
-      <div className="space-y-2">
-        <Label htmlFor="global-mcp-name">Name</Label>
-        <Input
-          id="global-mcp-name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder="memory"
-          disabled={!!existingServer}
-        />
-      </div>
-
-      <div className="space-y-2">
-        <Label htmlFor="global-mcp-type">Type</Label>
-        <Select
-          value={serverType}
-          onValueChange={(value) => setServerType(value as McpServerType)}
-          disabled={!!existingServer}
-        >
-          <SelectTrigger id="global-mcp-type">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="stdio">Stdio (command)</SelectItem>
-            <SelectItem value="http">HTTP</SelectItem>
-            <SelectItem value="sse">SSE (Server-Sent Events)</SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
-
-      {serverType === 'stdio' ? (
-        <>
-          <div className="space-y-2">
-            <Label htmlFor="global-mcp-command">Command</Label>
-            <Input
-              id="global-mcp-command"
-              value={command}
-              onChange={(e) => setCommand(e.target.value)}
-              placeholder="npx"
-            />
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="global-mcp-args">Arguments (space-separated)</Label>
-            <Input
-              id="global-mcp-args"
-              value={args}
-              onChange={(e) => setArgs(e.target.value)}
-              placeholder="@anthropic/mcp-server-memory"
-            />
-          </div>
-
-          <KeyValueListEditor
-            label="Environment Variables"
-            entries={envVars}
-            existingEntries={existingServer?.env}
-            onChange={setEnvVars}
-            keyPlaceholder="KEY"
-            keyTransform={(key) => key.toUpperCase()}
-          />
-        </>
-      ) : (
-        <>
-          <div className="space-y-2">
-            <Label htmlFor="global-mcp-url">URL</Label>
-            <Input
-              id="global-mcp-url"
-              value={url}
-              onChange={(e) => setUrl(e.target.value)}
-              placeholder="https://mcp.example.com/sse"
-            />
-          </div>
-
-          <KeyValueListEditor
-            label="Headers"
-            entries={headers}
-            existingEntries={existingServer?.headers}
-            onChange={setHeaders}
-            keyPlaceholder="Header-Name"
-          />
-        </>
-      )}
-
-      {error && <p className="text-sm text-destructive">{error}</p>}
-
-      <div className="flex justify-end gap-2">
-        <Button type="button" variant="outline" onClick={onClose}>
-          Cancel
-        </Button>
-        <Button type="submit" disabled={mutation.isPending}>
-          {mutation.isPending ? <Spinner size="sm" /> : existingServer ? 'Update' : 'Add'}
-        </Button>
-      </div>
-    </form>
   );
 }

--- a/src/components/settings/RepoSettingsEditor.tsx
+++ b/src/components/settings/RepoSettingsEditor.tsx
@@ -9,35 +9,57 @@ import {
   SheetTitle,
 } from '@/components/ui/sheet';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Spinner } from '@/components/ui/spinner';
 import { Separator } from '@/components/ui/separator';
 import { Textarea } from '@/components/ui/textarea';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
 import { trpc } from '@/lib/trpc';
-import { Plus, Trash2, Eye, EyeOff, Star, FileText, Plug, Check, X } from 'lucide-react';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
+import { Plus, Star, FileText } from 'lucide-react';
+import { EnvVarSection } from './shared/EnvVarSection';
+import { McpServerSection } from './shared/McpServerSection';
+import type { EnvVarMutations } from './shared/EnvVarSection';
+import type { McpServerMutations } from './shared/McpServerSection';
 
 interface RepoSettingsEditorProps {
   repoFullName: string;
   onClose: () => void;
+}
+
+function useRepoEnvVarMutations(repoFullName: string, onUpdate: () => void): EnvVarMutations {
+  const utils = trpc.useUtils();
+  const deleteMutation = trpc.repoSettings.deleteEnvVar.useMutation({ onSuccess: onUpdate });
+  const setMutation = trpc.repoSettings.setEnvVar.useMutation();
+
+  return {
+    deleteEnvVar: async (name) => {
+      await deleteMutation.mutateAsync({ repoFullName, name });
+    },
+    setEnvVar: async (envVar) => {
+      await setMutation.mutateAsync({ repoFullName, envVar });
+    },
+    getSecretValue: async (name) => {
+      return await utils.repoSettings.getEnvVarValue.fetch({ repoFullName, name });
+    },
+  };
+}
+
+function useRepoMcpServerMutations(repoFullName: string, onUpdate: () => void): McpServerMutations {
+  const deleteMutation = trpc.repoSettings.deleteMcpServer.useMutation({ onSuccess: onUpdate });
+  const setMutation = trpc.repoSettings.setMcpServer.useMutation();
+  const validateMutation = trpc.repoSettings.validateMcpServer.useMutation();
+
+  return {
+    deleteMcpServer: async (name) => {
+      await deleteMutation.mutateAsync({ repoFullName, name });
+    },
+    setMcpServer: async (mcpServer) => {
+      await setMutation.mutateAsync({ repoFullName, mcpServer });
+    },
+    validateMcpServer: async (name) => {
+      return await validateMutation.mutateAsync({ repoFullName, name });
+    },
+  };
 }
 
 export function RepoSettingsEditor({ repoFullName, onClose }: RepoSettingsEditorProps) {
@@ -45,6 +67,8 @@ export function RepoSettingsEditor({ repoFullName, onClose }: RepoSettingsEditor
   const toggleFavorite = trpc.repoSettings.toggleFavorite.useMutation({
     onSuccess: () => refetch(),
   });
+  const envVarMutations = useRepoEnvVarMutations(repoFullName, refetch);
+  const mcpServerMutations = useRepoMcpServerMutations(repoFullName, refetch);
 
   return (
     <Sheet open onOpenChange={(open) => !open && onClose()}>
@@ -88,19 +112,21 @@ export function RepoSettingsEditor({ repoFullName, onClose }: RepoSettingsEditor
             <Separator />
 
             {/* Environment Variables */}
-            <EnvVarsSection
-              repoFullName={repoFullName}
+            <EnvVarSection
               envVars={data?.envVars ?? []}
+              mutations={envVarMutations}
               onUpdate={refetch}
+              idPrefix="env"
             />
 
             <Separator />
 
             {/* MCP Servers */}
-            <McpServersSection
-              repoFullName={repoFullName}
+            <McpServerSection
               mcpServers={data?.mcpServers ?? []}
+              mutations={mcpServerMutations}
               onUpdate={refetch}
+              idPrefix="mcp"
             />
           </div>
         )}
@@ -189,721 +215,5 @@ function CustomSystemPromptSection({
         </Button>
       )}
     </div>
-  );
-}
-
-interface EnvVar {
-  id: string;
-  name: string;
-  value: string;
-  isSecret: boolean;
-}
-
-function EnvVarsSection({
-  repoFullName,
-  envVars,
-  onUpdate,
-}: {
-  repoFullName: string;
-  envVars: EnvVar[];
-  onUpdate: () => void;
-}) {
-  const [showForm, setShowForm] = useState(false);
-  const [editingId, setEditingId] = useState<string | null>(null);
-  const [deleteEnvVar, setDeleteEnvVar] = useState<string | null>(null);
-  // Map from env var name to its revealed value
-  const [revealedSecrets, setRevealedSecrets] = useState<Map<string, string>>(new Map());
-  const [loadingSecret, setLoadingSecret] = useState<string | null>(null);
-
-  const deleteMutation = trpc.repoSettings.deleteEnvVar.useMutation({
-    onSuccess: () => {
-      onUpdate();
-      setDeleteEnvVar(null);
-    },
-  });
-
-  const utils = trpc.useUtils();
-
-  const toggleSecretVisibility = async (name: string) => {
-    if (revealedSecrets.has(name)) {
-      // Hide the secret
-      setRevealedSecrets((prev) => {
-        const next = new Map(prev);
-        next.delete(name);
-        return next;
-      });
-    } else {
-      // Fetch and reveal the secret
-      setLoadingSecret(name);
-      try {
-        const result = await utils.repoSettings.getEnvVarValue.fetch({ repoFullName, name });
-        setRevealedSecrets((prev) => {
-          const next = new Map(prev);
-          next.set(name, result.value);
-          return next;
-        });
-      } finally {
-        setLoadingSecret(null);
-      }
-    }
-  };
-
-  return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <h3 className="font-medium">Environment Variables</h3>
-        <Button variant="outline" size="sm" onClick={() => setShowForm(true)}>
-          <Plus className="h-4 w-4 mr-1" />
-          Add
-        </Button>
-      </div>
-
-      {envVars.length === 0 && !showForm ? (
-        <p className="text-sm text-muted-foreground">No environment variables configured.</p>
-      ) : (
-        <ul className="space-y-2">
-          {envVars.map((envVar) => (
-            <li key={envVar.id} className="flex items-center gap-2 p-2 rounded-md bg-muted/50">
-              <div className="flex-1 min-w-0">
-                <div className="font-mono text-sm">{envVar.name}</div>
-                <div className="text-xs text-muted-foreground flex items-center gap-1">
-                  {envVar.isSecret ? (
-                    <>
-                      <span>
-                        {revealedSecrets.has(envVar.name)
-                          ? revealedSecrets.get(envVar.name)
-                          : '••••••••'}
-                      </span>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="h-5 w-5 p-0"
-                        onClick={() => toggleSecretVisibility(envVar.name)}
-                        disabled={loadingSecret === envVar.name}
-                      >
-                        {loadingSecret === envVar.name ? (
-                          <Spinner size="sm" className="h-3 w-3" />
-                        ) : revealedSecrets.has(envVar.name) ? (
-                          <EyeOff className="h-3 w-3" />
-                        ) : (
-                          <Eye className="h-3 w-3" />
-                        )}
-                      </Button>
-                    </>
-                  ) : (
-                    <span className="truncate">{envVar.value}</span>
-                  )}
-                </div>
-              </div>
-              <Button variant="ghost" size="sm" onClick={() => setEditingId(envVar.id)}>
-                Edit
-              </Button>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => setDeleteEnvVar(envVar.name)}
-                className="text-destructive hover:text-destructive"
-              >
-                <Trash2 className="h-4 w-4" />
-              </Button>
-            </li>
-          ))}
-        </ul>
-      )}
-
-      {(showForm || editingId) && (
-        <EnvVarForm
-          repoFullName={repoFullName}
-          existingEnvVar={editingId ? envVars.find((e) => e.id === editingId) : undefined}
-          onClose={() => {
-            setShowForm(false);
-            setEditingId(null);
-          }}
-          onSuccess={() => {
-            setShowForm(false);
-            setEditingId(null);
-            onUpdate();
-          }}
-        />
-      )}
-
-      <AlertDialog open={!!deleteEnvVar} onOpenChange={(open) => !open && setDeleteEnvVar(null)}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete environment variable?</AlertDialogTitle>
-            <AlertDialogDescription>
-              This will delete the environment variable <strong>{deleteEnvVar}</strong>.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() =>
-                deleteEnvVar && deleteMutation.mutate({ repoFullName, name: deleteEnvVar })
-              }
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            >
-              Delete
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    </div>
-  );
-}
-
-function EnvVarForm({
-  repoFullName,
-  existingEnvVar,
-  onClose,
-  onSuccess,
-}: {
-  repoFullName: string;
-  existingEnvVar?: EnvVar;
-  onClose: () => void;
-  onSuccess: () => void;
-}) {
-  const [name, setName] = useState(existingEnvVar?.name ?? '');
-  const [value, setValue] = useState(existingEnvVar?.isSecret ? '' : (existingEnvVar?.value ?? ''));
-  const [isSecret, setIsSecret] = useState(existingEnvVar?.isSecret ?? false);
-  const [error, setError] = useState<string | null>(null);
-
-  const mutation = trpc.repoSettings.setEnvVar.useMutation({
-    onSuccess,
-    onError: (err) => setError(err.message),
-  });
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    setError(null);
-
-    if (!name.match(/^[A-Za-z_][A-Za-z0-9_]*$/)) {
-      setError(
-        'Name must start with a letter or underscore and contain only alphanumeric characters and underscores'
-      );
-      return;
-    }
-
-    // For secrets being edited, only require value if it's a new secret or value was changed
-    if (!existingEnvVar?.isSecret && !value) {
-      setError('Value is required');
-      return;
-    }
-
-    mutation.mutate({
-      repoFullName,
-      envVar: {
-        name,
-        value: existingEnvVar?.isSecret && !value ? existingEnvVar.value : value,
-        isSecret,
-      },
-    });
-  };
-
-  return (
-    <form onSubmit={handleSubmit} className="space-y-4 p-4 border rounded-md">
-      <div className="space-y-2">
-        <Label htmlFor="env-name">Name</Label>
-        <Input
-          id="env-name"
-          value={name}
-          onChange={(e) => setName(e.target.value.toUpperCase())}
-          placeholder="MY_API_KEY"
-          disabled={!!existingEnvVar}
-        />
-      </div>
-
-      <div className="space-y-2">
-        <Label htmlFor="env-value">Value</Label>
-        <Input
-          id="env-value"
-          type={isSecret ? 'password' : 'text'}
-          value={value}
-          onChange={(e) => setValue(e.target.value)}
-          placeholder={existingEnvVar?.isSecret ? '(unchanged)' : 'Enter value'}
-        />
-      </div>
-
-      <div className="flex items-center gap-2">
-        <Switch id="env-secret" checked={isSecret} onCheckedChange={setIsSecret} />
-        <Label htmlFor="env-secret">Secret (encrypted at rest)</Label>
-      </div>
-
-      {error && <p className="text-sm text-destructive">{error}</p>}
-
-      <div className="flex justify-end gap-2">
-        <Button type="button" variant="outline" onClick={onClose}>
-          Cancel
-        </Button>
-        <Button type="submit" disabled={mutation.isPending}>
-          {mutation.isPending ? <Spinner size="sm" /> : existingEnvVar ? 'Update' : 'Add'}
-        </Button>
-      </div>
-    </form>
-  );
-}
-
-interface McpServer {
-  id: string;
-  name: string;
-  type: 'stdio' | 'http' | 'sse';
-  command: string;
-  args: string[];
-  env: Record<string, { value: string; isSecret: boolean }>;
-  url?: string;
-  headers: Record<string, { value: string; isSecret: boolean }>;
-}
-
-function McpServersSection({
-  repoFullName,
-  mcpServers,
-  onUpdate,
-}: {
-  repoFullName: string;
-  mcpServers: McpServer[];
-  onUpdate: () => void;
-}) {
-  const [showForm, setShowForm] = useState(false);
-  const [editingId, setEditingId] = useState<string | null>(null);
-  const [deleteMcpServer, setDeleteMcpServer] = useState<string | null>(null);
-  const [validationResults, setValidationResults] = useState<
-    Map<string, { success: boolean; error?: string; tools?: string[] }>
-  >(new Map());
-
-  const deleteMutation = trpc.repoSettings.deleteMcpServer.useMutation({
-    onSuccess: () => {
-      onUpdate();
-      setDeleteMcpServer(null);
-    },
-  });
-
-  const validateMutation = trpc.repoSettings.validateMcpServer.useMutation({
-    onSuccess: (result, variables) => {
-      setValidationResults((prev) => new Map(prev).set(variables.name, result));
-    },
-    onError: (err, variables) => {
-      setValidationResults((prev) =>
-        new Map(prev).set(variables.name, { success: false, error: err.message })
-      );
-    },
-  });
-
-  return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <h3 className="font-medium">MCP Servers</h3>
-        <Button variant="outline" size="sm" onClick={() => setShowForm(true)}>
-          <Plus className="h-4 w-4 mr-1" />
-          Add
-        </Button>
-      </div>
-
-      {mcpServers.length === 0 && !showForm ? (
-        <p className="text-sm text-muted-foreground">No MCP servers configured.</p>
-      ) : (
-        <ul className="space-y-2">
-          {mcpServers.map((server) => {
-            const result = validationResults.get(server.name);
-            const isTesting =
-              validateMutation.isPending && validateMutation.variables?.name === server.name;
-            return (
-              <li key={server.id} className="space-y-1">
-                <div className="flex items-center gap-2 p-2 rounded-md bg-muted/50">
-                  <div className="flex-1 min-w-0">
-                    <div className="font-mono text-sm flex items-center gap-2">
-                      {server.name}
-                      <span className="text-xs text-muted-foreground font-sans uppercase">
-                        {server.type}
-                      </span>
-                    </div>
-                    <div className="text-xs text-muted-foreground truncate">
-                      {server.type === 'stdio'
-                        ? `${server.command} ${server.args.join(' ')}`
-                        : server.url}
-                    </div>
-                  </div>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => validateMutation.mutate({ repoFullName, name: server.name })}
-                    disabled={isTesting}
-                    title="Test connection"
-                  >
-                    {isTesting ? (
-                      <Spinner size="sm" className="h-4 w-4" />
-                    ) : (
-                      <Plug className="h-4 w-4" />
-                    )}
-                  </Button>
-                  <Button variant="ghost" size="sm" onClick={() => setEditingId(server.id)}>
-                    Edit
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => setDeleteMcpServer(server.name)}
-                    className="text-destructive hover:text-destructive"
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </Button>
-                </div>
-                {result && (
-                  <div
-                    className={`text-xs px-2 py-1 rounded flex items-center gap-1 ${
-                      result.success
-                        ? 'text-green-700 bg-green-50 dark:text-green-400 dark:bg-green-950'
-                        : 'text-red-700 bg-red-50 dark:text-red-400 dark:bg-red-950'
-                    }`}
-                  >
-                    {result.success ? (
-                      <>
-                        <Check className="h-3 w-3" />
-                        Connected
-                        {result.tools && result.tools.length > 0
-                          ? ` \u2014 ${result.tools.length} tool${result.tools.length === 1 ? '' : 's'}`
-                          : ''}
-                      </>
-                    ) : (
-                      <>
-                        <X className="h-3 w-3" />
-                        {result.error}
-                      </>
-                    )}
-                  </div>
-                )}
-              </li>
-            );
-          })}
-        </ul>
-      )}
-
-      {(showForm || editingId) && (
-        <McpServerForm
-          repoFullName={repoFullName}
-          existingServer={editingId ? mcpServers.find((s) => s.id === editingId) : undefined}
-          onClose={() => {
-            setShowForm(false);
-            setEditingId(null);
-          }}
-          onSuccess={() => {
-            setShowForm(false);
-            setEditingId(null);
-            onUpdate();
-          }}
-        />
-      )}
-
-      <AlertDialog
-        open={!!deleteMcpServer}
-        onOpenChange={(open) => !open && setDeleteMcpServer(null)}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete MCP server?</AlertDialogTitle>
-            <AlertDialogDescription>
-              This will delete the MCP server <strong>{deleteMcpServer}</strong>.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() =>
-                deleteMcpServer && deleteMutation.mutate({ repoFullName, name: deleteMcpServer })
-              }
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            >
-              Delete
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    </div>
-  );
-}
-
-type McpServerType = 'stdio' | 'http' | 'sse';
-
-/** Shared key-value list editor for env vars and headers with secret support */
-function KeyValueListEditor({
-  label,
-  entries,
-  existingEntries,
-  onChange,
-  keyPlaceholder = 'KEY',
-  keyTransform,
-}: {
-  label: string;
-  entries: Array<{ key: string; value: string; isSecret: boolean }>;
-  existingEntries?: Record<string, { value: string; isSecret: boolean }>;
-  onChange: (entries: Array<{ key: string; value: string; isSecret: boolean }>) => void;
-  keyPlaceholder?: string;
-  keyTransform?: (key: string) => string;
-}) {
-  const addEntry = () => {
-    onChange([...entries, { key: '', value: '', isSecret: false }]);
-  };
-
-  const removeEntry = (index: number) => {
-    onChange(entries.filter((_, i) => i !== index));
-  };
-
-  const updateEntry = (
-    index: number,
-    field: 'key' | 'value' | 'isSecret',
-    value: string | boolean
-  ) => {
-    onChange(entries.map((entry, i) => (i === index ? { ...entry, [field]: value } : entry)));
-  };
-
-  return (
-    <div className="space-y-2">
-      <div className="flex items-center justify-between">
-        <Label>{label}</Label>
-        <Button type="button" variant="outline" size="sm" onClick={addEntry}>
-          <Plus className="h-4 w-4" />
-        </Button>
-      </div>
-      {entries.map((entry, index) => (
-        <div key={index} className="flex items-center gap-2">
-          <Input
-            value={entry.key}
-            onChange={(e) =>
-              updateEntry(
-                index,
-                'key',
-                keyTransform ? keyTransform(e.target.value) : e.target.value
-              )
-            }
-            placeholder={keyPlaceholder}
-            className="flex-1"
-          />
-          <Input
-            type={entry.isSecret ? 'password' : 'text'}
-            value={entry.value}
-            onChange={(e) => updateEntry(index, 'value', e.target.value)}
-            placeholder={existingEntries?.[entry.key]?.isSecret ? '(unchanged)' : 'value'}
-            className="flex-1"
-          />
-          <Switch
-            checked={entry.isSecret}
-            onCheckedChange={(checked) => updateEntry(index, 'isSecret', checked)}
-            title="Secret"
-          />
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={() => removeEntry(index)}
-            className="text-destructive"
-          >
-            <Trash2 className="h-4 w-4" />
-          </Button>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-function McpServerForm({
-  repoFullName,
-  existingServer,
-  onClose,
-  onSuccess,
-}: {
-  repoFullName: string;
-  existingServer?: McpServer;
-  onClose: () => void;
-  onSuccess: () => void;
-}) {
-  const [name, setName] = useState(existingServer?.name ?? '');
-  const [serverType, setServerType] = useState<McpServerType>(existingServer?.type ?? 'stdio');
-  // Stdio fields
-  const [command, setCommand] = useState(existingServer?.command ?? '');
-  const [args, setArgs] = useState(existingServer?.args.join(' ') ?? '');
-  const [envVars, setEnvVars] = useState<Array<{ key: string; value: string; isSecret: boolean }>>(
-    existingServer?.env
-      ? Object.entries(existingServer.env).map(([key, { value, isSecret }]) => ({
-          key,
-          value: isSecret ? '' : value,
-          isSecret,
-        }))
-      : []
-  );
-  // HTTP/SSE fields
-  const [url, setUrl] = useState(existingServer?.url ?? '');
-  const [headers, setHeaders] = useState<Array<{ key: string; value: string; isSecret: boolean }>>(
-    existingServer?.headers
-      ? Object.entries(existingServer.headers).map(([key, { value, isSecret }]) => ({
-          key,
-          value: isSecret ? '' : value,
-          isSecret,
-        }))
-      : []
-  );
-  const [error, setError] = useState<string | null>(null);
-
-  const mutation = trpc.repoSettings.setMcpServer.useMutation({
-    onSuccess,
-    onError: (err) => setError(err.message),
-  });
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    setError(null);
-
-    if (!name) {
-      setError('Name is required');
-      return;
-    }
-
-    if (serverType === 'stdio') {
-      if (!command) {
-        setError('Command is required');
-        return;
-      }
-
-      const env = envVars.reduce(
-        (acc, { key, value, isSecret }) => {
-          if (key) {
-            acc[key] = { value, isSecret };
-          }
-          return acc;
-        },
-        {} as Record<string, { value: string; isSecret: boolean }>
-      );
-
-      mutation.mutate({
-        repoFullName,
-        mcpServer: {
-          name,
-          type: 'stdio',
-          command,
-          args: args.split(/\s+/).filter(Boolean),
-          env: Object.keys(env).length > 0 ? env : undefined,
-        },
-      });
-    } else {
-      if (!url) {
-        setError('URL is required');
-        return;
-      }
-
-      const headersRecord = headers.reduce(
-        (acc, { key, value, isSecret }) => {
-          if (key) {
-            acc[key] = { value, isSecret };
-          }
-          return acc;
-        },
-        {} as Record<string, { value: string; isSecret: boolean }>
-      );
-
-      mutation.mutate({
-        repoFullName,
-        mcpServer: {
-          name,
-          type: serverType,
-          url,
-          headers: Object.keys(headersRecord).length > 0 ? headersRecord : undefined,
-        },
-      });
-    }
-  };
-
-  return (
-    <form onSubmit={handleSubmit} className="space-y-4 p-4 border rounded-md">
-      <div className="space-y-2">
-        <Label htmlFor="mcp-name">Name</Label>
-        <Input
-          id="mcp-name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder="memory"
-          disabled={!!existingServer}
-        />
-      </div>
-
-      <div className="space-y-2">
-        <Label htmlFor="mcp-type">Type</Label>
-        <Select
-          value={serverType}
-          onValueChange={(value) => setServerType(value as McpServerType)}
-          disabled={!!existingServer}
-        >
-          <SelectTrigger id="mcp-type">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="stdio">Stdio (command)</SelectItem>
-            <SelectItem value="http">HTTP</SelectItem>
-            <SelectItem value="sse">SSE (Server-Sent Events)</SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
-
-      {serverType === 'stdio' ? (
-        <>
-          <div className="space-y-2">
-            <Label htmlFor="mcp-command">Command</Label>
-            <Input
-              id="mcp-command"
-              value={command}
-              onChange={(e) => setCommand(e.target.value)}
-              placeholder="npx"
-            />
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="mcp-args">Arguments (space-separated)</Label>
-            <Input
-              id="mcp-args"
-              value={args}
-              onChange={(e) => setArgs(e.target.value)}
-              placeholder="@anthropic/mcp-server-memory"
-            />
-          </div>
-
-          <KeyValueListEditor
-            label="Environment Variables"
-            entries={envVars}
-            existingEntries={existingServer?.env}
-            onChange={setEnvVars}
-            keyPlaceholder="KEY"
-            keyTransform={(key) => key.toUpperCase()}
-          />
-        </>
-      ) : (
-        <>
-          <div className="space-y-2">
-            <Label htmlFor="mcp-url">URL</Label>
-            <Input
-              id="mcp-url"
-              value={url}
-              onChange={(e) => setUrl(e.target.value)}
-              placeholder="https://mcp.example.com/sse"
-            />
-          </div>
-
-          <KeyValueListEditor
-            label="Headers"
-            entries={headers}
-            existingEntries={existingServer?.headers}
-            onChange={setHeaders}
-            keyPlaceholder="Header-Name"
-          />
-        </>
-      )}
-
-      {error && <p className="text-sm text-destructive">{error}</p>}
-
-      <div className="flex justify-end gap-2">
-        <Button type="button" variant="outline" onClick={onClose}>
-          Cancel
-        </Button>
-        <Button type="submit" disabled={mutation.isPending}>
-          {mutation.isPending ? <Spinner size="sm" /> : existingServer ? 'Update' : 'Add'}
-        </Button>
-      </div>
-    </form>
   );
 }

--- a/src/components/settings/shared/EnvVarSection.tsx
+++ b/src/components/settings/shared/EnvVarSection.tsx
@@ -1,0 +1,281 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { Spinner } from '@/components/ui/spinner';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Plus, Trash2, Eye, EyeOff } from 'lucide-react';
+import type { EnvVar } from '@/lib/settings-types';
+
+export interface EnvVarMutations {
+  deleteEnvVar: (name: string) => Promise<void>;
+  setEnvVar: (envVar: { name: string; value: string; isSecret: boolean }) => Promise<void>;
+  getSecretValue: (name: string) => Promise<{ value: string }>;
+}
+
+interface EnvVarSectionProps {
+  envVars: EnvVar[];
+  mutations: EnvVarMutations;
+  onUpdate: () => void;
+  emptyMessage?: string;
+  deleteDescriptionPrefix?: string;
+  idPrefix?: string;
+}
+
+export function EnvVarSection({
+  envVars,
+  mutations,
+  onUpdate,
+  emptyMessage = 'No environment variables configured.',
+  deleteDescriptionPrefix = 'This will delete the environment variable',
+  idPrefix = 'env',
+}: EnvVarSectionProps) {
+  const [showForm, setShowForm] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [revealedSecrets, setRevealedSecrets] = useState<Map<string, string>>(new Map());
+  const [loadingSecret, setLoadingSecret] = useState<string | null>(null);
+
+  const toggleSecretVisibility = async (name: string) => {
+    if (revealedSecrets.has(name)) {
+      setRevealedSecrets((prev) => {
+        const next = new Map(prev);
+        next.delete(name);
+        return next;
+      });
+    } else {
+      setLoadingSecret(name);
+      try {
+        const result = await mutations.getSecretValue(name);
+        setRevealedSecrets((prev) => {
+          const next = new Map(prev);
+          next.set(name, result.value);
+          return next;
+        });
+      } finally {
+        setLoadingSecret(null);
+      }
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    setIsDeleting(true);
+    try {
+      await mutations.deleteEnvVar(deleteTarget);
+      setDeleteTarget(null);
+      onUpdate();
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="font-medium">Environment Variables</h3>
+        <Button variant="outline" size="sm" onClick={() => setShowForm(true)}>
+          <Plus className="h-4 w-4 mr-1" />
+          Add
+        </Button>
+      </div>
+
+      {envVars.length === 0 && !showForm ? (
+        <p className="text-sm text-muted-foreground">{emptyMessage}</p>
+      ) : (
+        <ul className="space-y-2">
+          {envVars.map((envVar) => (
+            <li key={envVar.id} className="flex items-center gap-2 p-2 rounded-md bg-muted/50">
+              <div className="flex-1 min-w-0">
+                <div className="font-mono text-sm">{envVar.name}</div>
+                <div className="text-xs text-muted-foreground flex items-center gap-1">
+                  {envVar.isSecret ? (
+                    <>
+                      <span>
+                        {revealedSecrets.has(envVar.name)
+                          ? revealedSecrets.get(envVar.name)
+                          : '••••••••'}
+                      </span>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-5 w-5 p-0"
+                        onClick={() => toggleSecretVisibility(envVar.name)}
+                        disabled={loadingSecret === envVar.name}
+                      >
+                        {loadingSecret === envVar.name ? (
+                          <Spinner size="sm" className="h-3 w-3" />
+                        ) : revealedSecrets.has(envVar.name) ? (
+                          <EyeOff className="h-3 w-3" />
+                        ) : (
+                          <Eye className="h-3 w-3" />
+                        )}
+                      </Button>
+                    </>
+                  ) : (
+                    <span className="truncate">{envVar.value}</span>
+                  )}
+                </div>
+              </div>
+              <Button variant="ghost" size="sm" onClick={() => setEditingId(envVar.id)}>
+                Edit
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setDeleteTarget(envVar.name)}
+                className="text-destructive hover:text-destructive"
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {(showForm || editingId) && (
+        <EnvVarForm
+          existingEnvVar={editingId ? envVars.find((e) => e.id === editingId) : undefined}
+          onClose={() => {
+            setShowForm(false);
+            setEditingId(null);
+          }}
+          onSuccess={() => {
+            setShowForm(false);
+            setEditingId(null);
+            onUpdate();
+          }}
+          setEnvVar={mutations.setEnvVar}
+          idPrefix={idPrefix}
+        />
+      )}
+
+      <AlertDialog open={!!deleteTarget} onOpenChange={(open) => !open && setDeleteTarget(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete environment variable?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {deleteDescriptionPrefix} <strong>{deleteTarget}</strong>.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              disabled={isDeleting}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
+function EnvVarForm({
+  existingEnvVar,
+  onClose,
+  onSuccess,
+  setEnvVar,
+  idPrefix,
+}: {
+  existingEnvVar?: EnvVar;
+  onClose: () => void;
+  onSuccess: () => void;
+  setEnvVar: EnvVarMutations['setEnvVar'];
+  idPrefix: string;
+}) {
+  const [name, setName] = useState(existingEnvVar?.name ?? '');
+  const [value, setValue] = useState(existingEnvVar?.isSecret ? '' : (existingEnvVar?.value ?? ''));
+  const [isSecret, setIsSecret] = useState(existingEnvVar?.isSecret ?? false);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, setIsPending] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (!name.match(/^[A-Za-z_][A-Za-z0-9_]*$/)) {
+      setError(
+        'Name must start with a letter or underscore and contain only alphanumeric characters and underscores'
+      );
+      return;
+    }
+
+    if (!existingEnvVar?.isSecret && !value) {
+      setError('Value is required');
+      return;
+    }
+
+    setIsPending(true);
+    try {
+      await setEnvVar({
+        name,
+        value: existingEnvVar?.isSecret && !value ? existingEnvVar.value : value,
+        isSecret,
+      });
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 p-4 border rounded-md">
+      <div className="space-y-2">
+        <Label htmlFor={`${idPrefix}-name`}>Name</Label>
+        <Input
+          id={`${idPrefix}-name`}
+          value={name}
+          onChange={(e) => setName(e.target.value.toUpperCase())}
+          placeholder="MY_API_KEY"
+          disabled={!!existingEnvVar}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor={`${idPrefix}-value`}>Value</Label>
+        <Input
+          id={`${idPrefix}-value`}
+          type={isSecret ? 'password' : 'text'}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder={existingEnvVar?.isSecret ? '(unchanged)' : 'Enter value'}
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Switch id={`${idPrefix}-secret`} checked={isSecret} onCheckedChange={setIsSecret} />
+        <Label htmlFor={`${idPrefix}-secret`}>Secret (encrypted at rest)</Label>
+      </div>
+
+      {error && <p className="text-sm text-destructive">{error}</p>}
+
+      <div className="flex justify-end gap-2">
+        <Button type="button" variant="outline" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button type="submit" disabled={isPending}>
+          {isPending ? <Spinner size="sm" /> : existingEnvVar ? 'Update' : 'Add'}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/settings/shared/KeyValueListEditor.tsx
+++ b/src/components/settings/shared/KeyValueListEditor.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { Plus, Trash2 } from 'lucide-react';
+
+interface KeyValueEntry {
+  key: string;
+  value: string;
+  isSecret: boolean;
+}
+
+interface KeyValueListEditorProps {
+  label: string;
+  entries: KeyValueEntry[];
+  existingEntries?: Record<string, { value: string; isSecret: boolean }>;
+  onChange: (entries: KeyValueEntry[]) => void;
+  keyPlaceholder?: string;
+  keyTransform?: (key: string) => string;
+}
+
+export function KeyValueListEditor({
+  label,
+  entries,
+  existingEntries,
+  onChange,
+  keyPlaceholder = 'KEY',
+  keyTransform,
+}: KeyValueListEditorProps) {
+  const addEntry = () => {
+    onChange([...entries, { key: '', value: '', isSecret: false }]);
+  };
+
+  const removeEntry = (index: number) => {
+    onChange(entries.filter((_, i) => i !== index));
+  };
+
+  const updateEntry = (
+    index: number,
+    field: 'key' | 'value' | 'isSecret',
+    value: string | boolean
+  ) => {
+    onChange(entries.map((entry, i) => (i === index ? { ...entry, [field]: value } : entry)));
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <Label>{label}</Label>
+        <Button type="button" variant="outline" size="sm" onClick={addEntry}>
+          <Plus className="h-4 w-4" />
+        </Button>
+      </div>
+      {entries.map((entry, index) => (
+        <div key={index} className="flex items-center gap-2">
+          <Input
+            value={entry.key}
+            onChange={(e) =>
+              updateEntry(
+                index,
+                'key',
+                keyTransform ? keyTransform(e.target.value) : e.target.value
+              )
+            }
+            placeholder={keyPlaceholder}
+            className="flex-1"
+          />
+          <Input
+            type={entry.isSecret ? 'password' : 'text'}
+            value={entry.value}
+            onChange={(e) => updateEntry(index, 'value', e.target.value)}
+            placeholder={existingEntries?.[entry.key]?.isSecret ? '(unchanged)' : 'value'}
+            className="flex-1"
+          />
+          <Switch
+            checked={entry.isSecret}
+            onCheckedChange={(checked) => updateEntry(index, 'isSecret', checked)}
+            title="Secret"
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => removeEntry(index)}
+            className="text-destructive"
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/settings/shared/McpServerSection.tsx
+++ b/src/components/settings/shared/McpServerSection.tsx
@@ -1,0 +1,438 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Spinner } from '@/components/ui/spinner';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Plus, Trash2, Plug, Check, X } from 'lucide-react';
+import { KeyValueListEditor } from './KeyValueListEditor';
+import type { McpServer, McpServerType, ValidationResult } from '@/lib/settings-types';
+
+interface StdioMcpServerInput {
+  name: string;
+  type: 'stdio';
+  command: string;
+  args: string[];
+  env?: Record<string, { value: string; isSecret: boolean }>;
+}
+
+interface HttpSseMcpServerInput {
+  name: string;
+  type: 'http' | 'sse';
+  url: string;
+  headers?: Record<string, { value: string; isSecret: boolean }>;
+}
+
+type McpServerInput = StdioMcpServerInput | HttpSseMcpServerInput;
+
+export interface McpServerMutations {
+  deleteMcpServer: (name: string) => Promise<void>;
+  setMcpServer: (mcpServer: McpServerInput) => Promise<void>;
+  validateMcpServer: (name: string) => Promise<ValidationResult>;
+}
+
+interface McpServerSectionProps {
+  mcpServers: McpServer[];
+  mutations: McpServerMutations;
+  onUpdate: () => void;
+  emptyMessage?: string;
+  deleteDescriptionPrefix?: string;
+  idPrefix?: string;
+}
+
+export function McpServerSection({
+  mcpServers,
+  mutations,
+  onUpdate,
+  emptyMessage = 'No MCP servers configured.',
+  deleteDescriptionPrefix = 'This will delete the MCP server',
+  idPrefix = 'mcp',
+}: McpServerSectionProps) {
+  const [showForm, setShowForm] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [validationResults, setValidationResults] = useState<Map<string, ValidationResult>>(
+    new Map()
+  );
+  const [validatingServer, setValidatingServer] = useState<string | null>(null);
+
+  const handleValidate = async (name: string) => {
+    setValidatingServer(name);
+    try {
+      const result = await mutations.validateMcpServer(name);
+      setValidationResults((prev) => new Map(prev).set(name, result));
+    } catch (err) {
+      setValidationResults((prev) =>
+        new Map(prev).set(name, {
+          success: false,
+          error: err instanceof Error ? err.message : 'Validation failed',
+        })
+      );
+    } finally {
+      setValidatingServer(null);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    setIsDeleting(true);
+    try {
+      await mutations.deleteMcpServer(deleteTarget);
+      setDeleteTarget(null);
+      onUpdate();
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="font-medium">MCP Servers</h3>
+        <Button variant="outline" size="sm" onClick={() => setShowForm(true)}>
+          <Plus className="h-4 w-4 mr-1" />
+          Add
+        </Button>
+      </div>
+
+      {mcpServers.length === 0 && !showForm ? (
+        <p className="text-sm text-muted-foreground">{emptyMessage}</p>
+      ) : (
+        <ul className="space-y-2">
+          {mcpServers.map((server) => {
+            const result = validationResults.get(server.name);
+            const isTesting = validatingServer === server.name;
+            return (
+              <li key={server.id} className="space-y-1">
+                <div className="flex items-center gap-2 p-2 rounded-md bg-muted/50">
+                  <div className="flex-1 min-w-0">
+                    <div className="font-mono text-sm flex items-center gap-2">
+                      {server.name}
+                      <span className="text-xs text-muted-foreground font-sans uppercase">
+                        {server.type}
+                      </span>
+                    </div>
+                    <div className="text-xs text-muted-foreground truncate">
+                      {server.type === 'stdio'
+                        ? `${server.command} ${server.args.join(' ')}`
+                        : server.url}
+                    </div>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => handleValidate(server.name)}
+                    disabled={isTesting}
+                    title="Test connection"
+                  >
+                    {isTesting ? (
+                      <Spinner size="sm" className="h-4 w-4" />
+                    ) : (
+                      <Plug className="h-4 w-4" />
+                    )}
+                  </Button>
+                  <Button variant="ghost" size="sm" onClick={() => setEditingId(server.id)}>
+                    Edit
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setDeleteTarget(server.name)}
+                    className="text-destructive hover:text-destructive"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
+                {result && (
+                  <div
+                    className={`text-xs px-2 py-1 rounded flex items-center gap-1 ${
+                      result.success
+                        ? 'text-green-700 bg-green-50 dark:text-green-400 dark:bg-green-950'
+                        : 'text-red-700 bg-red-50 dark:text-red-400 dark:bg-red-950'
+                    }`}
+                  >
+                    {result.success ? (
+                      <>
+                        <Check className="h-3 w-3" />
+                        Connected
+                        {result.tools && result.tools.length > 0
+                          ? ` \u2014 ${result.tools.length} tool${result.tools.length === 1 ? '' : 's'}`
+                          : ''}
+                      </>
+                    ) : (
+                      <>
+                        <X className="h-3 w-3" />
+                        {result.error}
+                      </>
+                    )}
+                  </div>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {(showForm || editingId) && (
+        <McpServerForm
+          existingServer={editingId ? mcpServers.find((s) => s.id === editingId) : undefined}
+          onClose={() => {
+            setShowForm(false);
+            setEditingId(null);
+          }}
+          onSuccess={() => {
+            setShowForm(false);
+            setEditingId(null);
+            onUpdate();
+          }}
+          setMcpServer={mutations.setMcpServer}
+          idPrefix={idPrefix}
+        />
+      )}
+
+      <AlertDialog open={!!deleteTarget} onOpenChange={(open) => !open && setDeleteTarget(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete MCP server?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {deleteDescriptionPrefix} <strong>{deleteTarget}</strong>.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              disabled={isDeleting}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
+function McpServerForm({
+  existingServer,
+  onClose,
+  onSuccess,
+  setMcpServer,
+  idPrefix,
+}: {
+  existingServer?: McpServer;
+  onClose: () => void;
+  onSuccess: () => void;
+  setMcpServer: McpServerMutations['setMcpServer'];
+  idPrefix: string;
+}) {
+  const [name, setName] = useState(existingServer?.name ?? '');
+  const [serverType, setServerType] = useState<McpServerType>(existingServer?.type ?? 'stdio');
+  const [command, setCommand] = useState(existingServer?.command ?? '');
+  const [args, setArgs] = useState(existingServer?.args.join(' ') ?? '');
+  const [envVars, setEnvVars] = useState<Array<{ key: string; value: string; isSecret: boolean }>>(
+    existingServer?.env
+      ? Object.entries(existingServer.env).map(([key, { value, isSecret }]) => ({
+          key,
+          value: isSecret ? '' : value,
+          isSecret,
+        }))
+      : []
+  );
+  const [url, setUrl] = useState(existingServer?.url ?? '');
+  const [headers, setHeaders] = useState<Array<{ key: string; value: string; isSecret: boolean }>>(
+    existingServer?.headers
+      ? Object.entries(existingServer.headers).map(([key, { value, isSecret }]) => ({
+          key,
+          value: isSecret ? '' : value,
+          isSecret,
+        }))
+      : []
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, setIsPending] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (!name) {
+      setError('Name is required');
+      return;
+    }
+
+    setIsPending(true);
+    try {
+      if (serverType === 'stdio') {
+        if (!command) {
+          setError('Command is required');
+          setIsPending(false);
+          return;
+        }
+
+        const env = envVars.reduce(
+          (acc, { key, value, isSecret }) => {
+            if (key) {
+              acc[key] = { value, isSecret };
+            }
+            return acc;
+          },
+          {} as Record<string, { value: string; isSecret: boolean }>
+        );
+
+        await setMcpServer({
+          name,
+          type: 'stdio',
+          command,
+          args: args.split(/\s+/).filter(Boolean),
+          env: Object.keys(env).length > 0 ? env : undefined,
+        });
+      } else {
+        if (!url) {
+          setError('URL is required');
+          setIsPending(false);
+          return;
+        }
+
+        const headersRecord = headers.reduce(
+          (acc, { key, value, isSecret }) => {
+            if (key) {
+              acc[key] = { value, isSecret };
+            }
+            return acc;
+          },
+          {} as Record<string, { value: string; isSecret: boolean }>
+        );
+
+        await setMcpServer({
+          name,
+          type: serverType,
+          url,
+          headers: Object.keys(headersRecord).length > 0 ? headersRecord : undefined,
+        });
+      }
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 p-4 border rounded-md">
+      <div className="space-y-2">
+        <Label htmlFor={`${idPrefix}-name`}>Name</Label>
+        <Input
+          id={`${idPrefix}-name`}
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="memory"
+          disabled={!!existingServer}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor={`${idPrefix}-type`}>Type</Label>
+        <Select
+          value={serverType}
+          onValueChange={(value) => setServerType(value as McpServerType)}
+          disabled={!!existingServer}
+        >
+          <SelectTrigger id={`${idPrefix}-type`}>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="stdio">Stdio (command)</SelectItem>
+            <SelectItem value="http">HTTP</SelectItem>
+            <SelectItem value="sse">SSE (Server-Sent Events)</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {serverType === 'stdio' ? (
+        <>
+          <div className="space-y-2">
+            <Label htmlFor={`${idPrefix}-command`}>Command</Label>
+            <Input
+              id={`${idPrefix}-command`}
+              value={command}
+              onChange={(e) => setCommand(e.target.value)}
+              placeholder="npx"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor={`${idPrefix}-args`}>Arguments (space-separated)</Label>
+            <Input
+              id={`${idPrefix}-args`}
+              value={args}
+              onChange={(e) => setArgs(e.target.value)}
+              placeholder="@anthropic/mcp-server-memory"
+            />
+          </div>
+
+          <KeyValueListEditor
+            label="Environment Variables"
+            entries={envVars}
+            existingEntries={existingServer?.env}
+            onChange={setEnvVars}
+            keyPlaceholder="KEY"
+            keyTransform={(key) => key.toUpperCase()}
+          />
+        </>
+      ) : (
+        <>
+          <div className="space-y-2">
+            <Label htmlFor={`${idPrefix}-url`}>URL</Label>
+            <Input
+              id={`${idPrefix}-url`}
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              placeholder="https://mcp.example.com/sse"
+            />
+          </div>
+
+          <KeyValueListEditor
+            label="Headers"
+            entries={headers}
+            existingEntries={existingServer?.headers}
+            onChange={setHeaders}
+            keyPlaceholder="Header-Name"
+          />
+        </>
+      )}
+
+      {error && <p className="text-sm text-destructive">{error}</p>}
+
+      <div className="flex justify-end gap-2">
+        <Button type="button" variant="outline" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button type="submit" disabled={isPending}>
+          {isPending ? <Spinner size="sm" /> : existingServer ? 'Update' : 'Add'}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/lib/settings-types.ts
+++ b/src/lib/settings-types.ts
@@ -1,0 +1,25 @@
+export interface EnvVar {
+  id: string;
+  name: string;
+  value: string;
+  isSecret: boolean;
+}
+
+export type McpServerType = 'stdio' | 'http' | 'sse';
+
+export interface McpServer {
+  id: string;
+  name: string;
+  type: McpServerType;
+  command: string;
+  args: string[];
+  env: Record<string, { value: string; isSecret: boolean }>;
+  url?: string;
+  headers: Record<string, { value: string; isSecret: boolean }>;
+}
+
+export interface ValidationResult {
+  success: boolean;
+  error?: string;
+  tools?: string[];
+}


### PR DESCRIPTION
## Summary
- Extracts duplicated env var and MCP server management code from `GlobalSettingsTab.tsx` (791 lines) and `RepoSettingsEditor.tsx` (909 lines) into shared components
- Creates `src/lib/settings-types.ts` with shared `EnvVar`, `McpServer`, and `ValidationResult` types
- Creates `src/components/settings/shared/KeyValueListEditor.tsx` — reusable key-value editor with secret toggle support
- Creates `src/components/settings/shared/EnvVarSection.tsx` — env var list, inline form, secret reveal, and delete dialog
- Creates `src/components/settings/shared/McpServerSection.tsx` — MCP server list, form, validation, and delete dialog
- Both consumer files now pass tRPC mutations via async callback props, keeping the shared components decoupled from specific tRPC routers
- Reduces GlobalSettingsTab from ~791 to ~137 lines and RepoSettingsEditor from ~909 to ~219 lines, eliminating ~1,100 lines of duplication

Fixes #196

## Test plan
- [x] TypeScript type check passes (`pnpm tsc --noEmit`)
- [x] All 237 tests pass (`pnpm test:run`)
- [x] ESLint passes on all changed files
- [ ] Manual: verify global env var CRUD in Settings tab
- [ ] Manual: verify global MCP server CRUD in Settings tab
- [ ] Manual: verify repo-specific env var CRUD in repo settings sheet
- [ ] Manual: verify repo-specific MCP server CRUD in repo settings sheet
- [ ] Manual: verify secret reveal/hide works in both contexts
- [ ] Manual: verify MCP server validation works in both contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)