### PR TITLE
Extract reusable DeleteConfirmDialog component

### DIFF
--- a/src/components/settings/RepositoriesTab.tsx
+++ b/src/components/settings/RepositoriesTab.tsx
@@ -7,16 +7,7 @@ import { Spinner } from '@/components/ui/spinner';
 import { trpc } from '@/lib/trpc';
 import { RepoSettingsEditor } from './RepoSettingsEditor';
 import { Star, Settings, Trash2 } from 'lucide-react';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
+import { DeleteConfirmDialog } from './shared/DeleteConfirmDialog';
 
 export function RepositoriesTab() {
   const [selectedRepo, setSelectedRepo] = useState<string | null>(null);
@@ -107,26 +98,19 @@ export function RepositoriesTab() {
         />
       )}
 
-      <AlertDialog open={!!deleteRepo} onOpenChange={(open) => !open && setDeleteRepo(null)}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete repository settings?</AlertDialogTitle>
-            <AlertDialogDescription>
-              This will delete all settings for <strong>{deleteRepo}</strong>, including environment
-              variables and MCP server configurations. This action cannot be undone.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() => deleteRepo && deleteMutation.mutate({ repoFullName: deleteRepo })}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            >
-              {deleteMutation.isPending ? <Spinner size="sm" /> : 'Delete'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <DeleteConfirmDialog
+        open={!!deleteRepo}
+        onClose={() => setDeleteRepo(null)}
+        onConfirm={() => deleteRepo && deleteMutation.mutate({ repoFullName: deleteRepo })}
+        title="Delete repository settings?"
+        description={
+          <>
+            This will delete all settings for <strong>{deleteRepo}</strong>, including environment
+            variables and MCP server configurations. This action cannot be undone.
+          </>
+        }
+        isPending={deleteMutation.isPending}
+      />
     </>
   );
 }

--- a/src/components/settings/shared/DeleteConfirmDialog.tsx
+++ b/src/components/settings/shared/DeleteConfirmDialog.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { ReactNode } from 'react';
+import { Spinner } from '@/components/ui/spinner';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+
+interface DeleteConfirmDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  title: string;
+  description: ReactNode;
+  isPending?: boolean;
+  confirmLabel?: string;
+}
+
+export function DeleteConfirmDialog({
+  open,
+  onClose,
+  onConfirm,
+  title,
+  description,
+  isPending = false,
+  confirmLabel = 'Delete',
+}: DeleteConfirmDialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onConfirm}
+            disabled={isPending}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            {isPending ? <Spinner size="sm" /> : confirmLabel}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/settings/shared/EnvVarSection.tsx
+++ b/src/components/settings/shared/EnvVarSection.tsx
@@ -6,17 +6,8 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Spinner } from '@/components/ui/spinner';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
 import { Plus, Trash2, Eye, EyeOff } from 'lucide-react';
+import { DeleteConfirmDialog } from './DeleteConfirmDialog';
 import type { EnvVar } from '@/lib/settings-types';
 
 export interface EnvVarMutations {
@@ -163,26 +154,18 @@ export function EnvVarSection({
         />
       )}
 
-      <AlertDialog open={!!deleteTarget} onOpenChange={(open) => !open && setDeleteTarget(null)}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete environment variable?</AlertDialogTitle>
-            <AlertDialogDescription>
-              {deleteDescriptionPrefix} <strong>{deleteTarget}</strong>.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleDelete}
-              disabled={isDeleting}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            >
-              Delete
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <DeleteConfirmDialog
+        open={!!deleteTarget}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={handleDelete}
+        title="Delete environment variable?"
+        description={
+          <>
+            {deleteDescriptionPrefix} <strong>{deleteTarget}</strong>.
+          </>
+        }
+        isPending={isDeleting}
+      />
     </div>
   );
 }

--- a/src/components/settings/shared/McpServerSection.tsx
+++ b/src/components/settings/shared/McpServerSection.tsx
@@ -12,17 +12,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
 import { Plus, Trash2, Plug, Check, X } from 'lucide-react';
+import { DeleteConfirmDialog } from './DeleteConfirmDialog';
 import { KeyValueListEditor } from './KeyValueListEditor';
 import type { McpServer, McpServerType, ValidationResult } from '@/lib/settings-types';
 
@@ -209,26 +200,18 @@ export function McpServerSection({
         />
       )}
 
-      <AlertDialog open={!!deleteTarget} onOpenChange={(open) => !open && setDeleteTarget(null)}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete MCP server?</AlertDialogTitle>
-            <AlertDialogDescription>
-              {deleteDescriptionPrefix} <strong>{deleteTarget}</strong>.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleDelete}
-              disabled={isDeleting}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            >
-              Delete
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <DeleteConfirmDialog
+        open={!!deleteTarget}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={handleDelete}
+        title="Delete MCP server?"
+        description={
+          <>
+            {deleteDescriptionPrefix} <strong>{deleteTarget}</strong>.
+          </>
+        }
+        isPending={isDeleting}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Created a reusable `DeleteConfirmDialog` component in `src/components/settings/shared/` that encapsulates the repeated AlertDialog pattern for delete confirmations
- Refactored `EnvVarSection`, `McpServerSection`, and `RepositoriesTab` to use the new component, replacing ~20 lines of boilerplate each with a single component usage
- The component supports customizable title, description (ReactNode), pending state with spinner, and confirm button label

## Test plan
- [x] All 237 tests pass (`pnpm test:run`)
- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] Lint and prettier pass (pre-commit hooks)
- [ ] Manual verification: test delete confirmation for env vars, MCP servers, and repo settings in the UI

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)