### PR TITLE
Standardize form state management with useReducer

### DIFF
--- a/src/components/settings/shared/env-var-reducer.test.ts
+++ b/src/components/settings/shared/env-var-reducer.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect } from 'vitest';
+import {
+  envVarSectionReducer,
+  initialEnvVarSectionState,
+  envVarFormReducer,
+  createInitialEnvVarFormState,
+} from './env-var-reducer';
+import type { EnvVarSectionState, EnvVarFormState } from './env-var-reducer';
+
+describe('envVarSectionReducer', () => {
+  describe('form visibility', () => {
+    it('opens the form', () => {
+      const result = envVarSectionReducer(initialEnvVarSectionState, { type: 'openForm' });
+      expect(result.showForm).toBe(true);
+    });
+
+    it('starts editing by id', () => {
+      const result = envVarSectionReducer(initialEnvVarSectionState, {
+        type: 'startEditing',
+        id: 'env-1',
+      });
+      expect(result.editingId).toBe('env-1');
+    });
+
+    it('closes the form and clears editingId', () => {
+      const state: EnvVarSectionState = {
+        ...initialEnvVarSectionState,
+        showForm: true,
+        editingId: 'env-1',
+      };
+      const result = envVarSectionReducer(state, { type: 'closeForm' });
+      expect(result.showForm).toBe(false);
+      expect(result.editingId).toBeNull();
+    });
+
+    it('formSuccess closes form and clears editingId', () => {
+      const state: EnvVarSectionState = {
+        ...initialEnvVarSectionState,
+        showForm: true,
+        editingId: 'env-1',
+      };
+      const result = envVarSectionReducer(state, { type: 'formSuccess' });
+      expect(result.showForm).toBe(false);
+      expect(result.editingId).toBeNull();
+    });
+  });
+
+  describe('delete flow', () => {
+    it('sets delete target', () => {
+      const result = envVarSectionReducer(initialEnvVarSectionState, {
+        type: 'setDeleteTarget',
+        name: 'MY_VAR',
+      });
+      expect(result.deleteTarget).toBe('MY_VAR');
+    });
+
+    it('clears delete target', () => {
+      const state: EnvVarSectionState = {
+        ...initialEnvVarSectionState,
+        deleteTarget: 'MY_VAR',
+      };
+      const result = envVarSectionReducer(state, { type: 'setDeleteTarget', name: null });
+      expect(result.deleteTarget).toBeNull();
+    });
+
+    it('starts deleting', () => {
+      const state: EnvVarSectionState = {
+        ...initialEnvVarSectionState,
+        deleteTarget: 'MY_VAR',
+      };
+      const result = envVarSectionReducer(state, { type: 'startDeleting' });
+      expect(result.isDeleting).toBe(true);
+    });
+
+    it('finishes deleting and clears target', () => {
+      const state: EnvVarSectionState = {
+        ...initialEnvVarSectionState,
+        isDeleting: true,
+        deleteTarget: 'MY_VAR',
+      };
+      const result = envVarSectionReducer(state, { type: 'finishDeleting' });
+      expect(result.isDeleting).toBe(false);
+      expect(result.deleteTarget).toBeNull();
+    });
+  });
+
+  describe('secret visibility', () => {
+    it('starts loading a secret', () => {
+      const result = envVarSectionReducer(initialEnvVarSectionState, {
+        type: 'startLoadingSecret',
+        name: 'API_KEY',
+      });
+      expect(result.loadingSecret).toBe('API_KEY');
+    });
+
+    it('reveals a secret and clears loading state', () => {
+      const state: EnvVarSectionState = {
+        ...initialEnvVarSectionState,
+        loadingSecret: 'API_KEY',
+      };
+      const result = envVarSectionReducer(state, {
+        type: 'revealSecret',
+        name: 'API_KEY',
+        value: 'secret-value',
+      });
+      expect(result.revealedSecrets.get('API_KEY')).toBe('secret-value');
+      expect(result.loadingSecret).toBeNull();
+    });
+
+    it('hides a secret', () => {
+      const state: EnvVarSectionState = {
+        ...initialEnvVarSectionState,
+        revealedSecrets: new Map([['API_KEY', 'secret-value']]),
+      };
+      const result = envVarSectionReducer(state, { type: 'hideSecret', name: 'API_KEY' });
+      expect(result.revealedSecrets.has('API_KEY')).toBe(false);
+    });
+
+    it('finishes loading secret without revealing', () => {
+      const state: EnvVarSectionState = {
+        ...initialEnvVarSectionState,
+        loadingSecret: 'API_KEY',
+      };
+      const result = envVarSectionReducer(state, { type: 'finishLoadingSecret' });
+      expect(result.loadingSecret).toBeNull();
+    });
+
+    it('preserves other revealed secrets when revealing a new one', () => {
+      const state: EnvVarSectionState = {
+        ...initialEnvVarSectionState,
+        revealedSecrets: new Map([['EXISTING', 'old-value']]),
+        loadingSecret: 'NEW_KEY',
+      };
+      const result = envVarSectionReducer(state, {
+        type: 'revealSecret',
+        name: 'NEW_KEY',
+        value: 'new-value',
+      });
+      expect(result.revealedSecrets.get('EXISTING')).toBe('old-value');
+      expect(result.revealedSecrets.get('NEW_KEY')).toBe('new-value');
+    });
+  });
+});
+
+describe('envVarFormReducer', () => {
+  describe('createInitialEnvVarFormState', () => {
+    it('creates empty state when no existing env var', () => {
+      const state = createInitialEnvVarFormState();
+      expect(state).toEqual({
+        name: '',
+        value: '',
+        isSecret: false,
+        error: null,
+        isPending: false,
+      });
+    });
+
+    it('populates from existing non-secret env var', () => {
+      const state = createInitialEnvVarFormState({
+        name: 'MY_VAR',
+        value: 'my-value',
+        isSecret: false,
+      });
+      expect(state.name).toBe('MY_VAR');
+      expect(state.value).toBe('my-value');
+      expect(state.isSecret).toBe(false);
+    });
+
+    it('clears value for existing secret env var', () => {
+      const state = createInitialEnvVarFormState({
+        name: 'SECRET_VAR',
+        value: 'encrypted-value',
+        isSecret: true,
+      });
+      expect(state.name).toBe('SECRET_VAR');
+      expect(state.value).toBe('');
+      expect(state.isSecret).toBe(true);
+    });
+  });
+
+  describe('field updates', () => {
+    it('sets name', () => {
+      const state = createInitialEnvVarFormState();
+      const result = envVarFormReducer(state, { type: 'setName', name: 'NEW_NAME' });
+      expect(result.name).toBe('NEW_NAME');
+    });
+
+    it('sets value', () => {
+      const state = createInitialEnvVarFormState();
+      const result = envVarFormReducer(state, { type: 'setValue', value: 'new-value' });
+      expect(result.value).toBe('new-value');
+    });
+
+    it('sets isSecret', () => {
+      const state = createInitialEnvVarFormState();
+      const result = envVarFormReducer(state, { type: 'setIsSecret', isSecret: true });
+      expect(result.isSecret).toBe(true);
+    });
+
+    it('sets error', () => {
+      const state = createInitialEnvVarFormState();
+      const result = envVarFormReducer(state, { type: 'setError', error: 'Something went wrong' });
+      expect(result.error).toBe('Something went wrong');
+    });
+
+    it('clears error', () => {
+      const state: EnvVarFormState = { ...createInitialEnvVarFormState(), error: 'old error' };
+      const result = envVarFormReducer(state, { type: 'setError', error: null });
+      expect(result.error).toBeNull();
+    });
+  });
+
+  describe('submit flow', () => {
+    it('startSubmit clears error and sets isPending', () => {
+      const state: EnvVarFormState = {
+        ...createInitialEnvVarFormState(),
+        error: 'previous error',
+      };
+      const result = envVarFormReducer(state, { type: 'startSubmit' });
+      expect(result.error).toBeNull();
+      expect(result.isPending).toBe(true);
+    });
+
+    it('submitError sets error and clears isPending', () => {
+      const state: EnvVarFormState = { ...createInitialEnvVarFormState(), isPending: true };
+      const result = envVarFormReducer(state, { type: 'submitError', error: 'Failed to save' });
+      expect(result.error).toBe('Failed to save');
+      expect(result.isPending).toBe(false);
+    });
+
+    it('finishSubmit clears isPending', () => {
+      const state: EnvVarFormState = { ...createInitialEnvVarFormState(), isPending: true };
+      const result = envVarFormReducer(state, { type: 'finishSubmit' });
+      expect(result.isPending).toBe(false);
+    });
+  });
+});

