### PR TITLE
Fix PR status detection by tracking agent's current git branch

### DIFF
--- a/prisma/migrations/20260209041420_add_current_branch_to_session/migration.sql
+++ b/prisma/migrations/20260209041420_add_current_branch_to_session/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Session" ADD COLUMN "currentBranch" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,8 +31,9 @@ model Session {
   containerId   String?
   status        String    @default("creating") // creating, running, stopped, error, archived
   statusMessage String?   // Human-readable progress message during creation
-  initialPrompt String?   // Optional prompt to send when session starts (e.g., from GitHub issue)
-  createdAt     DateTime  @default(now())
+  initialPrompt  String?   // Optional prompt to send when session starts (e.g., from GitHub issue)
+  currentBranch  String?   // Current git branch in the container (detected after each query)
+  createdAt      DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
   archivedAt    DateTime? // When the session was archived (null if not archived)
   messages      Message[]

--- a/src/components/SessionList.test.tsx
+++ b/src/components/SessionList.test.tsx
@@ -19,7 +19,7 @@ vi.mock('@/lib/trpc', () => ({
       delete: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
     },
     github: {
-      getPullRequestForBranch: {
+      getSessionPrStatus: {
         useQuery: () => ({ data: null, isLoading: false }),
       },
     },
@@ -30,7 +30,7 @@ vi.mock('@/lib/trpc', () => ({
     },
     useUtils: () => ({
       github: {
-        getPullRequestForBranch: { setData: vi.fn() },
+        getSessionPrStatus: { setData: vi.fn() },
       },
     }),
   },

--- a/src/components/SessionListItem.tsx
+++ b/src/components/SessionListItem.tsx
@@ -26,12 +26,7 @@ export function SessionListItem({ session, onMutationSuccess }: SessionListItemP
   const stopMutation = trpc.sessions.stop.useMutation({ onSuccess: onMutationSuccess });
   const archiveMutation = trpc.sessions.delete.useMutation({ onSuccess: onMutationSuccess });
 
-  const { pullRequest } = usePullRequestStatus(
-    session.id,
-    session.repoUrl,
-    session.branch,
-    !isArchived
-  );
+  const { pullRequest } = usePullRequestStatus(session.id, !isArchived);
 
   return (
     <li

--- a/src/hooks/usePullRequestStatus.ts
+++ b/src/hooks/usePullRequestStatus.ts
@@ -1,7 +1,6 @@
 'use client';
 
 import { trpc } from '@/lib/trpc';
-import { extractRepoFullName } from '@/lib/utils';
 
 export type PrState = 'open' | 'closed' | 'merged';
 
@@ -21,28 +20,26 @@ export interface UsePullRequestStatusResult {
 }
 
 /**
- * Hook to fetch and subscribe to PR status for a session's branch.
+ * Hook to fetch and subscribe to PR status for a session.
+ *
+ * Uses the session's persisted `currentBranch` to look up PRs, so it works
+ * even when the container is stopped.
  *
  * - Fetches initial PR status via tRPC query (cached 5 min)
  * - Subscribes to SSE updates so PR status updates in real-time when Claude finishes a turn
  *
- * @param sessionId - Session ID for SSE subscription
- * @param repoUrl - Full GitHub repo URL (e.g. "https://github.com/owner/repo.git")
- * @param branch - Branch name
+ * @param sessionId - Session ID for query and SSE subscription
  * @param enabled - Whether to fetch (false for archived sessions)
  * @returns PR info, null if no PR, undefined if loading/disabled
  */
 export function usePullRequestStatus(
   sessionId: string,
-  repoUrl: string,
-  branch: string,
   enabled: boolean = true
 ): UsePullRequestStatusResult {
-  const repoFullName = extractRepoFullName(repoUrl);
   const utils = trpc.useUtils();
 
-  const { data, isLoading } = trpc.github.getPullRequestForBranch.useQuery(
-    { repoFullName, branch },
+  const { data, isLoading } = trpc.github.getSessionPrStatus.useQuery(
+    { sessionId },
     {
       enabled,
       staleTime: 5 * 60 * 1000,
@@ -57,8 +54,8 @@ export function usePullRequestStatus(
       enabled,
       onData: (trackedData) => {
         const event = trackedData.data;
-        utils.github.getPullRequestForBranch.setData(
-          { repoFullName, branch },
+        utils.github.getSessionPrStatus.setData(
+          { sessionId },
           { pullRequest: event.pullRequest as PullRequestInfo | null }
         );
       },

--- a/src/server/services/agent-client.test.ts
+++ b/src/server/services/agent-client.test.ts
@@ -149,6 +149,32 @@ describe('AgentClient', () => {
     });
   });
 
+  describe('getCurrentBranch', () => {
+    it('should return branch name when available', async () => {
+      mockServer.setHandler((_req, res) => {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ branch: 'feature-branch' }));
+      });
+
+      expect(await client.getCurrentBranch()).toBe('feature-branch');
+    });
+
+    it('should return null when branch is null', async () => {
+      mockServer.setHandler((_req, res) => {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ branch: null }));
+      });
+
+      expect(await client.getCurrentBranch()).toBeNull();
+    });
+
+    it('should return null on error', async () => {
+      await mockServer.close();
+      const unreachableClient = createAgentClient('/tmp/nonexistent-socket.sock');
+      expect(await unreachableClient.getCurrentBranch()).toBeNull();
+    });
+  });
+
   describe('query', () => {
     it('should stream messages from SSE response', async () => {
       mockServer.setHandler((req, res) => {
@@ -319,6 +345,7 @@ describe('waitForAgentHealth', () => {
       getStatus: vi.fn(),
       getMessages: vi.fn(),
       getCommands: vi.fn(),
+      getCurrentBranch: vi.fn(),
     };
 
     const result = await waitForAgentHealth(mockClient, {
@@ -341,6 +368,7 @@ describe('waitForAgentHealth', () => {
       getStatus: vi.fn(),
       getMessages: vi.fn(),
       getCommands: vi.fn(),
+      getCurrentBranch: vi.fn(),
     };
 
     const result = await waitForAgentHealth(mockClient, {
@@ -359,6 +387,7 @@ describe('waitForAgentHealth', () => {
       getStatus: vi.fn(),
       getMessages: vi.fn(),
       getCommands: vi.fn(),
+      getCurrentBranch: vi.fn(),
     };
 
     const result = await waitForAgentHealth(mockClient, {

--- a/src/server/services/agent-client.ts
+++ b/src/server/services/agent-client.ts
@@ -108,6 +108,12 @@ export interface AgentClient {
   getCommands(): Promise<SlashCommand[]>;
 
   /**
+   * Get the current git branch in the container's working directory.
+   * Returns null if the branch cannot be determined (e.g., detached HEAD, error).
+   */
+  getCurrentBranch(): Promise<string | null>;
+
+  /**
    * Health check - returns true if the agent service is reachable.
    */
   health(): Promise<boolean>;
@@ -300,6 +306,16 @@ export function createAgentClient(socketPath: string): AgentClient {
     async getCommands() {
       const res = await fetchJson<{ commands: SlashCommand[] }>('/commands');
       return res.commands;
+    },
+
+    async getCurrentBranch() {
+      try {
+        const result = await fetchJson<{ branch: string | null }>('/branch');
+        return result.branch;
+      } catch (err) {
+        log.debug('Get current branch failed', { error: toError(err).message });
+        return null;
+      }
     },
 
     async health() {


### PR DESCRIPTION
## Summary

- PR status indicators on the session list never showed anything because sessions start on `main`/`master`, but agents create feature branches and open PRs from those branches. The old lookup searched for PRs with the session's initial branch which always returned zero results.
- Added `currentBranch` field to Session model, persisted after each Claude query by detecting the container's current git branch via a new `GET /branch` agent endpoint.
- Replaced `getPullRequestForBranch` tRPC endpoint with `getSessionPrStatus` which uses the persisted `currentBranch` server-side, so it works for both running and stopped sessions.

## Test plan

- [x] All 378 tests pass (`pnpm test:run`)
- [x] Build succeeds with no type errors (`pnpm build`)
- [ ] Manual: create a session, have Claude create a branch and open a PR, verify the PR icon appears on the session list
- [ ] Manual: stop the session, verify the PR icon still shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)