### PR TITLE
Split MessageBubble into smaller focused modules

### DIFF
--- a/src/components/messages/ContentRenderer.tsx
+++ b/src/components/messages/ContentRenderer.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import React from 'react';
+import { MarkdownContent } from '@/components/MarkdownContent';
+import type { ContentBlock, ToolCall, ToolResultMap } from './types';
+import { ToolCallDisplay } from './ToolCallDisplay';
+import { GlobDisplay } from './GlobDisplay';
+import { GrepDisplay } from './GrepDisplay';
+import { EditDisplay } from './EditDisplay';
+import { ReadDisplay } from './ReadDisplay';
+import { WriteDisplay } from './WriteDisplay';
+import { WebSearchDisplay } from './WebSearchDisplay';
+import { WebFetchDisplay } from './WebFetchDisplay';
+import { BashDisplay } from './BashDisplay';
+import { NotebookEditDisplay } from './NotebookEditDisplay';
+import { SkillDisplay } from './SkillDisplay';
+import { TaskDisplay } from './TaskDisplay';
+import { ExitPlanModeDisplay } from './ExitPlanModeDisplay';
+import { TodoWriteDisplay } from './TodoWriteDisplay';
+import { AskUserQuestionDisplay } from './AskUserQuestionDisplay';
+
+/**
+ * Map of tool names to their specialized display components.
+ * Tools not in this map fall through to the generic ToolCallDisplay.
+ */
+const TOOL_DISPLAY_MAP: Record<string, React.ComponentType<{ tool: ToolCall }>> = {
+  Glob: GlobDisplay,
+  Grep: GrepDisplay,
+  Edit: EditDisplay,
+  Read: ReadDisplay,
+  Write: WriteDisplay,
+  WebSearch: WebSearchDisplay,
+  WebFetch: WebFetchDisplay,
+  Bash: BashDisplay,
+  NotebookEdit: NotebookEditDisplay,
+  Skill: SkillDisplay,
+  Task: TaskDisplay,
+  ExitPlanMode: ExitPlanModeDisplay,
+  TodoWrite: TodoWriteDisplay,
+  AskUserQuestion: AskUserQuestionDisplay,
+};
+
+function renderContentBlocks(blocks: ContentBlock[], toolResults?: ToolResultMap): React.ReactNode {
+  const textBlocks: string[] = [];
+  const toolUseBlocks: ContentBlock[] = [];
+
+  for (const block of blocks) {
+    if (block.type === 'text' && block.text) {
+      textBlocks.push(block.text);
+    } else if (block.type === 'tool_use') {
+      toolUseBlocks.push(block);
+    }
+  }
+
+  return (
+    <>
+      {textBlocks.length > 0 && <MarkdownContent content={textBlocks.join('\n')} />}
+      {toolUseBlocks.length > 0 && (
+        <div className="mt-2 space-y-2">
+          {toolUseBlocks.map((block) => {
+            const result = block.id ? toolResults?.get(block.id) : undefined;
+            const tool: ToolCall = {
+              name: block.name || 'Unknown',
+              id: block.id,
+              input: block.input,
+              output: result?.content,
+              is_error: result?.is_error,
+            };
+
+            const DisplayComponent = TOOL_DISPLAY_MAP[block.name ?? ''];
+            if (DisplayComponent) {
+              return <DisplayComponent key={block.id} tool={tool} />;
+            }
+
+            return <ToolCallDisplay key={block.id} tool={tool} />;
+          })}
+        </div>
+      )}
+    </>
+  );
+}
+
+/**
+ * Renders message content - handles both string content and content block arrays.
+ */
+export function renderContent(content: unknown, toolResults?: ToolResultMap): React.ReactNode {
+  if (typeof content === 'string') {
+    return <MarkdownContent content={content} />;
+  }
+
+  if (Array.isArray(content)) {
+    return renderContentBlocks(content as ContentBlock[], toolResults);
+  }
+
+  return null;
+}