--- a/src/components/settings/shared/env-var-reducer.ts
+++ b/src/components/settings/shared/env-var-reducer.ts
@@ -1,0 +1,123 @@
+// -- EnvVarSection (list management) reducer --
+
+export interface EnvVarSectionState {
+  showForm: boolean;
+  editingId: string | null;
+  deleteTarget: string | null;
+  isDeleting: boolean;
+  revealedSecrets: Map<string, string>;
+  loadingSecret: string | null;
+}
+
+export type EnvVarSectionAction =
+  | { type: 'openForm' }
+  | { type: 'startEditing'; id: string }
+  | { type: 'closeForm' }
+  | { type: 'formSuccess' }
+  | { type: 'setDeleteTarget'; name: string | null }
+  | { type: 'startDeleting' }
+  | { type: 'finishDeleting' }
+  | { type: 'startLoadingSecret'; name: string }
+  | { type: 'revealSecret'; name: string; value: string }
+  | { type: 'hideSecret'; name: string }
+  | { type: 'finishLoadingSecret' };
+
+export const initialEnvVarSectionState: EnvVarSectionState = {
+  showForm: false,
+  editingId: null,
+  deleteTarget: null,
+  isDeleting: false,
+  revealedSecrets: new Map(),
+  loadingSecret: null,
+};
+
+export function envVarSectionReducer(
+  state: EnvVarSectionState,
+  action: EnvVarSectionAction
+): EnvVarSectionState {
+  switch (action.type) {
+    case 'openForm':
+      return { ...state, showForm: true };
+    case 'startEditing':
+      return { ...state, editingId: action.id };
+    case 'closeForm':
+      return { ...state, showForm: false, editingId: null };
+    case 'formSuccess':
+      return { ...state, showForm: false, editingId: null };
+    case 'setDeleteTarget':
+      return { ...state, deleteTarget: action.name };
+    case 'startDeleting':
+      return { ...state, isDeleting: true };
+    case 'finishDeleting':
+      return { ...state, isDeleting: false, deleteTarget: null };
+    case 'startLoadingSecret':
+      return { ...state, loadingSecret: action.name };
+    case 'revealSecret': {
+      const next = new Map(state.revealedSecrets);
+      next.set(action.name, action.value);
+      return { ...state, revealedSecrets: next, loadingSecret: null };
+    }
+    case 'hideSecret': {
+      const next = new Map(state.revealedSecrets);
+      next.delete(action.name);
+      return { ...state, revealedSecrets: next };
+    }
+    case 'finishLoadingSecret':
+      return { ...state, loadingSecret: null };
+  }
+}
+
+// -- EnvVarForm reducer --
+
+export interface EnvVarFormState {
+  name: string;
+  value: string;
+  isSecret: boolean;
+  error: string | null;
+  isPending: boolean;
+}
+
+export type EnvVarFormAction =
+  | { type: 'setName'; name: string }
+  | { type: 'setValue'; value: string }
+  | { type: 'setIsSecret'; isSecret: boolean }
+  | { type: 'setError'; error: string | null }
+  | { type: 'startSubmit' }
+  | { type: 'submitError'; error: string }
+  | { type: 'finishSubmit' };
+
+export function createInitialEnvVarFormState(existing?: {
+  name: string;
+  value: string;
+  isSecret: boolean;
+}): EnvVarFormState {
+  return {
+    name: existing?.name ?? '',
+    value: existing?.isSecret ? '' : (existing?.value ?? ''),
+    isSecret: existing?.isSecret ?? false,
+    error: null,
+    isPending: false,
+  };
+}
+
+export function envVarFormReducer(
+  state: EnvVarFormState,
+  action: EnvVarFormAction
+): EnvVarFormState {
+  switch (action.type) {
+    case 'setName':
+      return { ...state, name: action.name };
+    case 'setValue':
+      return { ...state, value: action.value };
+    case 'setIsSecret':
+      return { ...state, isSecret: action.isSecret };
+    case 'setError':
+      return { ...state, error: action.error };
+    case 'startSubmit':
+      return { ...state, error: null, isPending: true };
+    case 'submitError':
+      return { ...state, error: action.error, isPending: false };
+    case 'finishSubmit':
+      return { ...state, isPending: false };
+  }
+}

