### PR TITLE
Extract useDebounce hook from duplicated debounce logic

### DIFF
--- a/src/components/IssueSelector.tsx
+++ b/src/components/IssueSelector.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { trpc } from '@/lib/trpc';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
@@ -9,6 +9,7 @@ import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
 import type { Issue } from '@/lib/types';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
+import { useDebounce } from '@/hooks/useDebounce';
 
 export function IssueSelector({
   repoFullName,
@@ -20,12 +21,7 @@ export function IssueSelector({
   onSelect: (issue: Issue | null) => void;
 }) {
   const [search, setSearch] = useState('');
-  const [debouncedSearch, setDebouncedSearch] = useState('');
-
-  useEffect(() => {
-    const timer = setTimeout(() => setDebouncedSearch(search), 300);
-    return () => clearTimeout(timer);
-  }, [search]);
+  const debouncedSearch = useDebounce(search, 300);
 
   const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
     trpc.github.listIssues.useInfiniteQuery(

--- a/src/components/RepoSelector.tsx
+++ b/src/components/RepoSelector.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { trpc } from '@/lib/trpc';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
@@ -8,6 +8,7 @@ import { Spinner } from '@/components/ui/spinner';
 import { cn } from '@/lib/utils';
 import { Star } from 'lucide-react';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
+import { useDebounce } from '@/hooks/useDebounce';
 
 export interface Repo {
   id: number;
@@ -27,12 +28,7 @@ export function RepoSelector({
   onSelect: (repo: Repo) => void;
 }) {
   const [search, setSearch] = useState('');
-  const [debouncedSearch, setDebouncedSearch] = useState('');
-
-  useEffect(() => {
-    const timer = setTimeout(() => setDebouncedSearch(search), 300);
-    return () => clearTimeout(timer);
-  }, [search]);
+  const debouncedSearch = useDebounce(search, 300);
 
   const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
     trpc.github.listRepos.useInfiniteQuery(

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,12 @@
+import { useState, useEffect } from 'react';
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debouncedValue;
+}


### PR DESCRIPTION
## Summary

- Created a reusable `useDebounce<T>(value, delay)` hook in `src/hooks/useDebounce.ts`
- Replaced identical inline debounce logic in `RepoSelector` and `IssueSelector` with the new hook
- Removed unused `useEffect` imports from both components

Fixes #209

## Test plan

- [x] All 335 existing tests pass (`pnpm test:run`)
- [ ] Verify search debouncing still works in RepoSelector (new session page)
- [ ] Verify search debouncing still works in IssueSelector (new session page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)