--- a/src/components/messages/MainMessageBubble.tsx
+++ b/src/components/messages/MainMessageBubble.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { useCallback, useMemo } from 'react';
+import { cn } from '@/lib/utils';
+import { Badge } from '@/components/ui/badge';
+import { OctagonX, Loader2 } from 'lucide-react';
+
+import { CopyButton } from './CopyButton';
+import { ToolCallDisplay } from './ToolCallDisplay';
+import { renderContent } from './ContentRenderer';
+import {
+  buildToolCalls,
+  getCopyText,
+  getDisplayContent,
+  type MessageCategory,
+} from './messageHelpers';
+import type { MessageContent, ToolCall, ToolResultMap } from './types';
+
+interface MainMessageBubbleProps {
+  content: MessageContent;
+  category: MessageCategory;
+  isPartial: boolean;
+  toolResults?: ToolResultMap;
+}
+
+/**
+ * Renders the main styled message bubble for assistant, user, system, and error messages.
+ * Handles styling, status indicators, content rendering, and copy functionality.
+ */
+export function MainMessageBubble({
+  content,
+  category,
+  isPartial,
+  toolResults,
+}: MainMessageBubbleProps) {
+  const isUser = category === 'user';
+  const isAssistant = category === 'assistant';
+  const isSystem = category === 'system';
+  const isError = category === 'systemError';
+  const isInterrupted = content.interrupted === true;
+
+  const toolCalls = useMemo((): ToolCall[] => {
+    if (!isAssistant) return [];
+    return buildToolCalls(content, toolResults);
+  }, [isAssistant, content, toolResults]);
+
+  const handleGetCopyText = useCallback(() => {
+    return getCopyText(content, category, toolCalls);
+  }, [content, category, toolCalls]);
+
+  const displayContent = getDisplayContent(content, category);
+
+  return (
+    <div className="group max-w-[85%]">
+      <div
+        className={cn('rounded-lg p-4', {
+          'bg-primary text-primary-foreground ml-auto': isUser,
+          'bg-card border': isAssistant && !isInterrupted && !isPartial,
+          'bg-card border border-blue-300 dark:border-blue-700': isAssistant && isPartial,
+          'bg-card border border-amber-300 dark:border-amber-700':
+            isAssistant && isInterrupted && !isPartial,
+          'bg-muted text-muted-foreground text-sm': isSystem && !isError,
+          'bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 text-red-800 dark:text-red-200 text-sm':
+            isError,
+        })}
+      >
+        {isPartial && isAssistant && (
+          <div className="flex items-center gap-1.5 text-blue-600 dark:text-blue-400 text-xs mb-2">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            <span>Streaming...</span>
+          </div>
+        )}
+        {isSystem && !isError && (
+          <Badge variant="secondary" className="mb-2">
+            System
+          </Badge>
+        )}
+        {isError && (
+          <Badge variant="destructive" className="mb-2">
+            Error
+          </Badge>
+        )}
+        {isInterrupted && !isPartial && (
+          <div className="flex items-center gap-1 text-amber-600 dark:text-amber-400 text-xs mb-2">
+            <OctagonX className="h-3 w-3" />
+            <span>May be incomplete</span>
+          </div>
+        )}
+
+        {renderContent(displayContent, toolResults)}
+
+        {content.tool_calls && content.tool_calls.length > 0 && (
+          <div className="mt-2 space-y-2">
+            {content.tool_calls.map((tool, index) => (
+              <ToolCallDisplay key={index} tool={tool} />
+            ))}
+          </div>
+        )}
+      </div>
+      {!isPartial && (
+        <div className="mt-1">
+          <CopyButton getText={handleGetCopyText} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/messages/MessageBubble.tsx
+++ b/src/components/messages/MessageBubble.tsx
@@ -1,253 +1,18 @@
 'use client';
 
-import { useCallback, useMemo } from 'react';
-import { cn } from '@/lib/utils';
-import { Badge } from '@/components/ui/badge';
-import { MarkdownContent } from '@/components/MarkdownContent';
-import { OctagonX, Loader2 } from 'lucide-react';
+import { useMemo } from 'react';
+import { OctagonX } from 'lucide-react';
 
-import { CopyButton } from './CopyButton';
 import { RawJsonDisplay } from './RawJsonDisplay';
-import { EditDisplay } from './EditDisplay';
-import { ReadDisplay } from './ReadDisplay';
-import { WriteDisplay } from './WriteDisplay';
-import { TodoWriteDisplay } from './TodoWriteDisplay';
-import { GlobDisplay } from './GlobDisplay';
-import { GrepDisplay } from './GrepDisplay';
-import { WebSearchDisplay } from './WebSearchDisplay';
-import { WebFetchDisplay } from './WebFetchDisplay';
-import { BashDisplay } from './BashDisplay';
-import { NotebookEditDisplay } from './NotebookEditDisplay';
-import { SkillDisplay } from './SkillDisplay';
-import { AskUserQuestionDisplay } from './AskUserQuestionDisplay';
-import { TaskDisplay } from './TaskDisplay';
-import { ExitPlanModeDisplay } from './ExitPlanModeDisplay';
-import { ToolCallDisplay } from './ToolCallDisplay';
 import { ToolResultDisplay } from './ToolResultDisplay';
 import { SystemInitDisplay } from './SystemInitDisplay';
 import { ResultDisplay } from './ResultDisplay';
 import { HookResponseDisplay } from './HookResponseDisplay';
 import { HookStartedDisplay } from './HookStartedDisplay';
 import { CompactBoundaryDisplay } from './CompactBoundaryDisplay';
-import { formatAsJson, buildToolMessages } from './types';
-import type { ToolResultMap, ContentBlock, MessageContent, ToolCall } from './types';
-
-/**
- * Extract text content from message content blocks.
- * For user/assistant messages, returns the raw markdown text.
- */
-function extractTextContent(content: MessageContent): string | null {
-  // For assistant messages, extract text from content.message.content
-  if (content.message?.content && Array.isArray(content.message.content)) {
-    const textBlocks = content.message.content
-      .filter(
-        (block): block is ContentBlock => block.type === 'text' && typeof block.text === 'string'
-      )
-      .map((block) => block.text!);
-    if (textBlocks.length > 0) {
-      return textBlocks.join('\n');
-    }
-  }
-  // For simple content strings
-  if (typeof content.content === 'string') {
-    return content.content;
-  }
-  return null;
-}
-
-/**
- * Map of tool names to their specialized display components.
- * Tools not in this map fall through to the generic ToolCallDisplay.
- */
-const TOOL_DISPLAY_MAP: Record<string, React.ComponentType<{ tool: ToolCall }>> = {
-  Glob: GlobDisplay,
-  Grep: GrepDisplay,
-  Edit: EditDisplay,
-  Read: ReadDisplay,
-  Write: WriteDisplay,
-  WebSearch: WebSearchDisplay,
-  WebFetch: WebFetchDisplay,
-  Bash: BashDisplay,
-  NotebookEdit: NotebookEditDisplay,
-  Skill: SkillDisplay,
-  Task: TaskDisplay,
-  ExitPlanMode: ExitPlanModeDisplay,
-  TodoWrite: TodoWriteDisplay,
-  AskUserQuestion: AskUserQuestionDisplay,
-};
-
-function renderContentBlocks(blocks: ContentBlock[], toolResults?: ToolResultMap): React.ReactNode {
-  const textBlocks: string[] = [];
-  const toolUseBlocks: ContentBlock[] = [];
-
-  for (const block of blocks) {
-    if (block.type === 'text' && block.text) {
-      textBlocks.push(block.text);
-    } else if (block.type === 'tool_use') {
-      toolUseBlocks.push(block);
-    }
-  }
-
-  return (
-    <>
-      {textBlocks.length > 0 && <MarkdownContent content={textBlocks.join('\n')} />}
-      {toolUseBlocks.length > 0 && (
-        <div className="mt-2 space-y-2">
-          {toolUseBlocks.map((block) => {
-            // Look up the result for this tool_use
-            const result = block.id ? toolResults?.get(block.id) : undefined;
-            const tool: ToolCall = {
-              name: block.name || 'Unknown',
-              id: block.id,
-              input: block.input,
-              output: result?.content,
-              is_error: result?.is_error,
-            };
-
-            // Look up in the tool display map
-            const DisplayComponent = TOOL_DISPLAY_MAP[block.name ?? ''];
-            if (DisplayComponent) {
-              return <DisplayComponent key={block.id} tool={tool} />;
-            }
-
-            // Fallback to generic display
-            return <ToolCallDisplay key={block.id} tool={tool} />;
-          })}
-        </div>
-      )}
-    </>
-  );
-}
-
-function renderContent(content: unknown, toolResults?: ToolResultMap): React.ReactNode {
-  if (typeof content === 'string') {
-    return <MarkdownContent content={content} />;
-  }
-
-  if (Array.isArray(content)) {
-    return renderContentBlocks(content as ContentBlock[], toolResults);
-  }
-
-  return null;
-}
-
-// Check if a message is a tool result (comes as type "user" but contains tool_result content)
-function isToolResultMessage(content: MessageContent): boolean {
-  const innerContent = content.message?.content;
-  if (Array.isArray(innerContent)) {
-    return innerContent.some((block) => block.type === 'tool_result');
-  }
-  return false;
-}
-
-// Extract tool results from a message
-function getToolResults(content: MessageContent): ContentBlock[] {
-  const innerContent = content.message?.content;
-  if (Array.isArray(innerContent)) {
-    return innerContent.filter((block) => block.type === 'tool_result');
-  }
-  return [];
-}
-
-type MessageCategory =
-  | 'assistant'
-  | 'user'
-  | 'userInterrupt'
-  | 'toolResult'
-  | 'system'
-  | 'systemInit'
-  | 'systemError'
-  | 'systemCompactBoundary'
-  | 'hookStarted'
-  | 'hookResponse'
-  | 'result';
-
-/**
- * Check if a message can be recognized and displayed with our typed components.
- * Returns false if we should fall back to raw JSON display.
- */
-function isRecognizedMessage(
-  type: string,
-  content: MessageContent
-): { recognized: true; category: MessageCategory } | { recognized: false } {
-  // Assistant messages must have a valid message.content array
-  if (type === 'assistant') {
-    if (!content.message || !Array.isArray(content.message.content)) {
-      return { recognized: false };
-    }
-    return { recognized: true, category: 'assistant' };
-  }
-
-  // User messages that are tool results
-  if (type === 'user' && isToolResultMessage(content)) {
-    return { recognized: true, category: 'toolResult' };
-  }
-
-  // User interrupt messages
-  if (type === 'user' && content.subtype === 'interrupt') {
-    return { recognized: true, category: 'userInterrupt' };
-  }
-
-  // Regular user messages (prompts) must have text content
-  if (type === 'user') {
-    // User prompts typically have message.content with text blocks
-    if (content.message?.content && Array.isArray(content.message.content)) {
-      return { recognized: true, category: 'user' };
-    }
-    // Or simple content string
-    if (typeof content.content === 'string') {
-      return { recognized: true, category: 'user' };
-    }
-    return { recognized: false };
-  }
-
-  // System init messages
-  if (type === 'system' && content.subtype === 'init') {
-    if (content.model && content.session_id) {
-      return { recognized: true, category: 'systemInit' };
-    }
-    return { recognized: false };
-  }
-
-  // System error messages
-  if (type === 'system' && content.subtype === 'error') {
-    if (Array.isArray(content.content)) {
-      return { recognized: true, category: 'systemError' };
-    }
-    return { recognized: false };
-  }
-
-  // Compact boundary messages
-  if (type === 'system' && content.subtype === 'compact_boundary') {
-    return { recognized: true, category: 'systemCompactBoundary' };
-  }
-
-  // Hook started messages (pending hooks show loading state)
-  if (type === 'system' && content.subtype === 'hook_started') {
-    return { recognized: true, category: 'hookStarted' };
-  }
-
-  // Hook response messages
-  if (type === 'system' && content.subtype === 'hook_response') {
-    return { recognized: true, category: 'hookResponse' };
-  }
-
-  // Other system messages
-  if (type === 'system') {
-    return { recognized: true, category: 'system' };
-  }
-
-  // Result messages
-  if (type === 'result') {
-    if (content.subtype && typeof content.session_id === 'string') {
-      return { recognized: true, category: 'result' };
-    }
-    return { recognized: false };
-  }
-
-  // Unknown type
-  return { recognized: false };
-}
+import { MainMessageBubble } from './MainMessageBubble';
+import { isRecognizedMessage, getToolResults } from './messageHelpers';
+import type { ToolResultMap, MessageContent } from './types';
 
 export function MessageBubble({
   message,
@@ -259,69 +24,13 @@ export function MessageBubble({
   const { type } = message;
   const content = useMemo(() => (message.content || {}) as MessageContent, [message.content]);
 
-  // Check if this is a partial (streaming) message
   const isPartial = useMemo(() => {
     return content.partial === true || (message.id?.startsWith('partial-') ?? false);
   }, [content.partial, message.id]);
 
-  // Check if we can properly display this message
   const recognition = useMemo(() => isRecognizedMessage(type, content), [type, content]);
-
   const category = recognition.recognized ? recognition.category : null;
-  const isUser = category === 'user';
-  const isAssistant = category === 'assistant';
 
-  // Build tool call objects with results for assistant messages
-  const toolCalls = useMemo((): ToolCall[] => {
-    if (!isAssistant) return [];
-
-    const messageContent = content.message?.content;
-    if (!Array.isArray(messageContent)) return [];
-
-    // Extract tool_use blocks from message content
-    const toolUseBlocks = messageContent.filter(
-      (block): block is ContentBlock => block.type === 'tool_use'
-    );
-
-    return toolUseBlocks.map((block) => {
-      const result = block.id ? toolResults?.get(block.id) : undefined;
-      return {
-        name: block.name || 'Unknown',
-        id: block.id,
-        input: block.input,
-        output: result?.content,
-        is_error: result?.is_error,
-      };
-    });
-  }, [isAssistant, content, toolResults]);
-
-  // Compute copy text - for user/assistant, copy raw text + tool calls; for others, copy JSON
-  const getCopyText = useCallback(() => {
-    if (isUser) {
-      const text = extractTextContent(content);
-      return text ?? formatAsJson(content);
-    }
-    if (isAssistant) {
-      const text = extractTextContent(content);
-      // If there are tool calls, include them in the copy output
-      if (toolCalls.length > 0) {
-        const parts: string[] = [];
-        if (text) {
-          parts.push(text);
-        }
-        // Add each tool call and result
-        for (const tool of toolCalls) {
-          const toolMessages = buildToolMessages(tool);
-          parts.push(formatAsJson(toolMessages));
-        }
-        return parts.join('\n\n');
-      }
-      return text ?? formatAsJson(content);
-    }
-    return formatAsJson(content);
-  }, [content, isUser, isAssistant, toolCalls]);
-
-  // Unrecognized messages get the raw JSON display (collapsed by default)
   if (!recognition.recognized) {
     return (
       <div className="w-full max-w-[85%]">
@@ -330,7 +39,6 @@ export function MessageBubble({
     );
   }
 
-  // System init messages get their own compact display
   if (category === 'systemInit') {
     return (
       <div className="w-full max-w-[85%]">
@@ -339,7 +47,6 @@ export function MessageBubble({
     );
   }
 
-  // Compact boundary messages get a divider display
   if (category === 'systemCompactBoundary') {
     return (
       <div className="w-full">
@@ -348,7 +55,6 @@ export function MessageBubble({
     );
   }
 
-  // Hook started messages show loading indicator while hook runs
   if (category === 'hookStarted') {
     return (
       <div className="w-full max-w-[85%]">
@@ -357,7 +63,6 @@ export function MessageBubble({
     );
   }
 
-  // Hook response messages get their own compact display
   if (category === 'hookResponse') {
     return (
       <div className="w-full max-w-[85%]">
@@ -366,7 +71,6 @@ export function MessageBubble({
     );
   }
 
-  // Result messages get their own compact display
   if (category === 'result') {
     return (
       <div className="w-full max-w-[85%]">
@@ -375,7 +79,6 @@ export function MessageBubble({
     );
   }
 
-  // Tool result messages get their own compact display
   if (category === 'toolResult') {
     const toolResultBlocks = getToolResults(content);
     return (
@@ -385,7 +88,6 @@ export function MessageBubble({
     );
   }
 
-  // User interrupt messages get a special compact display
   if (category === 'userInterrupt') {
     return (
       <div className="w-full max-w-[85%] ml-auto">
@@ -397,75 +99,12 @@ export function MessageBubble({
     );
   }
 
-  // Get the actual content to render
-  // For assistant messages, content is in content.message.content
-  // For user/system messages, content is in content.content
-  const getDisplayContent = (): unknown => {
-    if (category === 'assistant' && content.message?.content) {
-      return content.message.content;
-    }
-    return content.content;
-  };
-
-  const displayContent = getDisplayContent();
-  const isSystem = category === 'system';
-  const isError = category === 'systemError';
-  const isInterrupted = content.interrupted === true;
-
   return (
-    <div className="group max-w-[85%]">
-      <div
-        className={cn('rounded-lg p-4', {
-          'bg-primary text-primary-foreground ml-auto': isUser,
-          'bg-card border': isAssistant && !isInterrupted && !isPartial,
-          'bg-card border border-blue-300 dark:border-blue-700': isAssistant && isPartial,
-          'bg-card border border-amber-300 dark:border-amber-700':
-            isAssistant && isInterrupted && !isPartial,
-          'bg-muted text-muted-foreground text-sm': isSystem && !isError,
-          'bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 text-red-800 dark:text-red-200 text-sm':
-            isError,
-        })}
-      >
-        {/* Streaming indicator for partial messages */}
-        {isPartial && isAssistant && (
-          <div className="flex items-center gap-1.5 text-blue-600 dark:text-blue-400 text-xs mb-2">
-            <Loader2 className="h-3 w-3 animate-spin" />
-            <span>Streaming...</span>
-          </div>
-        )}
-        {isSystem && !isError && (
-          <Badge variant="secondary" className="mb-2">
-            System
-          </Badge>
-        )}
-        {isError && (
-          <Badge variant="destructive" className="mb-2">
-            Error
-          </Badge>
-        )}
-        {isInterrupted && !isPartial && (
-          <div className="flex items-center gap-1 text-amber-600 dark:text-amber-400 text-xs mb-2">
-            <OctagonX className="h-3 w-3" />
-            <span>May be incomplete</span>
-          </div>
-        )}
-
-        {/* Render content (works for both regular messages and errors now) */}
-        {renderContent(displayContent, toolResults)}
-
-        {content.tool_calls && content.tool_calls.length > 0 && (
-          <div className="mt-2 space-y-2">
-            {content.tool_calls.map((tool, index) => (
-              <ToolCallDisplay key={index} tool={tool} />
-            ))}
-          </div>
-        )}
-      </div>
-      {!isPartial && (
-        <div className="mt-1">
-          <CopyButton getText={getCopyText} />
-        </div>
-      )}
-    </div>
+    <MainMessageBubble
+      content={content}
+      category={category!}
+      isPartial={isPartial}
+      toolResults={toolResults}
+    />
   );
 }

--- a/src/components/messages/messageHelpers.test.ts
+++ b/src/components/messages/messageHelpers.test.ts
@@ -1,0 +1,364 @@
+import { describe, it, expect } from 'vitest';
+import type { MessageContent } from './types';
+import {
+  extractTextContent,
+  isToolResultMessage,
+  getToolResults,
+  isRecognizedMessage,
+  buildToolCalls,
+  getCopyText,
+  getDisplayContent,
+} from './messageHelpers';
+
+describe('extractTextContent', () => {
+  it('extracts text from assistant message content array', () => {
+    const content: MessageContent = {
+      message: {
+        content: [
+          { type: 'text', text: 'Hello' },
+          { type: 'text', text: 'World' },
+        ],
+      },
+    };
+    expect(extractTextContent(content)).toBe('Hello\nWorld');
+  });
+
+  it('extracts text from simple content string', () => {
+    const content: MessageContent = {
+      content: 'Simple text',
+    };
+    expect(extractTextContent(content)).toBe('Simple text');
+  });
+
+  it('returns null when no text content exists', () => {
+    const content: MessageContent = {};
+    expect(extractTextContent(content)).toBeNull();
+  });
+
+  it('returns null when message content has no text blocks', () => {
+    const content: MessageContent = {
+      message: {
+        content: [{ type: 'tool_use', name: 'Read', input: {} }],
+      },
+    };
+    expect(extractTextContent(content)).toBeNull();
+  });
+
+  it('skips non-text blocks in message content', () => {
+    const content: MessageContent = {
+      message: {
+        content: [
+          { type: 'text', text: 'Some text' },
+          { type: 'tool_use', name: 'Read', input: {} },
+        ],
+      },
+    };
+    expect(extractTextContent(content)).toBe('Some text');
+  });
+});
+
+describe('isToolResultMessage', () => {
+  it('returns true for messages with tool_result content', () => {
+    const content: MessageContent = {
+      message: {
+        content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'result' }],
+      },
+    };
+    expect(isToolResultMessage(content)).toBe(true);
+  });
+
+  it('returns false for messages without tool_result content', () => {
+    const content: MessageContent = {
+      message: {
+        content: [{ type: 'text', text: 'hello' }],
+      },
+    };
+    expect(isToolResultMessage(content)).toBe(false);
+  });
+
+  it('returns false when message has no content array', () => {
+    const content: MessageContent = {
+      content: 'text',
+    };
+    expect(isToolResultMessage(content)).toBe(false);
+  });
+});
+
+describe('getToolResults', () => {
+  it('extracts tool_result blocks', () => {
+    const content: MessageContent = {
+      message: {
+        content: [
+          { type: 'tool_result', tool_use_id: 'tool-1', content: 'result 1' },
+          { type: 'text', text: 'hello' },
+          { type: 'tool_result', tool_use_id: 'tool-2', content: 'result 2' },
+        ],
+      },
+    };
+    const results = getToolResults(content);
+    expect(results).toHaveLength(2);
+    expect(results[0].tool_use_id).toBe('tool-1');
+    expect(results[1].tool_use_id).toBe('tool-2');
+  });
+
+  it('returns empty array when no tool_result blocks exist', () => {
+    const content: MessageContent = {
+      message: {
+        content: [{ type: 'text', text: 'hello' }],
+      },
+    };
+    expect(getToolResults(content)).toEqual([]);
+  });
+
+  it('returns empty array when message has no content', () => {
+    const content: MessageContent = {};
+    expect(getToolResults(content)).toEqual([]);
+  });
+});
+
+describe('isRecognizedMessage', () => {
+  it('recognizes assistant messages with valid content array', () => {
+    const content: MessageContent = {
+      message: { content: [{ type: 'text', text: 'hello' }] },
+    };
+    expect(isRecognizedMessage('assistant', content)).toEqual({
+      recognized: true,
+      category: 'assistant',
+    });
+  });
+
+  it('rejects assistant messages without content array', () => {
+    const content: MessageContent = { message: {} };
+    expect(isRecognizedMessage('assistant', content)).toEqual({ recognized: false });
+  });
+
+  it('recognizes user tool result messages', () => {
+    const content: MessageContent = {
+      message: {
+        content: [{ type: 'tool_result', tool_use_id: 'tool-1' }],
+      },
+    };
+    expect(isRecognizedMessage('user', content)).toEqual({
+      recognized: true,
+      category: 'toolResult',
+    });
+  });
+
+  it('recognizes user interrupt messages', () => {
+    const content: MessageContent = { subtype: 'interrupt' };
+    expect(isRecognizedMessage('user', content)).toEqual({
+      recognized: true,
+      category: 'userInterrupt',
+    });
+  });
+
+  it('recognizes user messages with content string', () => {
+    const content: MessageContent = { content: 'hello' };
+    expect(isRecognizedMessage('user', content)).toEqual({
+      recognized: true,
+      category: 'user',
+    });
+  });
+
+  it('recognizes user messages with message content array', () => {
+    const content: MessageContent = {
+      message: { content: [{ type: 'text', text: 'hello' }] },
+    };
+    expect(isRecognizedMessage('user', content)).toEqual({
+      recognized: true,
+      category: 'user',
+    });
+  });
+
+  it('rejects user messages without text content', () => {
+    const content: MessageContent = {};
+    expect(isRecognizedMessage('user', content)).toEqual({ recognized: false });
+  });
+
+  it('recognizes system init messages', () => {
+    const content: MessageContent = {
+      subtype: 'init',
+      model: 'claude-3',
+      session_id: 'sess-1',
+    };
+    expect(isRecognizedMessage('system', content)).toEqual({
+      recognized: true,
+      category: 'systemInit',
+    });
+  });
+
+  it('rejects system init messages without required fields', () => {
+    const content: MessageContent = { subtype: 'init' };
+    expect(isRecognizedMessage('system', content)).toEqual({ recognized: false });
+  });
+
+  it('recognizes system error messages', () => {
+    const content: MessageContent = {
+      subtype: 'error',
+      content: [{ type: 'text', text: 'error' }],
+    };
+    expect(isRecognizedMessage('system', content)).toEqual({
+      recognized: true,
+      category: 'systemError',
+    });
+  });
+
+  it('rejects system error messages without array content', () => {
+    const content: MessageContent = { subtype: 'error', content: 'string error' };
+    expect(isRecognizedMessage('system', content)).toEqual({ recognized: false });
+  });
+
+  it('recognizes system compact boundary messages', () => {
+    const content: MessageContent = { subtype: 'compact_boundary' };
+    expect(isRecognizedMessage('system', content)).toEqual({
+      recognized: true,
+      category: 'systemCompactBoundary',
+    });
+  });
+
+  it('recognizes hook started messages', () => {
+    const content: MessageContent = { subtype: 'hook_started' };
+    expect(isRecognizedMessage('system', content)).toEqual({
+      recognized: true,
+      category: 'hookStarted',
+    });
+  });
+
+  it('recognizes hook response messages', () => {
+    const content: MessageContent = { subtype: 'hook_response' };
+    expect(isRecognizedMessage('system', content)).toEqual({
+      recognized: true,
+      category: 'hookResponse',
+    });
+  });
+
+  it('recognizes generic system messages', () => {
+    const content: MessageContent = { content: 'system message' };
+    expect(isRecognizedMessage('system', content)).toEqual({
+      recognized: true,
+      category: 'system',
+    });
+  });
+
+  it('recognizes result messages', () => {
+    const content: MessageContent = { subtype: 'success', session_id: 'sess-1' };
+    expect(isRecognizedMessage('result', content)).toEqual({
+      recognized: true,
+      category: 'result',
+    });
+  });
+
+  it('rejects result messages without required fields', () => {
+    const content: MessageContent = { subtype: 'success' };
+    expect(isRecognizedMessage('result', content)).toEqual({ recognized: false });
+  });
+
+  it('rejects unknown message types', () => {
+    const content: MessageContent = {};
+    expect(isRecognizedMessage('unknown_type', content)).toEqual({ recognized: false });
+  });
+});
+
+describe('buildToolCalls', () => {
+  it('builds tool calls from assistant message content', () => {
+    const content: MessageContent = {
+      message: {
+        content: [
+          { type: 'tool_use', id: 'tool-1', name: 'Read', input: { file_path: '/test.txt' } },
+        ],
+      },
+    };
+    const toolResults = new Map([['tool-1', { content: 'file contents', is_error: false }]]);
+
+    const calls = buildToolCalls(content, toolResults);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({
+      name: 'Read',
+      id: 'tool-1',
+      input: { file_path: '/test.txt' },
+      output: 'file contents',
+      is_error: false,
+    });
+  });
+
+  it('returns empty array when no message content', () => {
+    const content: MessageContent = {};
+    expect(buildToolCalls(content)).toEqual([]);
+  });
+
+  it('skips non-tool_use blocks', () => {
+    const content: MessageContent = {
+      message: {
+        content: [
+          { type: 'text', text: 'hello' },
+          { type: 'tool_use', id: 'tool-1', name: 'Read', input: {} },
+        ],
+      },
+    };
+    const calls = buildToolCalls(content);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].name).toBe('Read');
+  });
+
+  it('handles missing tool results', () => {
+    const content: MessageContent = {
+      message: {
+        content: [{ type: 'tool_use', id: 'tool-1', name: 'Read', input: {} }],
+      },
+    };
+    const calls = buildToolCalls(content, new Map());
+    expect(calls[0].output).toBeUndefined();
+    expect(calls[0].is_error).toBeUndefined();
+  });
+});
+
+describe('getCopyText', () => {
+  it('returns text for user messages', () => {
+    const content: MessageContent = { content: 'user text' };
+    expect(getCopyText(content, 'user', [])).toBe('user text');
+  });
+
+  it('returns text for assistant messages without tool calls', () => {
+    const content: MessageContent = {
+      message: { content: [{ type: 'text', text: 'assistant text' }] },
+    };
+    expect(getCopyText(content, 'assistant', [])).toBe('assistant text');
+  });
+
+  it('includes tool calls in assistant copy text', () => {
+    const content: MessageContent = {
+      message: { content: [{ type: 'text', text: 'Some text' }] },
+    };
+    const toolCalls = [{ name: 'Read', id: 'tool-1', input: { file_path: '/test.txt' } }];
+    const result = getCopyText(content, 'assistant', toolCalls);
+    expect(result).toContain('Some text');
+    expect(result).toContain('Read');
+  });
+
+  it('returns JSON for other message types', () => {
+    const content: MessageContent = { subtype: 'init', model: 'claude-3' };
+    const result = getCopyText(content, 'systemInit', []);
+    expect(result).toContain('"subtype"');
+    expect(result).toContain('"init"');
+  });
+});
+
+describe('getDisplayContent', () => {
+  it('returns message.content for assistant messages', () => {
+    const blocks = [{ type: 'text' as const, text: 'hello' }];
+    const content: MessageContent = {
+      message: { content: blocks },
+    };
+    expect(getDisplayContent(content, 'assistant')).toBe(blocks);
+  });
+
+  it('returns content.content for user messages', () => {
+    const content: MessageContent = { content: 'user text' };
+    expect(getDisplayContent(content, 'user')).toBe('user text');
+  });
+
+  it('returns content.content for system messages', () => {
+    const content: MessageContent = { content: 'system text' };
+    expect(getDisplayContent(content, 'system')).toBe('system text');
+  });
+});

--- a/src/components/messages/messageHelpers.ts
+++ b/src/components/messages/messageHelpers.ts
@@ -1,0 +1,216 @@
+import type { ContentBlock, MessageContent, ToolCall, ToolResultMap } from './types';
+import { formatAsJson, buildToolMessages } from './types';
+
+export type MessageCategory =
+  | 'assistant'
+  | 'user'
+  | 'userInterrupt'
+  | 'toolResult'
+  | 'system'
+  | 'systemInit'
+  | 'systemError'
+  | 'systemCompactBoundary'
+  | 'hookStarted'
+  | 'hookResponse'
+  | 'result';
+
+export type RecognitionResult =
+  | { recognized: true; category: MessageCategory }
+  | { recognized: false };
+
+/**
+ * Extract text content from message content blocks.
+ * For user/assistant messages, returns the raw markdown text.
+ */
+export function extractTextContent(content: MessageContent): string | null {
+  // For assistant messages, extract text from content.message.content
+  if (content.message?.content && Array.isArray(content.message.content)) {
+    const textBlocks = content.message.content
+      .filter(
+        (block): block is ContentBlock => block.type === 'text' && typeof block.text === 'string'
+      )
+      .map((block) => block.text!);
+    if (textBlocks.length > 0) {
+      return textBlocks.join('\n');
+    }
+  }
+  // For simple content strings
+  if (typeof content.content === 'string') {
+    return content.content;
+  }
+  return null;
+}
+
+/**
+ * Check if a message is a tool result (comes as type "user" but contains tool_result content).
+ */
+export function isToolResultMessage(content: MessageContent): boolean {
+  const innerContent = content.message?.content;
+  if (Array.isArray(innerContent)) {
+    return innerContent.some((block) => block.type === 'tool_result');
+  }
+  return false;
+}
+
+/**
+ * Extract tool result blocks from a message.
+ */
+export function getToolResults(content: MessageContent): ContentBlock[] {
+  const innerContent = content.message?.content;
+  if (Array.isArray(innerContent)) {
+    return innerContent.filter((block) => block.type === 'tool_result');
+  }
+  return [];
+}
+
+/**
+ * Check if a message can be recognized and displayed with our typed components.
+ * Returns the message category if recognized, or { recognized: false } for unknown types.
+ */
+export function isRecognizedMessage(type: string, content: MessageContent): RecognitionResult {
+  // Assistant messages must have a valid message.content array
+  if (type === 'assistant') {
+    if (!content.message || !Array.isArray(content.message.content)) {
+      return { recognized: false };
+    }
+    return { recognized: true, category: 'assistant' };
+  }
+
+  // User messages that are tool results
+  if (type === 'user' && isToolResultMessage(content)) {
+    return { recognized: true, category: 'toolResult' };
+  }
+
+  // User interrupt messages
+  if (type === 'user' && content.subtype === 'interrupt') {
+    return { recognized: true, category: 'userInterrupt' };
+  }
+
+  // Regular user messages (prompts) must have text content
+  if (type === 'user') {
+    // User prompts typically have message.content with text blocks
+    if (content.message?.content && Array.isArray(content.message.content)) {
+      return { recognized: true, category: 'user' };
+    }
+    // Or simple content string
+    if (typeof content.content === 'string') {
+      return { recognized: true, category: 'user' };
+    }
+    return { recognized: false };
+  }
+
+  // System init messages
+  if (type === 'system' && content.subtype === 'init') {
+    if (content.model && content.session_id) {
+      return { recognized: true, category: 'systemInit' };
+    }
+    return { recognized: false };
+  }
+
+  // System error messages
+  if (type === 'system' && content.subtype === 'error') {
+    if (Array.isArray(content.content)) {
+      return { recognized: true, category: 'systemError' };
+    }
+    return { recognized: false };
+  }
+
+  // Compact boundary messages
+  if (type === 'system' && content.subtype === 'compact_boundary') {
+    return { recognized: true, category: 'systemCompactBoundary' };
+  }
+
+  // Hook started messages (pending hooks show loading state)
+  if (type === 'system' && content.subtype === 'hook_started') {
+    return { recognized: true, category: 'hookStarted' };
+  }
+
+  // Hook response messages
+  if (type === 'system' && content.subtype === 'hook_response') {
+    return { recognized: true, category: 'hookResponse' };
+  }
+
+  // Other system messages
+  if (type === 'system') {
+    return { recognized: true, category: 'system' };
+  }
+
+  // Result messages
+  if (type === 'result') {
+    if (content.subtype && typeof content.session_id === 'string') {
+      return { recognized: true, category: 'result' };
+    }
+    return { recognized: false };
+  }
+
+  // Unknown type
+  return { recognized: false };
+}
+
+/**
+ * Build tool call objects with results for assistant messages.
+ */
+export function buildToolCalls(content: MessageContent, toolResults?: ToolResultMap): ToolCall[] {
+  const messageContent = content.message?.content;
+  if (!Array.isArray(messageContent)) return [];
+
+  const toolUseBlocks = messageContent.filter(
+    (block): block is ContentBlock => block.type === 'tool_use'
+  );
+
+  return toolUseBlocks.map((block) => {
+    const result = block.id ? toolResults?.get(block.id) : undefined;
+    return {
+      name: block.name || 'Unknown',
+      id: block.id,
+      input: block.input,
+      output: result?.content,
+      is_error: result?.is_error,
+    };
+  });
+}
+
+/**
+ * Get the text to copy for a message.
+ */
+export function getCopyText(
+  content: MessageContent,
+  category: MessageCategory | null,
+  toolCalls: ToolCall[]
+): string {
+  if (category === 'user') {
+    const text = extractTextContent(content);
+    return text ?? formatAsJson(content);
+  }
+  if (category === 'assistant') {
+    const text = extractTextContent(content);
+    if (toolCalls.length > 0) {
+      const parts: string[] = [];
+      if (text) {
+        parts.push(text);
+      }
+      for (const tool of toolCalls) {
+        const toolMessages = buildToolMessages(tool);
+        parts.push(formatAsJson(toolMessages));
+      }
+      return parts.join('\n\n');
+    }
+    return text ?? formatAsJson(content);
+  }
+  return formatAsJson(content);
+}
+
+/**
+ * Get the display content for a message based on its category.
+ * For assistant messages, content is in content.message.content.
+ * For user/system messages, content is in content.content.
+ */
+export function getDisplayContent(
+  content: MessageContent,
+  category: MessageCategory | null
+): unknown {
+  if (category === 'assistant' && content.message?.content) {
+    return content.message.content;
+  }
+  return content.content;
+}


### PR DESCRIPTION
## Summary
- Extracted pure helper functions (message categorization, text extraction, tool call building, copy text generation) into `messageHelpers.ts`
- Moved content rendering logic (tool display map, content block rendering) to `ContentRenderer.tsx`
- Moved styled message bubble (assistant/user/system/error messages with status indicators and copy) to `MainMessageBubble.tsx`
- `MessageBubble.tsx` is now a ~110 line orchestrator that categorizes messages and delegates to the appropriate sub-component
- Added 40 unit tests for the extracted pure functions in `messageHelpers.test.ts`

## Test plan
- [x] All 375 existing tests pass (`pnpm test:run`)
- [x] New `messageHelpers.test.ts` tests cover all extracted functions
- [x] Existing `MessageBubble.test.tsx` tests pass unchanged (verifying no behavioral changes)
- [x] ESLint and Prettier pass via lint-staged

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)