--- a/src/components/settings/shared/mcp-server-reducer.test.ts
+++ b/src/components/settings/shared/mcp-server-reducer.test.ts
@@ -1,0 +1,376 @@
+import { describe, it, expect } from 'vitest';
+import {
+  mcpServerSectionReducer,
+  initialMcpServerSectionState,
+  mcpServerFormReducer,
+  createInitialMcpServerFormState,
+} from './mcp-server-reducer';
+import type { McpServerSectionState, McpServerFormState } from './mcp-server-reducer';
+
+describe('mcpServerSectionReducer', () => {
+  describe('form visibility', () => {
+    it('opens the form', () => {
+      const result = mcpServerSectionReducer(initialMcpServerSectionState, { type: 'openForm' });
+      expect(result.showForm).toBe(true);
+    });
+
+    it('starts editing by id', () => {
+      const result = mcpServerSectionReducer(initialMcpServerSectionState, {
+        type: 'startEditing',
+        id: 'mcp-1',
+      });
+      expect(result.editingId).toBe('mcp-1');
+    });
+
+    it('closes the form and clears editingId', () => {
+      const state: McpServerSectionState = {
+        ...initialMcpServerSectionState,
+        showForm: true,
+        editingId: 'mcp-1',
+      };
+      const result = mcpServerSectionReducer(state, { type: 'closeForm' });
+      expect(result.showForm).toBe(false);
+      expect(result.editingId).toBeNull();
+    });
+
+    it('formSuccess closes form and clears editingId', () => {
+      const state: McpServerSectionState = {
+        ...initialMcpServerSectionState,
+        showForm: true,
+        editingId: 'mcp-1',
+      };
+      const result = mcpServerSectionReducer(state, { type: 'formSuccess' });
+      expect(result.showForm).toBe(false);
+      expect(result.editingId).toBeNull();
+    });
+  });
+
+  describe('delete flow', () => {
+    it('sets delete target', () => {
+      const result = mcpServerSectionReducer(initialMcpServerSectionState, {
+        type: 'setDeleteTarget',
+        name: 'memory',
+      });
+      expect(result.deleteTarget).toBe('memory');
+    });
+
+    it('clears delete target', () => {
+      const state: McpServerSectionState = {
+        ...initialMcpServerSectionState,
+        deleteTarget: 'memory',
+      };
+      const result = mcpServerSectionReducer(state, { type: 'setDeleteTarget', name: null });
+      expect(result.deleteTarget).toBeNull();
+    });
+
+    it('starts deleting', () => {
+      const state: McpServerSectionState = {
+        ...initialMcpServerSectionState,
+        deleteTarget: 'memory',
+      };
+      const result = mcpServerSectionReducer(state, { type: 'startDeleting' });
+      expect(result.isDeleting).toBe(true);
+    });
+
+    it('finishes deleting and clears target', () => {
+      const state: McpServerSectionState = {
+        ...initialMcpServerSectionState,
+        isDeleting: true,
+        deleteTarget: 'memory',
+      };
+      const result = mcpServerSectionReducer(state, { type: 'finishDeleting' });
+      expect(result.isDeleting).toBe(false);
+      expect(result.deleteTarget).toBeNull();
+    });
+  });
+
+  describe('validation', () => {
+    it('starts validating a server', () => {
+      const result = mcpServerSectionReducer(initialMcpServerSectionState, {
+        type: 'startValidating',
+        name: 'memory',
+      });
+      expect(result.validatingServer).toBe('memory');
+    });
+
+    it('sets validation result and clears validating state', () => {
+      const state: McpServerSectionState = {
+        ...initialMcpServerSectionState,
+        validatingServer: 'memory',
+      };
+      const result = mcpServerSectionReducer(state, {
+        type: 'setValidationResult',
+        name: 'memory',
+        result: { success: true, tools: ['tool1', 'tool2'] },
+      });
+      expect(result.validationResults.get('memory')).toEqual({
+        success: true,
+        tools: ['tool1', 'tool2'],
+      });
+      expect(result.validatingServer).toBeNull();
+    });
+
+    it('sets failed validation result', () => {
+      const state: McpServerSectionState = {
+        ...initialMcpServerSectionState,
+        validatingServer: 'memory',
+      };
+      const result = mcpServerSectionReducer(state, {
+        type: 'setValidationResult',
+        name: 'memory',
+        result: { success: false, error: 'Connection failed' },
+      });
+      expect(result.validationResults.get('memory')).toEqual({
+        success: false,
+        error: 'Connection failed',
+      });
+    });
+
+    it('preserves other validation results when setting a new one', () => {
+      const state: McpServerSectionState = {
+        ...initialMcpServerSectionState,
+        validationResults: new Map([['other', { success: true }]]),
+        validatingServer: 'memory',
+      };
+      const result = mcpServerSectionReducer(state, {
+        type: 'setValidationResult',
+        name: 'memory',
+        result: { success: true },
+      });
+      expect(result.validationResults.get('other')).toEqual({ success: true });
+      expect(result.validationResults.get('memory')).toEqual({ success: true });
+    });
+
+    it('finishes validating without result', () => {
+      const state: McpServerSectionState = {
+        ...initialMcpServerSectionState,
+        validatingServer: 'memory',
+      };
+      const result = mcpServerSectionReducer(state, { type: 'finishValidating' });
+      expect(result.validatingServer).toBeNull();
+    });
+  });
+});
+
+describe('mcpServerFormReducer', () => {
+  describe('createInitialMcpServerFormState', () => {
+    it('creates empty state when no existing server', () => {
+      const state = createInitialMcpServerFormState();
+      expect(state).toEqual({
+        name: '',
+        serverType: 'stdio',
+        command: '',
+        args: '',
+        envVars: [],
+        url: '',
+        headers: [],
+        error: null,
+        isPending: false,
+      });
+    });
+
+    it('populates from existing stdio server', () => {
+      const state = createInitialMcpServerFormState({
+        name: 'memory',
+        type: 'stdio',
+        command: 'npx',
+        args: ['@anthropic/mcp-server-memory'],
+        env: { API_KEY: { value: 'key123', isSecret: false } },
+        headers: {},
+      });
+      expect(state.name).toBe('memory');
+      expect(state.serverType).toBe('stdio');
+      expect(state.command).toBe('npx');
+      expect(state.args).toBe('@anthropic/mcp-server-memory');
+      expect(state.envVars).toEqual([{ key: 'API_KEY', value: 'key123', isSecret: false }]);
+    });
+
+    it('populates from existing HTTP server', () => {
+      const state = createInitialMcpServerFormState({
+        name: 'web-server',
+        type: 'http',
+        command: '',
+        args: [],
+        env: {},
+        url: 'https://example.com/mcp',
+        headers: { Authorization: { value: 'Bearer token', isSecret: true } },
+      });
+      expect(state.name).toBe('web-server');
+      expect(state.serverType).toBe('http');
+      expect(state.url).toBe('https://example.com/mcp');
+      expect(state.headers).toEqual([{ key: 'Authorization', value: '', isSecret: true }]);
+    });
+
+    it('clears secret env var values', () => {
+      const state = createInitialMcpServerFormState({
+        name: 'test',
+        type: 'stdio',
+        command: 'node',
+        args: [],
+        env: { SECRET: { value: 'hidden', isSecret: true } },
+        headers: {},
+      });
+      expect(state.envVars).toEqual([{ key: 'SECRET', value: '', isSecret: true }]);
+    });
+
+    it('joins args with spaces', () => {
+      const state = createInitialMcpServerFormState({
+        name: 'test',
+        type: 'stdio',
+        command: 'node',
+        args: ['--flag', 'value', '--other'],
+        env: {},
+        headers: {},
+      });
+      expect(state.args).toBe('--flag value --other');
+    });
+  });
+
+  describe('field updates', () => {
+    it('sets name', () => {
+      const state = createInitialMcpServerFormState();
+      const result = mcpServerFormReducer(state, { type: 'setName', name: 'new-server' });
+      expect(result.name).toBe('new-server');
+    });
+
+    it('sets server type', () => {
+      const state = createInitialMcpServerFormState();
+      const result = mcpServerFormReducer(state, { type: 'setServerType', serverType: 'http' });
+      expect(result.serverType).toBe('http');
+    });
+
+    it('sets command', () => {
+      const state = createInitialMcpServerFormState();
+      const result = mcpServerFormReducer(state, { type: 'setCommand', command: 'npx' });
+      expect(result.command).toBe('npx');
+    });
+
+    it('sets args', () => {
+      const state = createInitialMcpServerFormState();
+      const result = mcpServerFormReducer(state, {
+        type: 'setArgs',
+        args: '--flag value',
+      });
+      expect(result.args).toBe('--flag value');
+    });
+
+    it('sets envVars', () => {
+      const state = createInitialMcpServerFormState();
+      const envVars = [{ key: 'KEY', value: 'val', isSecret: false }];
+      const result = mcpServerFormReducer(state, { type: 'setEnvVars', envVars });
+      expect(result.envVars).toEqual(envVars);
+    });
+
+    it('sets url', () => {
+      const state = createInitialMcpServerFormState();
+      const result = mcpServerFormReducer(state, {
+        type: 'setUrl',
+        url: 'https://example.com',
+      });
+      expect(result.url).toBe('https://example.com');
+    });
+
+    it('sets headers', () => {
+      const state = createInitialMcpServerFormState();
+      const headers = [{ key: 'Auth', value: 'token', isSecret: true }];
+      const result = mcpServerFormReducer(state, { type: 'setHeaders', headers });
+      expect(result.headers).toEqual(headers);
+    });
+
+    it('sets error', () => {
+      const state = createInitialMcpServerFormState();
+      const result = mcpServerFormReducer(state, { type: 'setError', error: 'Name is required' });
+      expect(result.error).toBe('Name is required');
+    });
+
+    it('clears error', () => {
+      const state: McpServerFormState = {
+        ...createInitialMcpServerFormState(),
+        error: 'old error',
+      };
+      const result = mcpServerFormReducer(state, { type: 'setError', error: null });
+      expect(result.error).toBeNull();
+    });
+  });
+
+  describe('submit flow', () => {
+    it('startSubmit clears error and sets isPending', () => {
+      const state: McpServerFormState = {
+        ...createInitialMcpServerFormState(),
+        error: 'previous error',
+      };
+      const result = mcpServerFormReducer(state, { type: 'startSubmit' });
+      expect(result.error).toBeNull();
+      expect(result.isPending).toBe(true);
+    });
+
+    it('submitError sets error and clears isPending', () => {
+      const state: McpServerFormState = {
+        ...createInitialMcpServerFormState(),
+        isPending: true,
+      };
+      const result = mcpServerFormReducer(state, {
+        type: 'submitError',
+        error: 'Failed to save',
+      });
+      expect(result.error).toBe('Failed to save');
+      expect(result.isPending).toBe(false);
+    });
+
+    it('finishSubmit clears isPending', () => {
+      const state: McpServerFormState = {
+        ...createInitialMcpServerFormState(),
+        isPending: true,
+      };
+      const result = mcpServerFormReducer(state, { type: 'finishSubmit' });
+      expect(result.isPending).toBe(false);
+    });
+  });
+
+  describe('state transitions', () => {
+    it('handles full stdio form workflow', () => {
+      let state = createInitialMcpServerFormState();
+
+      state = mcpServerFormReducer(state, { type: 'setName', name: 'memory' });
+      state = mcpServerFormReducer(state, { type: 'setCommand', command: 'npx' });
+      state = mcpServerFormReducer(state, {
+        type: 'setArgs',
+        args: '@anthropic/mcp-server-memory',
+      });
+      state = mcpServerFormReducer(state, {
+        type: 'setEnvVars',
+        envVars: [{ key: 'TOKEN', value: 'abc', isSecret: true }],
+      });
+
+      expect(state.name).toBe('memory');
+      expect(state.serverType).toBe('stdio');
+      expect(state.command).toBe('npx');
+      expect(state.args).toBe('@anthropic/mcp-server-memory');
+      expect(state.envVars).toHaveLength(1);
+
+      state = mcpServerFormReducer(state, { type: 'startSubmit' });
+      expect(state.isPending).toBe(true);
+      expect(state.error).toBeNull();
+    });
+
+    it('handles full HTTP form workflow', () => {
+      let state = createInitialMcpServerFormState();
+
+      state = mcpServerFormReducer(state, { type: 'setName', name: 'web-mcp' });
+      state = mcpServerFormReducer(state, { type: 'setServerType', serverType: 'http' });
+      state = mcpServerFormReducer(state, {
+        type: 'setUrl',
+        url: 'https://example.com/mcp',
+      });
+      state = mcpServerFormReducer(state, {
+        type: 'setHeaders',
+        headers: [{ key: 'Authorization', value: 'Bearer token', isSecret: true }],
+      });
+
+      expect(state.name).toBe('web-mcp');
+      expect(state.serverType).toBe('http');
+      expect(state.url).toBe('https://example.com/mcp');
+      expect(state.headers).toHaveLength(1);
+    });
+  });
+});

