### PR TITLE
Improve plan mode: auto-interrupt, rendered plans, better displays

### DIFF
--- a/src/components/messages/ContentRenderer.tsx
+++ b/src/components/messages/ContentRenderer.tsx
@@ -15,6 +15,7 @@ import { BashDisplay } from './BashDisplay';
 import { NotebookEditDisplay } from './NotebookEditDisplay';
 import { SkillDisplay } from './SkillDisplay';
 import { TaskDisplay } from './TaskDisplay';
+import { EnterPlanModeDisplay } from './EnterPlanModeDisplay';
 import { ExitPlanModeDisplay } from './ExitPlanModeDisplay';
 import { TodoWriteDisplay } from './TodoWriteDisplay';
 import { AskUserQuestionDisplay } from './AskUserQuestionDisplay';
@@ -35,6 +36,7 @@ const TOOL_DISPLAY_MAP: Record<string, React.ComponentType<{ tool: ToolCall }>> 
   NotebookEdit: NotebookEditDisplay,
   Skill: SkillDisplay,
   Task: TaskDisplay,
+  EnterPlanMode: EnterPlanModeDisplay,
   ExitPlanMode: ExitPlanModeDisplay,
   TodoWrite: TodoWriteDisplay,
   AskUserQuestion: AskUserQuestionDisplay,

--- a/src/components/messages/EditDisplay.tsx
+++ b/src/components/messages/EditDisplay.tsx
@@ -1,8 +1,10 @@
 'use client';
 
+import { useMemo } from 'react';
 import { cn } from '@/lib/utils';
 import { Badge } from '@/components/ui/badge';
 import { ToolDisplayWrapper } from './ToolDisplayWrapper';
