### PR TITLE
Add PR status indicators to session list

### DIFF
--- a/src/components/PrStatusIndicator.test.tsx
+++ b/src/components/PrStatusIndicator.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { PrStatusIndicator } from './PrStatusIndicator';
+import type { PullRequestInfo } from '@/hooks/usePullRequestStatus';
+
+const basePr: PullRequestInfo = {
+  number: 42,
+  title: 'Add feature X',
+  state: 'open',
+  draft: false,
+  url: 'https://github.com/owner/repo/pull/42',
+  author: 'testuser',
+  updatedAt: '2024-01-01T00:00:00Z',
+};
+
+describe('PrStatusIndicator', () => {
+  it('renders a link to the PR', () => {
+    render(<PrStatusIndicator pullRequest={basePr} />);
+
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', 'https://github.com/owner/repo/pull/42');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('shows correct aria-label for open PR', () => {
+    render(<PrStatusIndicator pullRequest={basePr} />);
+
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('aria-label', 'PR #42: Add feature X (Open)');
+  });
+
+  it('shows correct aria-label for merged PR', () => {
+    render(<PrStatusIndicator pullRequest={{ ...basePr, state: 'merged' }} />);
+
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('aria-label', 'PR #42: Add feature X (Merged)');
+  });
+
+  it('shows correct aria-label for closed PR', () => {
+    render(<PrStatusIndicator pullRequest={{ ...basePr, state: 'closed' }} />);
+
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('aria-label', 'PR #42: Add feature X (Closed)');
+  });
+
+  it('shows draft label for draft PRs', () => {
+    render(<PrStatusIndicator pullRequest={{ ...basePr, draft: true }} />);
+
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('aria-label', 'PR #42: Add feature X (Draft)');
+  });
+
+  it('applies green color class for open PRs', () => {
+    render(<PrStatusIndicator pullRequest={basePr} />);
+
+    const link = screen.getByRole('link');
+    expect(link.className).toContain('text-green-600');
+  });
+
+  it('applies purple color class for merged PRs', () => {
+    render(<PrStatusIndicator pullRequest={{ ...basePr, state: 'merged' }} />);
+
+    const link = screen.getByRole('link');
+    expect(link.className).toContain('text-purple-600');
+  });
+
+  it('applies red color class for closed PRs', () => {
+    render(<PrStatusIndicator pullRequest={{ ...basePr, state: 'closed' }} />);
+
+    const link = screen.getByRole('link');
+    expect(link.className).toContain('text-red-600');
+  });
+
+  it('applies muted color class for draft PRs', () => {
+    render(<PrStatusIndicator pullRequest={{ ...basePr, draft: true }} />);
+
+    const link = screen.getByRole('link');
+    expect(link.className).toContain('text-muted-foreground');
+  });
+
+  it('renders an SVG icon', () => {
+    render(<PrStatusIndicator pullRequest={basePr} />);
+
+    const link = screen.getByRole('link');
+    const svg = link.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+
+  it('applies custom className', () => {
+    render(<PrStatusIndicator pullRequest={basePr} className="custom-class" />);
+
+    const link = screen.getByRole('link');
+    expect(link.className).toContain('custom-class');
+  });
+});

--- a/src/components/PrStatusIndicator.tsx
+++ b/src/components/PrStatusIndicator.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { GitPullRequest, GitPullRequestClosed, GitPullRequestDraft, GitMerge } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+import type { PullRequestInfo, PrState } from '@/hooks/usePullRequestStatus';
+
+type EffectivePrState = PrState | 'draft';
+
+interface PrStateConfig {
+  icon: typeof GitPullRequest;
+  colorClass: string;
+  label: string;
+}
+
+const prStateConfig: Record<EffectivePrState, PrStateConfig> = {
+  open: {
+    icon: GitPullRequest,
+    colorClass: 'text-green-600 dark:text-green-400',
+    label: 'Open',
+  },
+  draft: {
+    icon: GitPullRequestDraft,
+    colorClass: 'text-muted-foreground',
+    label: 'Draft',
+  },
+  merged: {
+    icon: GitMerge,
+    colorClass: 'text-purple-600 dark:text-purple-400',
+    label: 'Merged',
+  },
+  closed: {
+    icon: GitPullRequestClosed,
+    colorClass: 'text-red-600 dark:text-red-400',
+    label: 'Closed',
+  },
+};
+
+interface PrStatusIndicatorProps {
+  pullRequest: PullRequestInfo;
+  className?: string;
+}
+
+export function PrStatusIndicator({ pullRequest, className }: PrStatusIndicatorProps) {
+  const effectiveState: EffectivePrState =
+    pullRequest.draft && pullRequest.state === 'open' ? 'draft' : pullRequest.state;
+
+  const config = prStateConfig[effectiveState];
+  const Icon = config.icon;
+
+  return (
+    <TooltipProvider>
+      <Tooltip delayDuration={300}>
+        <TooltipTrigger asChild>
+          <a
+            href={pullRequest.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={cn(
+              'inline-flex items-center justify-center p-1 rounded-md',
+              'hover:bg-muted/50 transition-colors',
+              config.colorClass,
+              className
+            )}
+            onClick={(e) => e.stopPropagation()}
+            aria-label={`PR #${pullRequest.number}: ${pullRequest.title} (${config.label})`}
+          >
+            <Icon className="w-4 h-4" />
+          </a>
+        </TooltipTrigger>
+        <TooltipContent side="top">
+          PR #{pullRequest.number}: {pullRequest.title} ({config.label})
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/src/components/SessionList.test.tsx
+++ b/src/components/SessionList.test.tsx
@@ -10,7 +10,7 @@ vi.mock('next/link', () => ({
   ),
 }));
 
-// Mock trpc so SessionListItem's useMutation calls work without a provider
+// Mock trpc so SessionListItem's useMutation and useQuery calls work without a provider
 vi.mock('@/lib/trpc', () => ({
   trpc: {
     sessions: {
@@ -18,6 +18,21 @@ vi.mock('@/lib/trpc', () => ({
       stop: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
       delete: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
     },
+    github: {
+      getPullRequestForBranch: {
+        useQuery: () => ({ data: null, isLoading: false }),
+      },
+    },
+    sse: {
+      onPrUpdate: {
+        useSubscription: vi.fn(),
+      },
+    },
+    useUtils: () => ({
+      github: {
+        getPullRequestForBranch: { setData: vi.fn() },
+      },
+    }),
   },
 }));
 

--- a/src/hooks/usePullRequestStatus.ts
+++ b/src/hooks/usePullRequestStatus.ts
@@ -1,0 +1,72 @@
+'use client';
+
+import { trpc } from '@/lib/trpc';
+import { extractRepoFullName } from '@/lib/utils';
+
+export type PrState = 'open' | 'closed' | 'merged';
+
+export interface PullRequestInfo {
+  number: number;
+  title: string;
+  state: PrState;
+  draft: boolean;
+  url: string;
+  author: string;
+  updatedAt: string;
+}
+
+export interface UsePullRequestStatusResult {
+  pullRequest: PullRequestInfo | null | undefined;
+  isLoading: boolean;
+}
+
+/**
+ * Hook to fetch and subscribe to PR status for a session's branch.
+ *
+ * - Fetches initial PR status via tRPC query (cached 5 min)
+ * - Subscribes to SSE updates so PR status updates in real-time when Claude finishes a turn
+ *
+ * @param sessionId - Session ID for SSE subscription
+ * @param repoUrl - Full GitHub repo URL (e.g. "https://github.com/owner/repo.git")
+ * @param branch - Branch name
+ * @param enabled - Whether to fetch (false for archived sessions)
+ * @returns PR info, null if no PR, undefined if loading/disabled
+ */
+export function usePullRequestStatus(
+  sessionId: string,
+  repoUrl: string,
+  branch: string,
+  enabled: boolean = true
+): UsePullRequestStatusResult {
+  const repoFullName = extractRepoFullName(repoUrl);
+  const utils = trpc.useUtils();
+
+  const { data, isLoading } = trpc.github.getPullRequestForBranch.useQuery(
+    { repoFullName, branch },
+    {
+      enabled,
+      staleTime: 5 * 60 * 1000,
+      refetchOnWindowFocus: false,
+    }
+  );
+
+  // Subscribe to real-time PR updates via SSE
+  trpc.sse.onPrUpdate.useSubscription(
+    { sessionId },
+    {
+      enabled,
+      onData: (trackedData) => {
+        const event = trackedData.data;
+        utils.github.getPullRequestForBranch.setData(
+          { repoFullName, branch },
+          { pullRequest: event.pullRequest as PullRequestInfo | null }
+        );
+      },
+    }
+  );
+
+  return {
+    pullRequest: data?.pullRequest as PullRequestInfo | null | undefined,
+    isLoading,
+  };
+}

--- a/src/server/services/github.test.ts
+++ b/src/server/services/github.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock global fetch
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+// Mock logger
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+  toError: (e: unknown) => (e instanceof Error ? e : new Error(String(e))),
+}));
+
+import { fetchPullRequestForBranch, GitHubApiError, githubFetch, parseLinkHeader } from './github';
+
+function createMockResponse(data: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: vi.fn().mockResolvedValue(data),
+    headers: {
+      get: () => null,
+    },
+  };
+}
+
+describe('github service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.GITHUB_TOKEN = 'test-token';
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('githubFetch', () => {
+    it('should fetch and parse JSON from GitHub API', async () => {
+      const mockData = { id: 1, name: 'test' };
+      mockFetch.mockResolvedValue(createMockResponse(mockData));
+
+      const result = await githubFetch<{ id: number; name: string }>('/repos/owner/repo', 'token');
+      expect(result).toEqual(mockData);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.github.com/repos/owner/repo',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer token',
+          }),
+        })
+      );
+    });
+
+    it('should throw GitHubApiError on non-ok response', async () => {
+      mockFetch.mockResolvedValue(createMockResponse({}, 404));
+
+      await expect(githubFetch('/repos/owner/repo', 'token')).rejects.toThrow(GitHubApiError);
+    });
+  });
+
+  describe('parseLinkHeader', () => {
+    it('should parse next page from link header', () => {
+      const header =
+        '<https://api.github.com/repos?page=3>; rel="next", <https://api.github.com/repos?page=5>; rel="last"';
+      expect(parseLinkHeader(header)).toEqual({ next: '3' });
+    });
+
+    it('should return empty object for null header', () => {
+      expect(parseLinkHeader(null)).toEqual({});
+    });
+
+    it('should return empty object when no next link', () => {
+      const header = '<https://api.github.com/repos?page=1>; rel="prev"';
+      expect(parseLinkHeader(header)).toEqual({});
+    });
+  });
+
+  describe('fetchPullRequestForBranch', () => {
+    it('should return PR info when a PR exists', async () => {
+      const mockPulls = [
+        {
+          id: 1,
+          number: 42,
+          title: 'Add feature X',
+          state: 'open',
+          draft: false,
+          merged_at: null,
+          html_url: 'https://github.com/owner/repo/pull/42',
+          user: { login: 'author' },
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-02T00:00:00Z',
+        },
+      ];
+      mockFetch.mockResolvedValue(createMockResponse(mockPulls));
+
+      const result = await fetchPullRequestForBranch('owner/repo', 'feature-branch');
+
+      expect(result).toEqual({
+        number: 42,
+        title: 'Add feature X',
+        state: 'open',
+        draft: false,
+        url: 'https://github.com/owner/repo/pull/42',
+        author: 'author',
+        updatedAt: '2024-01-02T00:00:00Z',
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/repos/owner/repo/pulls?head='),
+        expect.any(Object)
+      );
+    });
+
+    it('should return null when no PR exists for branch', async () => {
+      mockFetch.mockResolvedValue(createMockResponse([]));
+
+      const result = await fetchPullRequestForBranch('owner/repo', 'no-pr-branch');
+
+      expect(result).toBeNull();
+    });
+
+    it('should derive merged state from merged_at field', async () => {
+      const mockPulls = [
+        {
+          id: 1,
+          number: 10,
+          title: 'Merged PR',
+          state: 'closed',
+          draft: false,
+          merged_at: '2024-01-03T00:00:00Z',
+          html_url: 'https://github.com/owner/repo/pull/10',
+          user: { login: 'author' },
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-03T00:00:00Z',
+        },
+      ];
+      mockFetch.mockResolvedValue(createMockResponse(mockPulls));
+
+      const result = await fetchPullRequestForBranch('owner/repo', 'merged-branch');
+
+      expect(result?.state).toBe('merged');
+    });
+
+    it('should handle draft PRs', async () => {
+      const mockPulls = [
+        {
+          id: 1,
+          number: 5,
+          title: 'WIP: Draft PR',
+          state: 'open',
+          draft: true,
+          merged_at: null,
+          html_url: 'https://github.com/owner/repo/pull/5',
+          user: { login: 'author' },
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-02T00:00:00Z',
+        },
+      ];
+      mockFetch.mockResolvedValue(createMockResponse(mockPulls));
+
+      const result = await fetchPullRequestForBranch('owner/repo', 'draft-branch');
+
+      expect(result?.draft).toBe(true);
+      expect(result?.state).toBe('open');
+    });
+
+    it('should return undefined when no GitHub token is configured', async () => {
+      delete process.env.GITHUB_TOKEN;
+
+      const result = await fetchPullRequestForBranch('owner/repo', 'branch');
+
+      expect(result).toBeUndefined();
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('should return undefined on API errors', async () => {
+      mockFetch.mockResolvedValue(createMockResponse({}, 500));
+
+      const result = await fetchPullRequestForBranch('owner/repo', 'branch');
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should handle PR with null user', async () => {
+      const mockPulls = [
+        {
+          id: 1,
+          number: 7,
+          title: 'Ghost user PR',
+          state: 'open',
+          draft: false,
+          merged_at: null,
+          html_url: 'https://github.com/owner/repo/pull/7',
+          user: null,
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-02T00:00:00Z',
+        },
+      ];
+      mockFetch.mockResolvedValue(createMockResponse(mockPulls));
+
+      const result = await fetchPullRequestForBranch('owner/repo', 'ghost-branch');
+
+      expect(result?.author).toBe('unknown');
+    });
+
+    it('should use correct head filter format', async () => {
+      mockFetch.mockResolvedValue(createMockResponse([]));
+
+      await fetchPullRequestForBranch('myorg/myrepo', 'feature/test');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('head=' + encodeURIComponent('myorg:feature/test')),
+        expect.any(Object)
+      );
+    });
+  });
+});

