### PR TITLE
Show idle-timed-out auth sessions as expired in the UI

### DIFF
--- a/src/components/settings/AuthSessionListItem.tsx
+++ b/src/components/settings/AuthSessionListItem.tsx
@@ -79,7 +79,8 @@ export function AuthSessionListItem({ session, onRevoke }: AuthSessionListItemPr
 
   const now = new Date();
   const isRevoked = !!session.revokedAt;
-  const isExpired = new Date(session.expiresAt) <= now;
+  const isExpired = new Date(session.effectiveExpiresAt) <= now;
+  const isIdleExpired = !isRevoked && isExpired && new Date(session.expiresAt) > now;
   const isActive = !isRevoked && !isExpired;
 
   const handleRevoke = async () => {
@@ -107,7 +108,12 @@ export function AuthSessionListItem({ session, onRevoke }: AuthSessionListItemPr
                 Revoked
               </Badge>
             )}
-            {isExpired && !isRevoked && (
+            {isIdleExpired && (
+              <Badge variant="outline" className="text-xs text-muted-foreground">
+                Idle timeout
+              </Badge>
+            )}
+            {isExpired && !isRevoked && !isIdleExpired && (
               <Badge variant="outline" className="text-xs text-muted-foreground">
                 Expired
               </Badge>
@@ -119,7 +125,8 @@ export function AuthSessionListItem({ session, onRevoke }: AuthSessionListItemPr
             <p>Last active: {formatRelativeTime(session.lastActivityAt)}</p>
             {isRevoked && session.revokedAt && <p>Revoked: {formatDate(session.revokedAt)}</p>}
             <p>
-              {isExpired ? 'Expired' : 'Expires'}: {formatDate(session.expiresAt)}
+              {isExpired ? 'Expired' : 'Expires'}: {formatDate(session.effectiveExpiresAt)}
+              {isIdleExpired && ' (idle)'}
             </p>
             <p>Created: {formatDate(session.createdAt)}</p>
           </div>

--- a/src/components/settings/AuthSessionsTab.tsx
+++ b/src/components/settings/AuthSessionsTab.tsx
@@ -36,7 +36,7 @@ export function AuthSessionsTab() {
 
   const now = new Date();
   const isSessionActive = (s: (typeof sessions)[number]) =>
-    !s.revokedAt && new Date(s.expiresAt) > now;
+    !s.revokedAt && new Date(s.effectiveExpiresAt) > now;
   const activeSessions = sessions.filter(isSessionActive);
   const inactiveSessions = sessions.filter((s) => !isSessionActive(s));
 

--- a/src/hooks/useAuthSessions.ts
+++ b/src/hooks/useAuthSessions.ts
@@ -6,6 +6,7 @@ export interface AuthSession {
   id: string;
   createdAt: Date;
   expiresAt: Date;
+  effectiveExpiresAt: Date;
   lastActivityAt: Date;
   revokedAt: Date | null;
   ipAddress: string | null;


### PR DESCRIPTION
## Summary
- Auth sessions have a 24-hour idle timeout alongside the 7-day absolute expiry, but the UI only showed `expiresAt` (7 days). This caused confusion where sessions appeared active with days remaining but actually required re-login after 24h of inactivity.
- The server now computes `effectiveExpiresAt = MIN(expiresAt, lastActivityAt + IDLE_TIMEOUT)` and returns it in the `listSessions` response. The UI uses this for both active/inactive filtering and display.
- Sessions that expired due to idle timeout show an "Idle timeout" badge instead of "Expired".

## Test plan
- [x] Existing integration tests updated with `effectiveExpiresAt` assertions
- [x] New integration test verifies stale sessions (lastActivityAt 2 days ago) get correct `effectiveExpiresAt` in the past
- [x] All 390 unit tests and 162 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)