### PR TITLE
Extract shared SettingsListEditor from EnvVarSection and McpServerSection

### DIFF
--- a/src/components/settings/shared/EnvVarSection.tsx
+++ b/src/components/settings/shared/EnvVarSection.tsx
@@ -6,8 +6,8 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Spinner } from '@/components/ui/spinner';
-import { Plus, Trash2, Eye, EyeOff } from 'lucide-react';
-import { DeleteConfirmDialog } from './DeleteConfirmDialog';
+import { Eye, EyeOff } from 'lucide-react';
+import { SettingsListEditor } from './SettingsListEditor';
 import {
   envVarSectionReducer,
   initialEnvVarSectionState,
@@ -68,100 +68,61 @@ export function EnvVarSection({
   };
 
   return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <h3 className="font-medium">Environment Variables</h3>
-        <Button variant="outline" size="sm" onClick={() => dispatch({ type: 'openForm' })}>
-          <Plus className="h-4 w-4 mr-1" />
-          Add
-        </Button>
-      </div>
-
-      {envVars.length === 0 && !state.showForm ? (
-        <p className="text-sm text-muted-foreground">{emptyMessage}</p>
-      ) : (
-        <ul className="space-y-2">
-          {envVars.map((envVar) => (
-            <li key={envVar.id} className="flex items-center gap-2 p-2 rounded-md bg-muted/50">
-              <div className="flex-1 min-w-0">
-                <div className="font-mono text-sm">{envVar.name}</div>
-                <div className="text-xs text-muted-foreground flex items-center gap-1">
-                  {envVar.isSecret ? (
-                    <>
-                      <span>
-                        {state.revealedSecrets.has(envVar.name)
-                          ? state.revealedSecrets.get(envVar.name)
-                          : '••••••••'}
-                      </span>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="h-5 w-5 p-0"
-                        onClick={() => toggleSecretVisibility(envVar.name)}
-                        disabled={state.loadingSecret === envVar.name}
-                      >
-                        {state.loadingSecret === envVar.name ? (
-                          <Spinner size="sm" className="h-3 w-3" />
-                        ) : state.revealedSecrets.has(envVar.name) ? (
-                          <EyeOff className="h-3 w-3" />
-                        ) : (
-                          <Eye className="h-3 w-3" />
-                        )}
-                      </Button>
-                    </>
+    <SettingsListEditor
+      title="Environment Variables"
+      items={envVars}
+      state={state}
+      dispatch={dispatch}
+      onDelete={handleDelete}
+      emptyMessage={emptyMessage}
+      deleteDialogTitle="Delete environment variable?"
+      deleteDescriptionPrefix={deleteDescriptionPrefix}
+      renderItem={(envVar) => (
+        <>
+          <div className="font-mono text-sm">{envVar.name}</div>
+          <div className="text-xs text-muted-foreground flex items-center gap-1">
+            {envVar.isSecret ? (
+              <>
+                <span>
+                  {state.revealedSecrets.has(envVar.name)
+                    ? state.revealedSecrets.get(envVar.name)
+                    : '••••••••'}
+                </span>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-5 w-5 p-0"
+                  onClick={() => toggleSecretVisibility(envVar.name)}
+                  disabled={state.loadingSecret === envVar.name}
+                >
+                  {state.loadingSecret === envVar.name ? (
+                    <Spinner size="sm" className="h-3 w-3" />
+                  ) : state.revealedSecrets.has(envVar.name) ? (
+                    <EyeOff className="h-3 w-3" />
                   ) : (
-                    <span className="truncate">{envVar.value}</span>
+                    <Eye className="h-3 w-3" />
                   )}
-                </div>
-              </div>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => dispatch({ type: 'startEditing', id: envVar.id })}
-              >
-                Edit
-              </Button>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => dispatch({ type: 'setDeleteTarget', name: envVar.name })}
-                className="text-destructive hover:text-destructive"
-              >
-                <Trash2 className="h-4 w-4" />
-              </Button>
-            </li>
-          ))}
-        </ul>
+                </Button>
+              </>
+            ) : (
+              <span className="truncate">{envVar.value}</span>
+            )}
+          </div>
+        </>
       )}
-
-      {(state.showForm || state.editingId) && (
+      renderForm={({ existingItem, onClose, onSuccess }) => (
         <EnvVarForm
-          existingEnvVar={
-            state.editingId ? envVars.find((e) => e.id === state.editingId) : undefined
-          }
-          onClose={() => dispatch({ type: 'closeForm' })}
+          existingEnvVar={existingItem}
+          onClose={onClose}
           onSuccess={() => {
-            dispatch({ type: 'formSuccess' });
+            onSuccess();
             onUpdate();
           }}
           setEnvVar={mutations.setEnvVar}
           idPrefix={idPrefix}
         />
       )}
-
-      <DeleteConfirmDialog
-        open={!!state.deleteTarget}
-        onClose={() => dispatch({ type: 'setDeleteTarget', name: null })}
-        onConfirm={handleDelete}
-        title="Delete environment variable?"
-        description={
-          <>
-            {deleteDescriptionPrefix} <strong>{state.deleteTarget}</strong>.
-          </>
-        }
-        isPending={state.isDeleting}
-      />
-    </div>
+    />
   );
 }
 

--- a/src/components/settings/shared/SettingsListEditor.tsx
+++ b/src/components/settings/shared/SettingsListEditor.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { ReactNode } from 'react';
+import { Button } from '@/components/ui/button';
+import { Plus, Trash2 } from 'lucide-react';
+import { DeleteConfirmDialog } from './DeleteConfirmDialog';
+import type { SettingsListState, SettingsListAction } from './settings-list-reducer';
+
+interface SettingsListItem {
+  id: string;
+  name: string;
+}
+
+interface SettingsListEditorProps<T extends SettingsListItem> {
+  title: string;
+  items: T[];
+  state: SettingsListState;
+  dispatch: (action: SettingsListAction) => void;
+  onDelete: () => void;
+  emptyMessage: string;
+  deleteDialogTitle: string;
+  deleteDescriptionPrefix: string;
+  renderItem: (item: T) => ReactNode;
+  renderForm: (props: {
+    existingItem: T | undefined;
+    onClose: () => void;
+    onSuccess: () => void;
+  }) => ReactNode;
+  extraItemActions?: (item: T) => ReactNode;
+  renderItemExtra?: (item: T) => ReactNode;
+}
+
+export function SettingsListEditor<T extends SettingsListItem>({
+  title,
+  items,
+  state,
+  dispatch,
+  onDelete,
+  emptyMessage,
+  deleteDialogTitle,
+  deleteDescriptionPrefix,
+  renderItem,
+  renderForm,
+  extraItemActions,
+  renderItemExtra,
+}: SettingsListEditorProps<T>) {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="font-medium">{title}</h3>
+        <Button variant="outline" size="sm" onClick={() => dispatch({ type: 'openForm' })}>
+          <Plus className="h-4 w-4 mr-1" />
+          Add
+        </Button>
+      </div>
+
+      {items.length === 0 && !state.showForm ? (
+        <p className="text-sm text-muted-foreground">{emptyMessage}</p>
+      ) : (
+        <ul className="space-y-2">
+          {items.map((item) => (
+            <li key={item.id} className="space-y-1">
+              <div className="flex items-center gap-2 p-2 rounded-md bg-muted/50">
+                <div className="flex-1 min-w-0">{renderItem(item)}</div>
+                {extraItemActions?.(item)}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => dispatch({ type: 'startEditing', id: item.id })}
+                >
+                  Edit
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => dispatch({ type: 'setDeleteTarget', name: item.name })}
+                  className="text-destructive hover:text-destructive"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
+              {renderItemExtra?.(item)}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {(state.showForm || state.editingId) &&
+        renderForm({
+          existingItem: state.editingId
+            ? items.find((item) => item.id === state.editingId)
+            : undefined,
+          onClose: () => dispatch({ type: 'closeForm' }),
+          onSuccess: () => dispatch({ type: 'formSuccess' }),
+        })}
+
+      <DeleteConfirmDialog
+        open={!!state.deleteTarget}
+        onClose={() => dispatch({ type: 'setDeleteTarget', name: null })}
+        onConfirm={onDelete}
+        title={deleteDialogTitle}
+        description={
+          <>
+            {deleteDescriptionPrefix} <strong>{state.deleteTarget}</strong>.
+          </>
+        }
+        isPending={state.isDeleting}
+      />
+    </div>
+  );
+}

--- a/src/components/settings/shared/env-var-reducer.ts
+++ b/src/components/settings/shared/env-var-reducer.ts
@@ -1,32 +1,27 @@
+import {
+  SettingsListState,
+  SettingsListAction,
+  initialSettingsListState,
+  reduceSettingsListAction,
+} from './settings-list-reducer';
+
 // -- EnvVarSection (list management) reducer --
 
-export interface EnvVarSectionState {
-  showForm: boolean;
-  editingId: string | null;
-  deleteTarget: string | null;
-  isDeleting: boolean;
+export interface EnvVarSectionState extends SettingsListState {
   revealedSecrets: Map<string, string>;
   loadingSecret: string | null;
 }
 
-export type EnvVarSectionAction =
-  | { type: 'openForm' }
-  | { type: 'startEditing'; id: string }
-  | { type: 'closeForm' }
-  | { type: 'formSuccess' }
-  | { type: 'setDeleteTarget'; name: string | null }
-  | { type: 'startDeleting' }
-  | { type: 'finishDeleting' }
+type EnvVarSpecificAction =
   | { type: 'startLoadingSecret'; name: string }
   | { type: 'revealSecret'; name: string; value: string }
   | { type: 'hideSecret'; name: string }
   | { type: 'finishLoadingSecret' };
 
+export type EnvVarSectionAction = SettingsListAction | EnvVarSpecificAction;
+
 export const initialEnvVarSectionState: EnvVarSectionState = {
-  showForm: false,
-  editingId: null,
-  deleteTarget: null,
-  isDeleting: false,
+  ...initialSettingsListState,
   revealedSecrets: new Map(),
   loadingSecret: null,
 };
@@ -35,21 +30,10 @@ export function envVarSectionReducer(
   state: EnvVarSectionState,
   action: EnvVarSectionAction
 ): EnvVarSectionState {
+  const baseResult = reduceSettingsListAction(state, action as SettingsListAction);
+  if (baseResult) return baseResult;
+
   switch (action.type) {
-    case 'openForm':
-      return { ...state, showForm: true };
-    case 'startEditing':
-      return { ...state, editingId: action.id };
-    case 'closeForm':
-      return { ...state, showForm: false, editingId: null };
-    case 'formSuccess':
-      return { ...state, showForm: false, editingId: null };
-    case 'setDeleteTarget':
-      return { ...state, deleteTarget: action.name };
-    case 'startDeleting':
-      return { ...state, isDeleting: true };
-    case 'finishDeleting':
-      return { ...state, isDeleting: false, deleteTarget: null };
     case 'startLoadingSecret':
       return { ...state, loadingSecret: action.name };
     case 'revealSecret': {
@@ -64,6 +48,8 @@ export function envVarSectionReducer(
     }
     case 'finishLoadingSecret':
       return { ...state, loadingSecret: null };
+    default:
+      return state;
   }
 }
 

--- a/src/components/settings/shared/mcp-server-reducer.ts
+++ b/src/components/settings/shared/mcp-server-reducer.ts
@@ -1,33 +1,27 @@
+import {
+  SettingsListState,
+  SettingsListAction,
+  initialSettingsListState,
+  reduceSettingsListAction,
+} from './settings-list-reducer';
 import type { McpServerType, ValidationResult } from '@/lib/settings-types';
 
 // -- McpServerSection (list management) reducer --
 
-export interface McpServerSectionState {
-  showForm: boolean;
-  editingId: string | null;
-  deleteTarget: string | null;
-  isDeleting: boolean;
+export interface McpServerSectionState extends SettingsListState {
   validationResults: Map<string, ValidationResult>;
   validatingServer: string | null;
 }
 
-export type McpServerSectionAction =
-  | { type: 'openForm' }
-  | { type: 'startEditing'; id: string }
-  | { type: 'closeForm' }
-  | { type: 'formSuccess' }
-  | { type: 'setDeleteTarget'; name: string | null }
-  | { type: 'startDeleting' }
-  | { type: 'finishDeleting' }
+type McpServerSpecificAction =
   | { type: 'startValidating'; name: string }
   | { type: 'setValidationResult'; name: string; result: ValidationResult }
   | { type: 'finishValidating' };
 
+export type McpServerSectionAction = SettingsListAction | McpServerSpecificAction;
+
 export const initialMcpServerSectionState: McpServerSectionState = {
-  showForm: false,
-  editingId: null,
-  deleteTarget: null,
-  isDeleting: false,
+  ...initialSettingsListState,
   validationResults: new Map(),
   validatingServer: null,
 };
@@ -36,21 +30,10 @@ export function mcpServerSectionReducer(
   state: McpServerSectionState,
   action: McpServerSectionAction
 ): McpServerSectionState {
+  const baseResult = reduceSettingsListAction(state, action as SettingsListAction);
+  if (baseResult) return baseResult;
+
   switch (action.type) {
-    case 'openForm':
-      return { ...state, showForm: true };
-    case 'startEditing':
-      return { ...state, editingId: action.id };
-    case 'closeForm':
-      return { ...state, showForm: false, editingId: null };
-    case 'formSuccess':
-      return { ...state, showForm: false, editingId: null };
-    case 'setDeleteTarget':
-      return { ...state, deleteTarget: action.name };
-    case 'startDeleting':
-      return { ...state, isDeleting: true };
-    case 'finishDeleting':
-      return { ...state, isDeleting: false, deleteTarget: null };
     case 'startValidating':
       return { ...state, validatingServer: action.name };
     case 'setValidationResult': {
@@ -60,6 +43,8 @@ export function mcpServerSectionReducer(
     }
     case 'finishValidating':
       return { ...state, validatingServer: null };
+    default:
+      return state;
   }
 }
 

--- a/src/components/settings/shared/settings-list-reducer.test.ts
+++ b/src/components/settings/shared/settings-list-reducer.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { reduceSettingsListAction, initialSettingsListState } from './settings-list-reducer';
+import type { SettingsListState, SettingsListAction } from './settings-list-reducer';
+
+describe('reduceSettingsListAction', () => {
+  describe('form visibility', () => {
+    it('opens the form', () => {
+      const result = reduceSettingsListAction(initialSettingsListState, { type: 'openForm' });
+      expect(result).toEqual({ ...initialSettingsListState, showForm: true });
+    });
+
+    it('starts editing by id', () => {
+      const result = reduceSettingsListAction(initialSettingsListState, {
+        type: 'startEditing',
+        id: 'item-1',
+      });
+      expect(result).toEqual({ ...initialSettingsListState, editingId: 'item-1' });
+    });
+
+    it('closes the form and clears editingId', () => {
+      const state: SettingsListState = {
+        ...initialSettingsListState,
+        showForm: true,
+        editingId: 'item-1',
+      };
+      const result = reduceSettingsListAction(state, { type: 'closeForm' });
+      expect(result?.showForm).toBe(false);
+      expect(result?.editingId).toBeNull();
+    });
+
+    it('formSuccess closes form and clears editingId', () => {
+      const state: SettingsListState = {
+        ...initialSettingsListState,
+        showForm: true,
+        editingId: 'item-1',
+      };
+      const result = reduceSettingsListAction(state, { type: 'formSuccess' });
+      expect(result?.showForm).toBe(false);
+      expect(result?.editingId).toBeNull();
+    });
+  });
+
+  describe('delete flow', () => {
+    it('sets delete target', () => {
+      const result = reduceSettingsListAction(initialSettingsListState, {
+        type: 'setDeleteTarget',
+        name: 'MY_ITEM',
+      });
+      expect(result?.deleteTarget).toBe('MY_ITEM');
+    });
+
+    it('clears delete target', () => {
+      const state: SettingsListState = {
+        ...initialSettingsListState,
+        deleteTarget: 'MY_ITEM',
+      };
+      const result = reduceSettingsListAction(state, { type: 'setDeleteTarget', name: null });
+      expect(result?.deleteTarget).toBeNull();
+    });
+
+    it('starts deleting', () => {
+      const result = reduceSettingsListAction(initialSettingsListState, { type: 'startDeleting' });
+      expect(result?.isDeleting).toBe(true);
+    });
+
+    it('finishes deleting and clears target', () => {
+      const state: SettingsListState = {
+        ...initialSettingsListState,
+        isDeleting: true,
+        deleteTarget: 'MY_ITEM',
+      };
+      const result = reduceSettingsListAction(state, { type: 'finishDeleting' });
+      expect(result?.isDeleting).toBe(false);
+      expect(result?.deleteTarget).toBeNull();
+    });
+  });
+
+  it('returns null for unrecognized actions', () => {
+    const result = reduceSettingsListAction(initialSettingsListState, {
+      type: 'unknownAction',
+    } as unknown as SettingsListAction);
+    expect(result).toBeNull();
+  });
+
+  it('preserves extra state fields from extended state', () => {
+    interface ExtendedState extends SettingsListState {
+      customField: string;
+    }
+    const state: ExtendedState = {
+      ...initialSettingsListState,
+      customField: 'preserved',
+    };
+    const result = reduceSettingsListAction(state, { type: 'openForm' });
+    expect(result?.showForm).toBe(true);
+    expect((result as ExtendedState).customField).toBe('preserved');
+  });
+});

--- a/src/components/settings/shared/settings-list-reducer.ts
+++ b/src/components/settings/shared/settings-list-reducer.ts
@@ -1,0 +1,53 @@
+// -- Shared settings list state management --
+// Base state and actions shared by EnvVarSection and McpServerSection
+
+export interface SettingsListState {
+  showForm: boolean;
+  editingId: string | null;
+  deleteTarget: string | null;
+  isDeleting: boolean;
+}
+
+export type SettingsListAction =
+  | { type: 'openForm' }
+  | { type: 'startEditing'; id: string }
+  | { type: 'closeForm' }
+  | { type: 'formSuccess' }
+  | { type: 'setDeleteTarget'; name: string | null }
+  | { type: 'startDeleting' }
+  | { type: 'finishDeleting' };
+
+export const initialSettingsListState: SettingsListState = {
+  showForm: false,
+  editingId: null,
+  deleteTarget: null,
+  isDeleting: false,
+};
+
+/**
+ * Handles the shared settings list actions. Returns the new state if the action
+ * was handled, or null if the action is not a base settings list action.
+ */
+export function reduceSettingsListAction<S extends SettingsListState>(
+  state: S,
+  action: SettingsListAction
+): S | null {
+  switch (action.type) {
+    case 'openForm':
+      return { ...state, showForm: true };
+    case 'startEditing':
+      return { ...state, editingId: action.id };
+    case 'closeForm':
+      return { ...state, showForm: false, editingId: null };
+    case 'formSuccess':
+      return { ...state, showForm: false, editingId: null };
+    case 'setDeleteTarget':
+      return { ...state, deleteTarget: action.name };
+    case 'startDeleting':
+      return { ...state, isDeleting: true };
+    case 'finishDeleting':
+      return { ...state, isDeleting: false, deleteTarget: null };
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
## Summary
- Extracts duplicated state management (`showForm`, `editingId`, `deleteTarget`, `isDeleting`) and reducer logic into a shared `settings-list-reducer.ts` with `reduceSettingsListAction()`
- Creates a generic `SettingsListEditor` component that handles the common UI patterns: header with add button, list rendering with edit/delete actions, delete confirmation dialog, and form show/hide lifecycle
- Refactors `EnvVarSection` and `McpServerSection` to use the shared abstractions via render props for type-specific content (env var display/form vs MCP server display/form)

Fixes #213

## Test plan
- [x] All 315 existing + new tests pass (`pnpm test:run`)
- [x] TypeScript compiles without errors (`tsc --noEmit`)
- [x] Lint and prettier pass (via pre-commit hooks)
- [ ] Manual verification that env var and MCP server settings UI works correctly in both global settings and repo settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)