--- a/src/components/settings/shared/mcp-server-reducer.ts
+++ b/src/components/settings/shared/mcp-server-reducer.ts
@@ -1,0 +1,161 @@
+import type { McpServerType, ValidationResult } from '@/lib/settings-types';
+
+// -- McpServerSection (list management) reducer --
+
+export interface McpServerSectionState {
+  showForm: boolean;
+  editingId: string | null;
+  deleteTarget: string | null;
+  isDeleting: boolean;
+  validationResults: Map<string, ValidationResult>;
+  validatingServer: string | null;
+}
+
+export type McpServerSectionAction =
+  | { type: 'openForm' }
+  | { type: 'startEditing'; id: string }
+  | { type: 'closeForm' }
+  | { type: 'formSuccess' }
+  | { type: 'setDeleteTarget'; name: string | null }
+  | { type: 'startDeleting' }
+  | { type: 'finishDeleting' }
+  | { type: 'startValidating'; name: string }
+  | { type: 'setValidationResult'; name: string; result: ValidationResult }
+  | { type: 'finishValidating' };
+
+export const initialMcpServerSectionState: McpServerSectionState = {
+  showForm: false,
+  editingId: null,
+  deleteTarget: null,
+  isDeleting: false,
+  validationResults: new Map(),
+  validatingServer: null,
+};
+
+export function mcpServerSectionReducer(
+  state: McpServerSectionState,
+  action: McpServerSectionAction
+): McpServerSectionState {
+  switch (action.type) {
+    case 'openForm':
+      return { ...state, showForm: true };
+    case 'startEditing':
+      return { ...state, editingId: action.id };
+    case 'closeForm':
+      return { ...state, showForm: false, editingId: null };
+    case 'formSuccess':
+      return { ...state, showForm: false, editingId: null };
+    case 'setDeleteTarget':
+      return { ...state, deleteTarget: action.name };
+    case 'startDeleting':
+      return { ...state, isDeleting: true };
+    case 'finishDeleting':
+      return { ...state, isDeleting: false, deleteTarget: null };
+    case 'startValidating':
+      return { ...state, validatingServer: action.name };
+    case 'setValidationResult': {
+      const next = new Map(state.validationResults);
+      next.set(action.name, action.result);
+      return { ...state, validationResults: next, validatingServer: null };
+    }
+    case 'finishValidating':
+      return { ...state, validatingServer: null };
+  }
+}
+
+// -- McpServerForm reducer --
+
+interface KeyValueEntry {
+  key: string;
+  value: string;
+  isSecret: boolean;
+}
+
+export interface McpServerFormState {
+  name: string;
+  serverType: McpServerType;
+  command: string;
+  args: string;
+  envVars: KeyValueEntry[];
+  url: string;
+  headers: KeyValueEntry[];
+  error: string | null;
+  isPending: boolean;
+}
+
+export type McpServerFormAction =
+  | { type: 'setName'; name: string }
+  | { type: 'setServerType'; serverType: McpServerType }
+  | { type: 'setCommand'; command: string }
+  | { type: 'setArgs'; args: string }
+  | { type: 'setEnvVars'; envVars: KeyValueEntry[] }
+  | { type: 'setUrl'; url: string }
+  | { type: 'setHeaders'; headers: KeyValueEntry[] }
+  | { type: 'setError'; error: string | null }
+  | { type: 'startSubmit' }
+  | { type: 'submitError'; error: string }
+  | { type: 'finishSubmit' };
+
+export function createInitialMcpServerFormState(existing?: {
+  name: string;
+  type: McpServerType;
+  command: string;
+  args: string[];
+  env: Record<string, { value: string; isSecret: boolean }>;
+  url?: string;
+  headers: Record<string, { value: string; isSecret: boolean }>;
+}): McpServerFormState {
+  return {
+    name: existing?.name ?? '',
+    serverType: existing?.type ?? 'stdio',
+    command: existing?.command ?? '',
+    args: existing?.args.join(' ') ?? '',
+    envVars: existing?.env
+      ? Object.entries(existing.env).map(([key, { value, isSecret }]) => ({
+          key,
+          value: isSecret ? '' : value,
+          isSecret,
+        }))
+      : [],
+    url: existing?.url ?? '',
+    headers: existing?.headers
+      ? Object.entries(existing.headers).map(([key, { value, isSecret }]) => ({
+          key,
+          value: isSecret ? '' : value,
+          isSecret,
+        }))
+      : [],
+    error: null,
+    isPending: false,
+  };
+}
+
+export function mcpServerFormReducer(
+  state: McpServerFormState,
+  action: McpServerFormAction
+): McpServerFormState {
+  switch (action.type) {
+    case 'setName':
+      return { ...state, name: action.name };
+    case 'setServerType':
+      return { ...state, serverType: action.serverType };
+    case 'setCommand':
+      return { ...state, command: action.command };
+    case 'setArgs':
+      return { ...state, args: action.args };
+    case 'setEnvVars':
+      return { ...state, envVars: action.envVars };
+    case 'setUrl':
+      return { ...state, url: action.url };
+    case 'setHeaders':
+      return { ...state, headers: action.headers };
+    case 'setError':
+      return { ...state, error: action.error };
+    case 'startSubmit':
+      return { ...state, error: null, isPending: true };
+    case 'submitError':
+      return { ...state, error: action.error, isPending: false };
+    case 'finishSubmit':
+      return { ...state, isPending: false };
+  }
+}


### PR DESCRIPTION
## Summary
- Refactors `EnvVarSection` and `McpServerSection` components to use `useReducer` instead of multiple `useState` calls, matching the pattern established by `NewSessionForm`'s `formReducer`
- Extracts four new reducers into dedicated, testable files: `envVarSectionReducer`, `envVarFormReducer`, `mcpServerSectionReducer`, and `mcpServerFormReducer`
- Adds 56 new unit tests covering all reducer state transitions

## Test plan
- [x] All 305 tests pass (`pnpm test:run`)
- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] ESLint and Prettier pass (via lint-staged pre-commit hook)
- [ ] Manual test: add/edit/delete environment variables in repo settings
- [ ] Manual test: add/edit/delete MCP servers in repo settings
- [ ] Manual test: toggle secret visibility for env vars
- [ ] Manual test: validate MCP server connections

Fixes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)