### PR TITLE
Add Fly CLI to runner container image

### DIFF
--- a/docker/Dockerfile.claude-code
+++ b/docker/Dockerfile.claude-code
@@ -97,6 +97,9 @@ RUN yes | sdkmanager --licenses > /dev/null 2>&1 && \
 # Install uv package manager for Python (system-wide to avoid chown overhead)
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
 
+# Install Fly CLI (system-wide)
+RUN curl -L https://fly.io/install.sh | FLYCTL_INSTALL=/usr/local sh
+
 # Enable corepack for pnpm (built into Node.js) and install Claude Code
 # This is placed late because Claude Code updates frequently, and we want to
 # preserve cache for the slow Android SDK layers above


### PR DESCRIPTION
## Summary
- Installs the Fly CLI (`flyctl`) system-wide in the runner container image
- Uses `FLYCTL_INSTALL=/usr/local` so the binary lands in `/usr/local/bin/` and is available on PATH without extra config
- Enables Claude agents to deploy and manage Fly.io applications from sessions

## Test plan
- [ ] Rebuild the container image and verify `fly version` works inside a session
- [ ] Verify existing tools (gh, node, pnpm, etc.) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)