### PR TITLE
Extract duplicated getFileType() and FileIcon from ReadDisplay and WriteDisplay

### DIFF
--- a/src/components/messages/FileIcon.tsx
+++ b/src/components/messages/FileIcon.tsx
@@ -1,0 +1,30 @@
+/**
+ * File icon SVG component used in tool displays.
+ *
+ * variant="read" shows a plain document icon.
+ * variant="write" shows a document icon with lines inside it.
+ */
+export function FileIcon({
+  className,
+  variant = 'read',
+}: {
+  className?: string;
+  variant?: 'read' | 'write';
+}) {
+  const path =
+    variant === 'write'
+      ? 'M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z'
+      : 'M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z';
+
+  return (
+    <svg
+      className={`w-4 h-4 text-muted-foreground flex-shrink-0 ${className ?? ''}`}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={1.5}
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d={path} />
+    </svg>
+  );
+}

--- a/src/components/messages/ReadDisplay.tsx
+++ b/src/components/messages/ReadDisplay.tsx
@@ -2,6 +2,8 @@
 
 import { useMemo } from 'react';
 import { Badge } from '@/components/ui/badge';
+import { getFileType } from '@/lib/file-types';
+import { FileIcon } from './FileIcon';
 import { ToolDisplayWrapper } from './ToolDisplayWrapper';
 import type { ToolCall } from './types';
 
@@ -61,67 +63,6 @@ function parseReadOutput(output: string): ParsedLine[] {
   }
 
   return result;
-}
-
-/**
- * Detect file type from extension for syntax highlighting hints.
- */
-function getFileType(filePath: string): string {
-  const ext = filePath.split('.').pop()?.toLowerCase() ?? '';
-  const typeMap: Record<string, string> = {
-    ts: 'typescript',
-    tsx: 'typescript',
-    js: 'javascript',
-    jsx: 'javascript',
-    py: 'python',
-    rb: 'ruby',
-    rs: 'rust',
-    go: 'go',
-    java: 'java',
-    kt: 'kotlin',
-    swift: 'swift',
-    c: 'c',
-    cpp: 'cpp',
-    h: 'c',
-    hpp: 'cpp',
-    css: 'css',
-    scss: 'scss',
-    less: 'less',
-    html: 'html',
-    xml: 'xml',
-    json: 'json',
-    yaml: 'yaml',
-    yml: 'yaml',
-    md: 'markdown',
-    sql: 'sql',
-    sh: 'shell',
-    bash: 'shell',
-    zsh: 'shell',
-    dockerfile: 'docker',
-    prisma: 'prisma',
-  };
-  return typeMap[ext] ?? 'text';
-}
-
-/**
- * FileIcon component for Read tool display
- */
-function FileIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={`w-4 h-4 text-muted-foreground flex-shrink-0 ${className ?? ''}`}
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke="currentColor"
-      strokeWidth={1.5}
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z"
-      />
-    </svg>
-  );
 }
 
 /**

--- a/src/components/messages/WriteDisplay.tsx
+++ b/src/components/messages/WriteDisplay.tsx
@@ -3,73 +3,14 @@
 import { useMemo } from 'react';
 import { cn } from '@/lib/utils';
 import { Badge } from '@/components/ui/badge';
+import { getFileType } from '@/lib/file-types';
+import { FileIcon } from './FileIcon';
 import { ToolDisplayWrapper } from './ToolDisplayWrapper';
 import type { ToolCall } from './types';
 
 interface WriteInput {
   file_path?: string;
   content?: string;
-}
-
-/**
- * Detect file type from extension for syntax highlighting hints.
- */
-function getFileType(filePath: string): string {
-  const ext = filePath.split('.').pop()?.toLowerCase() ?? '';
-  const typeMap: Record<string, string> = {
-    ts: 'typescript',
-    tsx: 'typescript',
-    js: 'javascript',
-    jsx: 'javascript',
-    py: 'python',
-    rb: 'ruby',
-    rs: 'rust',
-    go: 'go',
-    java: 'java',
-    kt: 'kotlin',
-    swift: 'swift',
-    c: 'c',
-    cpp: 'cpp',
-    h: 'c',
-    hpp: 'cpp',
-    css: 'css',
-    scss: 'scss',
-    less: 'less',
-    html: 'html',
-    xml: 'xml',
-    json: 'json',
-    yaml: 'yaml',
-    yml: 'yaml',
-    md: 'markdown',
-    sql: 'sql',
-    sh: 'shell',
-    bash: 'shell',
-    zsh: 'shell',
-    dockerfile: 'docker',
-    prisma: 'prisma',
-  };
-  return typeMap[ext] ?? 'text';
-}
-
-/**
- * FileIcon component for Write tool display
- */
-function FileIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={`w-4 h-4 text-muted-foreground flex-shrink-0 ${className ?? ''}`}
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke="currentColor"
-      strokeWidth={1.5}
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z"
-      />
-    </svg>
-  );
 }
 
 /**
@@ -96,7 +37,7 @@ export function WriteDisplay({ tool }: { tool: ToolCall }) {
   return (
     <ToolDisplayWrapper
       tool={tool}
-      icon={<FileIcon />}
+      icon={<FileIcon variant="write" />}
       title="Write"
       pendingText="Writing..."
       headerContent={

--- a/src/lib/file-types.ts
+++ b/src/lib/file-types.ts
@@ -1,0 +1,44 @@
+/**
+ * Map of file extensions to language/file type names.
+ * Used for syntax highlighting hints in tool displays.
+ */
+const FILE_TYPE_MAP: Record<string, string> = {
+  ts: 'typescript',
+  tsx: 'typescript',
+  js: 'javascript',
+  jsx: 'javascript',
+  py: 'python',
+  rb: 'ruby',
+  rs: 'rust',
+  go: 'go',
+  java: 'java',
+  kt: 'kotlin',
+  swift: 'swift',
+  c: 'c',
+  cpp: 'cpp',
+  h: 'c',
+  hpp: 'cpp',
+  css: 'css',
+  scss: 'scss',
+  less: 'less',
+  html: 'html',
+  xml: 'xml',
+  json: 'json',
+  yaml: 'yaml',
+  yml: 'yaml',
+  md: 'markdown',
+  sql: 'sql',
+  sh: 'shell',
+  bash: 'shell',
+  zsh: 'shell',
+  dockerfile: 'docker',
+  prisma: 'prisma',
+};
+
+/**
+ * Detect file type from extension for syntax highlighting hints.
+ */
+export function getFileType(filePath: string): string {
+  const ext = filePath.split('.').pop()?.toLowerCase() ?? '';
+  return FILE_TYPE_MAP[ext] ?? 'text';
+}


### PR DESCRIPTION
## Summary
- Extracted the duplicated `getFileType()` function into a shared utility at `src/lib/file-types.ts`
- Extracted the duplicated `FileIcon` SVG component into `src/components/messages/FileIcon.tsx` with a `variant` prop (`"read"` | `"write"`) to preserve the slightly different SVG paths
- Updated `ReadDisplay.tsx` and `WriteDisplay.tsx` to import from the shared modules

Fixes #208

## Test plan
- [x] All 249 existing tests pass (`pnpm test:run`)
- [x] TypeScript type-check passes (`tsc --noEmit`)
- [x] Lint and format pass (pre-commit hooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)