### PR TITLE
Replace prop drilling with MessageListContext

### DIFF
--- a/src/components/messages/AskUserQuestionDisplay.tsx
+++ b/src/components/messages/AskUserQuestionDisplay.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo } from 'react';
 import { cn } from '@/lib/utils';
 import { Badge } from '@/components/ui/badge';
 import { ToolDisplayWrapper } from './ToolDisplayWrapper';
+import { useMessageListContext } from './MessageListContext';
 import type { ToolCall } from './types';
 
 interface QuestionOption {
@@ -86,23 +87,14 @@ function RadioIcon({ selected }: { selected?: boolean }) {
   );
 }
 
-interface AskUserQuestionDisplayProps {
-  tool: ToolCall;
-  /** Callback to send a response to Claude */
-  onSendResponse?: (response: string) => void;
-  /** Whether Claude is currently running (disables clicking options) */
-  isClaudeRunning?: boolean;
-}
-
 /**
  * Specialized display for AskUserQuestion tool calls.
  * Shows a nicely formatted question with clickable options.
  */
-export function AskUserQuestionDisplay({
-  tool,
-  onSendResponse,
-  isClaudeRunning,
-}: AskUserQuestionDisplayProps) {
+export function AskUserQuestionDisplay({ tool }: { tool: ToolCall }) {
+  const ctx = useMessageListContext();
+  const onSendResponse = ctx?.onSendResponse;
+  const isClaudeRunning = ctx?.isClaudeRunning;
   const [selectedOptions, setSelectedOptions] = useState<Map<number, Set<number>>>(new Map());
 
   const hasOutput = tool.output !== undefined;

--- a/src/components/messages/MessageBubble.test.tsx
+++ b/src/components/messages/MessageBubble.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MessageBubble } from './MessageBubble';
+import { MessageListProvider } from './MessageListContext';
 import type { ToolResultMap, MessageContent } from './types';
 
 describe('MessageBubble', () => {
@@ -299,7 +300,7 @@ describe('MessageBubble', () => {
   });
 
   describe('TodoWrite tracking', () => {
-    it('passes todo tracking props to TodoWrite tool displays', () => {
+    it('renders TodoWrite tool display when context is provided', () => {
       const onTodoManualToggle = vi.fn();
       const manuallyToggledTodoIds = new Set<string>();
 
@@ -322,12 +323,15 @@ describe('MessageBubble', () => {
       };
 
       render(
-        <MessageBubble
-          message={message}
-          latestTodoWriteId="todo-1"
-          manuallyToggledTodoIds={manuallyToggledTodoIds}
-          onTodoManualToggle={onTodoManualToggle}
-        />
+        <MessageListProvider
+          value={{
+            latestTodoWriteId: 'todo-1',
+            manuallyToggledTodoIds,
+            onTodoManualToggle,
+          }}
+        >
+          <MessageBubble message={message} />
+        </MessageListProvider>
       );
 
       // TodoWriteDisplay should be rendered (check for its specific elements)

--- a/src/components/messages/MessageListContext.tsx
+++ b/src/components/messages/MessageListContext.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+
+interface MessageListContextValue {
+  /** The tool ID of the latest TodoWrite call (by sequence), or null */
+  latestTodoWriteId: string | null;
+  /** Set of TodoWrite tool IDs that the user has manually toggled */
+  manuallyToggledTodoIds: Set<string>;
+  /** Callback when a TodoWrite is manually toggled by the user */
+  onTodoManualToggle: (toolId: string) => void;
+  /** Callback to send a response to Claude (for AskUserQuestion) */
+  onSendResponse?: (response: string) => void;
+  /** Whether Claude is currently running (disables AskUserQuestion interactions) */
+  isClaudeRunning?: boolean;
+}
+
+const MessageListContext = createContext<MessageListContextValue | null>(null);
+
+export function MessageListProvider({
+  children,
+  value,
+}: {
+  children: React.ReactNode;
+  value: MessageListContextValue;
+}) {
+  return <MessageListContext.Provider value={value}>{children}</MessageListContext.Provider>;
+}
+
+export function useMessageListContext(): MessageListContextValue | null {
+  return useContext(MessageListContext);
+}

--- a/src/components/messages/TodoWriteDisplay.tsx
+++ b/src/components/messages/TodoWriteDisplay.tsx
@@ -4,17 +4,11 @@ import { useState } from 'react';
 import { cn } from '@/lib/utils';
 import { Badge } from '@/components/ui/badge';
 import { ToolDisplayWrapper } from './ToolDisplayWrapper';
+import { useMessageListContext } from './MessageListContext';
 import type { ToolCall, TodoItem } from './types';
 
 interface TodoWriteInput {
   todos: TodoItem[];
-}
-
-interface TodoWriteDisplayProps {
-  tool: ToolCall;
-  isLatest?: boolean;
-  wasManuallyToggled?: boolean;
-  onManualToggle?: () => void;
 }
 
 // Checkmark icon for completed items
@@ -90,12 +84,11 @@ function ChecklistIcon() {
  * Shows a checklist of todo items with status indicators.
  * Supports auto-collapse behavior for non-latest items.
  */
-export function TodoWriteDisplay({
-  tool,
-  isLatest = false,
-  wasManuallyToggled = false,
-  onManualToggle,
-}: TodoWriteDisplayProps) {
+export function TodoWriteDisplay({ tool }: { tool: ToolCall }) {
+  const ctx = useMessageListContext();
+  const isLatest = ctx ? tool.id === ctx.latestTodoWriteId : false;
+  const wasManuallyToggled = ctx && tool.id ? ctx.manuallyToggledTodoIds.has(tool.id) : false;
+
   const [manualExpandedState, setManualExpandedState] = useState(true);
 
   // Conditional expanded state:
@@ -104,7 +97,9 @@ export function TodoWriteDisplay({
   const expanded = wasManuallyToggled ? manualExpandedState : isLatest;
 
   const handleOpenChange = (open: boolean) => {
-    onManualToggle?.();
+    if (ctx && tool.id) {
+      ctx.onTodoManualToggle(tool.id);
+    }
     setManualExpandedState(open);
   };
 


### PR DESCRIPTION
## Summary
- Creates `MessageListContext` to provide todo tracking state (`latestTodoWriteId`, `manuallyToggledTodoIds`, `onTodoManualToggle`) and response handler props (`onSendResponse`, `isClaudeRunning`) via React context
- Removes 5 pass-through props from `MessageBubble` that it never used — only forwarded to child components
- `TodoWriteDisplay` and `AskUserQuestionDisplay` now consume context directly, and are added to the unified `TOOL_DISPLAY_MAP` instead of being special-cased in `renderContentBlocks`

## Test plan
- [x] All 305 existing tests pass
- [x] ESLint passes
- [ ] Verify TodoWrite auto-expand/collapse behavior works in UI
- [ ] Verify AskUserQuestion clickable options work in UI

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)