--- a/src/server/services/github.ts
+++ b/src/server/services/github.ts
@@ -1,0 +1,145 @@
+import { createLogger } from '@/lib/logger';
+import { env } from '@/lib/env';
+
+const log = createLogger('github');
+
+const GITHUB_API = 'https://api.github.com';
+
+// =============================================================================
+// Shared types
+// =============================================================================
+
+export type PrState = 'open' | 'closed' | 'merged';
+
+export interface PullRequestInfo {
+  number: number;
+  title: string;
+  state: PrState;
+  draft: boolean;
+  url: string;
+  author: string;
+  updatedAt: string;
+}
+
+interface GitHubPullRequest {
+  id: number;
+  number: number;
+  title: string;
+  state: 'open' | 'closed';
+  draft: boolean;
+  merged_at: string | null;
+  html_url: string;
+  user: { login: string } | null;
+  created_at: string;
+  updated_at: string;
+}
+
+// =============================================================================
+// GitHub API helpers
+// =============================================================================
+
+export async function githubFetchResponse(path: string, token?: string): Promise<Response> {
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  const response = await fetch(`${GITHUB_API}${path}`, { headers });
+
+  if (!response.ok) {
+    throw new GitHubApiError(response.status, path);
+  }
+
+  return response;
+}
+
+export async function githubFetch<T>(path: string, token?: string): Promise<T> {
+  const response = await githubFetchResponse(path, token);
+  return response.json();
+}
+
+export class GitHubApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly path: string
+  ) {
+    super(`GitHub API error: ${status} for ${path}`);
+    this.name = 'GitHubApiError';
+  }
+}
+
+export function parseLinkHeader(header: string | null): { next?: string } {
+  if (!header) return {};
+
+  const links: { next?: string } = {};
+  const parts = header.split(',');
+
+  for (const part of parts) {
+    const match = part.match(/<([^>]+)>;\s*rel="([^"]+)"/);
+    if (match) {
+      const [, url, rel] = match;
+      if (rel === 'next') {
+        const pageMatch = url.match(/[?&]page=(\d+)/);
+        if (pageMatch) {
+          links.next = pageMatch[1];
+        }
+      }
+    }
+  }
+
+  return links;
+}
+
+// =============================================================================
+// PR lookup
+// =============================================================================
+
+/**
+ * Fetch the most recent pull request for a given branch.
+ * Returns null if no PR exists for the branch.
+ * Returns undefined if the GitHub token is not configured.
+ */
+export async function fetchPullRequestForBranch(
+  repoFullName: string,
+  branch: string
+): Promise<PullRequestInfo | null | undefined> {
+  const token = env.GITHUB_TOKEN;
+  if (!token) {
+    return undefined;
+  }
+
+  const [owner] = repoFullName.split('/');
+  const headFilter = `${owner}:${branch}`;
+
+  try {
+    const pulls = await githubFetch<GitHubPullRequest[]>(
+      `/repos/${repoFullName}/pulls?head=${encodeURIComponent(headFilter)}&state=all&per_page=1&sort=updated&direction=desc`,
+      token
+    );
+
+    if (pulls.length === 0) {
+      return null;
+    }
+
+    const pr = pulls[0];
+    return {
+      number: pr.number,
+      title: pr.title,
+      state: pr.merged_at ? 'merged' : pr.state,
+      draft: pr.draft,
+      url: pr.html_url,
+      author: pr.user?.login || 'unknown',
+      updatedAt: pr.updated_at,
+    };
+  } catch (err) {
+    log.error('Failed to fetch PR for branch', err instanceof Error ? err : undefined, {
+      repoFullName,
+      branch,
+    });
+    return undefined;
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a clickable PR status icon to each session in the session list, showing the state of the most recent PR from that session's branch
- PR status updates in real-time via SSE when Claude finishes a turn (no page refresh needed)
- Icons use GitHub-standard colors: green (open), gray (draft), purple (merged), red (closed)
- Clicking the icon opens the PR on GitHub in a new tab

## Implementation

**Backend:**
- New `fetchPullRequestForBranch` service function in `src/server/services/github.ts`
- New `getPullRequestForBranch` tRPC query endpoint
- New `PrUpdateEvent` SSE event type with `onPrUpdate` subscription
- `claude-runner.ts` checks for PR updates after each Claude turn completes (fire-and-forget)

**Frontend:**
- `usePullRequestStatus` hook: initial fetch via tRPC query (5-min cache) + SSE subscription for real-time updates
- `PrStatusIndicator` component: renders the appropriate lucide-react icon with tooltip
- Integrated into `SessionListItem` next to the session status badge

## Test plan

- [x] Unit tests for `fetchPullRequestForBranch` service (13 tests)
- [x] Unit tests for `getPullRequestForBranch` router endpoint (7 tests)  
- [x] Component tests for `PrStatusIndicator` (11 tests)
- [x] Existing `SessionList` tests still pass
- [x] Build succeeds with no type errors
- [ ] Manual: verify PR icon appears in session list for branches with PRs
- [ ] Manual: verify clicking icon opens PR on GitHub
- [ ] Manual: verify PR icon updates after Claude creates a PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)