### PR TITLE
Share PartialAssistantMessage type between agent-service and main app

### DIFF
--- a/agent-service/package.json
+++ b/agent-service/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc",
-    "start": "node dist/index.js",
+    "start": "node dist/agent-service/src/index.js",
     "dev": "tsx src/index.ts",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/agent-service/src/stream-accumulator.ts
+++ b/agent-service/src/stream-accumulator.ts
@@ -11,6 +11,10 @@
  * the frontend replaces the partial with the final version.
  */
 
+import type { PartialAssistantMessage } from '../../shared/agent-types.js';
+
+export type { PartialAssistantMessage };
+
 /**
  * Represents a content block being accumulated from stream deltas.
  */
@@ -22,29 +26,6 @@ interface AccumulatingContentBlock {
   id?: string;
   name?: string;
   input?: string; // accumulated JSON string, parsed at emission time
-}
-
-/**
- * A partial assistant message built from accumulated stream events.
- * Shaped to match the assistant message content structure so the frontend
- * can render it identically to a complete message.
- */
-export interface PartialAssistantMessage {
-  type: 'assistant';
-  /** Whether this is a partial (in-progress) message */
-  partial: true;
-  message: {
-    role: 'assistant';
-    content: Array<
-      | { type: 'text'; text: string }
-      | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> }
-    >;
-    model?: string;
-    stop_reason?: string | null;
-  };
-  parent_tool_use_id: string | null;
-  uuid: string;
-  session_id: string;
 }
 
 /**

--- a/agent-service/tsconfig.json
+++ b/agent-service/tsconfig.json
@@ -5,7 +5,7 @@
     "moduleResolution": "bundler",
     "lib": ["ES2022"],
     "outDir": "./dist",
-    "rootDir": "./src",
+    "rootDir": "..",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
@@ -13,6 +13,6 @@
     "resolveJsonModule": true,
     "isolatedModules": true
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "../shared/**/*.ts"],
   "exclude": ["node_modules", "dist", "**/*.test.ts"]
 }

--- a/docker/Dockerfile.claude-code
+++ b/docker/Dockerfile.claude-code
@@ -109,9 +109,10 @@ RUN corepack enable && \
 COPY agent-service/package.json agent-service/package-lock.json* /opt/agent-service/
 RUN cd /opt/agent-service && npm install
 
-# Copy source, build, then prune devDependencies
+# Copy source and shared types, build, then prune devDependencies
 COPY agent-service/tsconfig.json /opt/agent-service/
 COPY agent-service/src/ /opt/agent-service/src/
+COPY shared/ /opt/shared/
 RUN cd /opt/agent-service && \
     npm run build && \
     npm prune --production

--- a/shared/agent-types.ts
+++ b/shared/agent-types.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared types for the SSE protocol between the agent service and the main Next.js app.
+ *
+ * These types define the contract for streaming messages from the agent service
+ * (running inside Podman containers) to the main app. Both sides must agree on
+ * these shapes for the protocol to work correctly.
+ */
+
+/**
+ * A partial assistant message built from accumulated stream events.
+ * Shaped to match the assistant message content structure so the frontend
+ * can render it identically to a complete message.
+ *
+ * Produced by the agent service's StreamAccumulator and consumed by the
+ * main app's agent client.
+ */
+export interface PartialAssistantMessage {
+  type: 'assistant';
+  /** Whether this is a partial (in-progress) message */
+  partial: true;
+  message: {
+    role: 'assistant';
+    content: Array<
+      | { type: 'text'; text: string }
+      | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> }
+    >;
+    model?: string;
+    stop_reason?: string | null;
+  };
+  parent_tool_use_id: string | null;
+  uuid: string;
+  session_id: string;
+}

--- a/src/server/services/agent-client.ts
+++ b/src/server/services/agent-client.ts
@@ -14,6 +14,7 @@ import { resolve } from 'node:path';
 import type { SDKMessage, SlashCommand } from '@anthropic-ai/claude-agent-sdk';
 import { createLogger, toError } from '@/lib/logger';
 import { env } from '@/lib/env';
+import type { PartialAssistantMessage } from '../../../shared/agent-types';
 
 const log = createLogger('agent-client');
 
@@ -32,22 +33,7 @@ export interface AgentMessage {
  */
 export interface AgentPartialMessage {
   kind: 'partial';
-  partial: {
-    type: 'assistant';
-    partial: true;
-    message: {
-      role: 'assistant';
-      content: Array<
-        | { type: 'text'; text: string }
-        | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> }
-      >;
-      model?: string;
-      stop_reason?: string | null;
-    };
-    parent_tool_use_id: string | null;
-    uuid: string;
-    session_id: string;
-  };
+  partial: PartialAssistantMessage;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Extracts the duplicated `PartialAssistantMessage` type into `shared/agent-types.ts` as a single source of truth
- Updates agent-service (`stream-accumulator.ts`) to import and re-export from shared types
- Updates main app (`agent-client.ts`) to reference `PartialAssistantMessage` in `AgentPartialMessage`
- Adjusts agent-service `tsconfig.json` rootDir and Dockerfile to support the shared directory

## Test plan
- [x] Main app type-checks cleanly (`npx tsc --noEmit`)
- [x] Agent-service type-checks (only pre-existing `better-sqlite3` error from missing local node_modules)
- [x] All 305 tests pass across 18 test files (`pnpm test:run`)
- [ ] Verify Docker build works with the updated Dockerfile (COPY shared/)

Fixes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)