+import { isPlanFile } from './plan-utils';
 import type { ToolCall } from './types';
 
 interface EditInput {
@@ -15,6 +17,7 @@ interface EditInput {
 /**
  * Specialized display for Edit tool calls.
  * Shows file path and a diff-like view of old vs new content.
+ * For plan files, shows a simplified "Plan updated" view.
  */
 export function EditDisplay({ tool }: { tool: ToolCall }) {
   const hasOutput = tool.output !== undefined;
@@ -27,6 +30,61 @@ export function EditDisplay({ tool }: { tool: ToolCall }) {
 
   // Extract just the filename for the header
   const fileName = filePath.split('/').pop() ?? filePath;
+
+  // Check if this is a plan file
+  const isPlan = useMemo(() => isPlanFile(filePath), [filePath]);
+
+  // For plan files, show a simplified compact view
+  if (isPlan) {
+    return (
+      <ToolDisplayWrapper
+        tool={tool}
+        title="Plan Updated"
+        subtitle={
+          <div className="text-muted-foreground text-xs mt-1">Plan was updated with changes</div>
+        }
+        doneBadge={
+          <Badge
+            variant="outline"
+            className="text-xs border-purple-500 text-purple-700 dark:text-purple-400"
+          >
+            Updated
+          </Badge>
+        }
+        cardClassName="border-purple-300 dark:border-purple-700"
+      >
+        {/* Show the changes as a simple diff */}
+        <div>
+          <div className="flex items-center gap-2 mb-1">
+            <span className="text-red-600 dark:text-red-400 font-medium">Removed</span>
+            <span className="text-muted-foreground">
+              ({oldString.split('\n').length}{' '}
+              {oldString.split('\n').length === 1 ? 'line' : 'lines'})
+            </span>
+          </div>
+          <pre className="bg-red-50 dark:bg-red-950/50 border border-red-200 dark:border-red-800 p-2 rounded overflow-x-auto max-h-32 overflow-y-auto">
+            <code className="text-red-800 dark:text-red-200 whitespace-pre-wrap break-words">
+              {oldString || '(empty)'}
+            </code>
+          </pre>
+        </div>
+        <div>
+          <div className="flex items-center gap-2 mb-1">
+            <span className="text-green-600 dark:text-green-400 font-medium">Added</span>
+            <span className="text-muted-foreground">
+              ({newString.split('\n').length}{' '}
+              {newString.split('\n').length === 1 ? 'line' : 'lines'})
+            </span>
+          </div>
+          <pre className="bg-green-50 dark:bg-green-950/50 border border-green-200 dark:border-green-800 p-2 rounded overflow-x-auto max-h-32 overflow-y-auto">
+            <code className="text-green-800 dark:text-green-200 whitespace-pre-wrap break-words">
+              {newString || '(empty)'}
+            </code>
+          </pre>
+        </div>
+      </ToolDisplayWrapper>
+    );
+  }
 
   return (
     <ToolDisplayWrapper

--- a/src/components/messages/EnterPlanModeDisplay.tsx
+++ b/src/components/messages/EnterPlanModeDisplay.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { Badge } from '@/components/ui/badge';
+import { ToolDisplayWrapper } from './ToolDisplayWrapper';
+import type { ToolCall } from './types';
+
+// Blueprint/planning icon
+function PlanIcon() {
+  return (
+    <svg
+      className="w-4 h-4 text-purple-600 dark:text-purple-400 flex-shrink-0"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={1.5}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M12 18v-5.25m0 0a6.01 6.01 0 001.5-.189m-1.5.189a6.01 6.01 0 01-1.5-.189m3.75 7.478a12.06 12.06 0 01-4.5 0m3.75 2.383a14.406 14.406 0 01-3 0M14.25 18v-.192c0-.983.658-1.823 1.508-2.316a7.5 7.5 0 10-7.517 0c.85.493 1.509 1.333 1.509 2.316V18"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Specialized display for EnterPlanMode tool calls.
+ * Shows a compact indicator that Claude has entered planning mode.
+ */
+export function EnterPlanModeDisplay({ tool }: { tool: ToolCall }) {
+  const hasOutput = tool.output !== undefined;
+
+  return (
+    <ToolDisplayWrapper
+      tool={tool}
+      icon={<PlanIcon />}
+      title="Entering Plan Mode"
+      pendingText="Entering..."
+      cardClassName="border-purple-300 dark:border-purple-700"
+      subtitle={
+        <div className="text-muted-foreground text-xs mt-1">
+          Claude is exploring the codebase and designing an implementation approach
+        </div>
+      }
+      doneBadge={
+        hasOutput ? (
+          <Badge
+            variant="outline"
+            className="text-xs border-purple-500 text-purple-700 dark:text-purple-400"
+          >
+            Planning
+          </Badge>
+        ) : null
+      }
+    >
+      <div className="text-muted-foreground text-xs py-1">
+        Claude will explore the codebase and present a plan for your approval before making changes.
+      </div>
+    </ToolDisplayWrapper>
+  );
+}

--- a/src/components/messages/MessageBubble.test.tsx
+++ b/src/components/messages/MessageBubble.test.tsx
@@ -328,6 +328,7 @@ describe('MessageBubble', () => {
             latestTodoWriteId: 'todo-1',
             manuallyToggledTodoIds,
             onTodoManualToggle,
+            latestPlanContent: null,
           }}
         >
           <MessageBubble message={message} />

--- a/src/components/messages/MessageListContext.tsx
+++ b/src/components/messages/MessageListContext.tsx
@@ -13,6 +13,8 @@ interface MessageListContextValue {
   onSendResponse?: (response: string) => void;
   /** Whether Claude is currently running (disables AskUserQuestion interactions) */
   isClaudeRunning?: boolean;
+  /** The latest plan content from Write/Edit of plan files, or null */
+  latestPlanContent: string | null;
 }
 
 const MessageListContext = createContext<MessageListContextValue | null>(null);

--- a/src/components/messages/WriteDisplay.tsx
+++ b/src/components/messages/WriteDisplay.tsx
@@ -4,8 +4,10 @@ import { useMemo } from 'react';
 import { cn } from '@/lib/utils';
 import { Badge } from '@/components/ui/badge';
 import { getFileType } from '@/lib/file-types';
+import { MarkdownContent } from '@/components/MarkdownContent';
 import { FileIcon } from './FileIcon';
 import { ToolDisplayWrapper } from './ToolDisplayWrapper';
+import { isPlanFile } from './plan-utils';
 import type { ToolCall } from './types';
 
 interface WriteInput {
@@ -16,6 +18,7 @@ interface WriteInput {
 /**
  * Specialized display for Write tool calls.
  * Shows file path and the content being written to the file.
+ * For plan files (.md inside .claude/projects/), renders content as Markdown.
  */
 export function WriteDisplay({ tool }: { tool: ToolCall }) {
   const hasOutput = tool.output !== undefined;
@@ -28,6 +31,9 @@ export function WriteDisplay({ tool }: { tool: ToolCall }) {
   const fileName = filePath.split('/').pop() ?? filePath;
   const fileType = useMemo(() => getFileType(filePath), [filePath]);
 
+  // Check if this is a plan file
+  const isPlan = useMemo(() => isPlanFile(filePath), [filePath]);
+
   // Count lines in content
   const lineCount = useMemo(() => {
     if (!content) return 0;
@@ -38,23 +44,44 @@ export function WriteDisplay({ tool }: { tool: ToolCall }) {
     <ToolDisplayWrapper
       tool={tool}
       icon={<FileIcon variant="write" />}
-      title="Write"
-      pendingText="Writing..."
+      title={isPlan ? 'Plan' : 'Write'}
+      pendingText={isPlan ? 'Writing plan...' : 'Writing...'}
       headerContent={
-        <span className="text-muted-foreground font-mono text-xs truncate">{fileName}</span>
+        !isPlan ? (
+          <span className="text-muted-foreground font-mono text-xs truncate">{fileName}</span>
+        ) : undefined
       }
-      subtitle={<div className="text-muted-foreground text-xs mt-1 truncate">{filePath}</div>}
+      subtitle={
+        isPlan ? (
+          <div className="text-muted-foreground text-xs mt-1">
+            Claude is writing a plan for your review
+          </div>
+        ) : (
+          <div className="text-muted-foreground text-xs mt-1 truncate">{filePath}</div>
+        )
+      }
       doneBadge={
-        <Badge
-          variant="outline"
-          className="text-xs border-green-500 text-green-700 dark:text-green-400"
-        >
-          {lineCount} {lineCount === 1 ? 'line' : 'lines'}
-        </Badge>
+        isPlan ? (
+          <Badge
+            variant="outline"
+            className="text-xs border-purple-500 text-purple-700 dark:text-purple-400"
+          >
+            Plan
+          </Badge>
+        ) : (
+          <Badge
+            variant="outline"
+            className="text-xs border-green-500 text-green-700 dark:text-green-400"
+          >
+            {lineCount} {lineCount === 1 ? 'line' : 'lines'}
+          </Badge>
+        )
       }
+      cardClassName={isPlan ? 'border-purple-300 dark:border-purple-700' : undefined}
+      defaultExpanded={isPlan}
     >
-      {/* File type badge */}
-      {fileType !== 'text' && (
+      {/* File type badge (non-plan files only) */}
+      {!isPlan && fileType !== 'text' && (
         <div>
           <Badge variant="secondary" className="text-xs">
             {fileType}
@@ -62,27 +89,36 @@ export function WriteDisplay({ tool }: { tool: ToolCall }) {
         </div>
       )}
 
-      {/* File content section */}
-      <div>
-        <div className="flex items-center gap-2 mb-1">
-          <span className="text-green-600 dark:text-green-400 font-medium">Content</span>
-          <span className="text-muted-foreground">
-            ({lineCount} {lineCount === 1 ? 'line' : 'lines'})
-          </span>
+      {/* Plan file: render as Markdown */}
+      {isPlan && content && (
+        <div className="bg-muted/50 rounded p-3 overflow-y-auto max-h-[600px]">
+          <MarkdownContent content={content} />
         </div>
-        {content ? (
-          <pre className="bg-green-50 dark:bg-green-950/50 border border-green-200 dark:border-green-800 p-2 rounded overflow-x-auto max-h-96 overflow-y-auto">
-            <code className="text-green-800 dark:text-green-200 whitespace-pre-wrap break-words">
-              {content}
-            </code>
-          </pre>
-        ) : (
-          <div className="text-muted-foreground italic py-2">(empty file)</div>
-        )}
-      </div>
+      )}
 
-      {/* Output/Result if available */}
-      {hasOutput && (
+      {/* Non-plan file: show raw content */}
+      {!isPlan && (
+        <div>
+          <div className="flex items-center gap-2 mb-1">
+            <span className="text-green-600 dark:text-green-400 font-medium">Content</span>
+            <span className="text-muted-foreground">
+              ({lineCount} {lineCount === 1 ? 'line' : 'lines'})
+            </span>
+          </div>
+          {content ? (
+            <pre className="bg-green-50 dark:bg-green-950/50 border border-green-200 dark:border-green-800 p-2 rounded overflow-x-auto max-h-96 overflow-y-auto">
+              <code className="text-green-800 dark:text-green-200 whitespace-pre-wrap break-words">
+                {content}
+              </code>
+            </pre>
+          ) : (
+            <div className="text-muted-foreground italic py-2">(empty file)</div>
+          )}
+        </div>
+      )}
+
+      {/* Output/Result if available (non-plan files only) */}
+      {!isPlan && hasOutput && (
         <div>
           <div className="text-muted-foreground mb-1">Result:</div>
           <pre

--- a/src/components/messages/index.ts
+++ b/src/components/messages/index.ts
@@ -25,6 +25,7 @@ export { HookStartedDisplay } from './HookStartedDisplay';
 export { WebSearchDisplay } from './WebSearchDisplay';
 export { AskUserQuestionDisplay } from './AskUserQuestionDisplay';
 export { TaskDisplay } from './TaskDisplay';
+export { EnterPlanModeDisplay } from './EnterPlanModeDisplay';
 export { ExitPlanModeDisplay } from './ExitPlanModeDisplay';
 
 export type { ToolResultMap, ToolCall, ContentBlock, MessageContent, TodoItem } from './types';

--- a/src/components/messages/plan-utils.test.ts
+++ b/src/components/messages/plan-utils.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { isPlanFile } from './plan-utils';
+
+describe('isPlanFile', () => {
+  it('should detect plan.md inside .claude/projects/', () => {
+    expect(isPlanFile('/home/claudeuser/.claude/projects/-workspace-clawed-abode/plan.md')).toBe(
+      true
+    );
+  });
+
+  it('should detect any .md file inside .claude/projects/', () => {
+    expect(isPlanFile('/home/claudeuser/.claude/projects/-workspace-foo/implementation.md')).toBe(
+      true
+    );
+  });
+
+  it('should not detect .md files outside .claude/projects/', () => {
+    expect(isPlanFile('/workspace/clawed-abode/README.md')).toBe(false);
+  });
+
+  it('should not detect non-.md files inside .claude/projects/', () => {
+    expect(isPlanFile('/home/claudeuser/.claude/projects/-workspace-foo/config.json')).toBe(false);
+  });
+
+  it('should not detect files in .claude but not in projects/', () => {
+    expect(isPlanFile('/home/claudeuser/.claude/MEMORY.md')).toBe(false);
+  });
+});

--- a/src/components/messages/plan-utils.ts
+++ b/src/components/messages/plan-utils.ts
@@ -1,0 +1,17 @@
+/**
+ * Utility functions for detecting and handling plan mode files.
+ *
+ * Plan files are written by Claude during plan mode to a path like:
+ *   /home/claudeuser/.claude/projects/<project>/plan.md
+ *
+ * These files should be rendered as Markdown rather than raw code.
+ */
+
+/**
+ * Check if a file path looks like a Claude plan file.
+ * Plan files live inside .claude/projects/ directories and end with plan.md
+ * (or sometimes have other names, but are always .md inside .claude/projects/).
+ */
+export function isPlanFile(filePath: string): boolean {
+  return filePath.includes('.claude/projects/') && filePath.endsWith('.md');
+}


### PR DESCRIPTION
## Summary
- **Auto-interrupt on user input tools**: When the agent calls `AskUserQuestion` or `ExitPlanMode`, the query is automatically interrupted so the conversation stops and waits for user input instead of continuing with error responses
- **Plan file detection and Markdown rendering**: Write/Edit operations targeting plan files (`.md` inside `.claude/projects/`) now render as Markdown instead of raw code/diffs
- **Full plan display in ExitPlanMode**: Reconstructs the current plan content from Write/Edit history and displays the full rendered Markdown with a copy-to-clipboard button
- **EnterPlanMode display**: New component showing a planning mode indicator when Claude enters plan mode

## Test plan
- [x] All 390 tests pass (12 new tests added)
- [x] TypeScript compiles with no errors
- [x] Unit tests for `isPlanFile` (5 tests) covering plan paths, non-plan paths, and edge cases
- [x] Unit tests for `shouldAutoInterrupt` (7 tests) covering AskUserQuestion, ExitPlanMode, regular tools, text messages, user messages, and null/undefined
- [ ] Manual test: Start a session, ask Claude to enter plan mode, verify auto-interrupt works on AskUserQuestion
- [ ] Manual test: Verify plan Write renders as Markdown, plan Edit shows "Plan Updated"
- [ ] Manual test: Verify ExitPlanMode shows full rendered plan with copy button

Fixes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)