### PR TITLE
Disable Gradle daemon to fix phantom builds from shared cache

### DIFF
--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -77,7 +77,7 @@ The system uses **named Docker volumes** to avoid permission issues with rootles
 
 3. **pnpm Store** (`clawed-abode-pnpm-store`): Shared pnpm cache at `/pnpm-store` in runner containers. Speeds up package installs.
 
-4. **Gradle Cache** (`clawed-abode-gradle-cache`): Shared Gradle cache at `/gradle-cache` in runner containers. Speeds up builds.
+4. **Gradle Cache** (`clawed-abode-gradle-cache`): Shared Gradle cache at `/gradle-cache` in runner containers. Speeds up builds. The Gradle daemon is disabled (`org.gradle.daemon=false`) because stale daemons from previous sessions have cached VFS snapshots of old `/workspace` mounts, causing phantom builds.
 
 5. **Git Cache** (`clawed-abode-git-cache`): Shared bare repository cache at `/cache` in clone containers. Used as `--reference` during clones to avoid re-downloading git objects for repos that have been cloned before.
 
@@ -436,6 +436,7 @@ ORDER BY sequence ASC;
 - The cache is mounted at `/gradle-cache` in containers and `GRADLE_USER_HOME` env var is set
 - Gradle's cache is safe for concurrent access (uses file locking)
 - Includes downloaded dependencies, wrapper distributions, and build caches
+- **Daemon disabled**: The Gradle daemon is disabled via `GRADLE_OPTS=-Dorg.gradle.daemon=false` (env var) and `/gradle-cache/gradle.properties` (written at container startup). Stale daemons from previous sessions persist in the shared volume with cached VFS snapshots of old `/workspace` mounts, causing phantom builds where outputs are invisible. The entrypoint also kills any leftover `GradleDaemon` processes as a safety measure.
 
 ### Git Reference Cache
 

--- a/src/server/services/podman.ts
+++ b/src/server/services/podman.ts
@@ -608,6 +608,10 @@ export async function createAndStartContainer(config: ContainerConfig): Promise<
     envArgs.push('-e', `CLAUDE_CODE_OAUTH_TOKEN=${oauthToken}`);
     // Set Gradle user home to use the shared cache volume
     envArgs.push('-e', 'GRADLE_USER_HOME=/gradle-cache');
+    // Disable Gradle daemon - the shared /gradle-cache volume persists daemons across
+    // container sessions, but stale daemons have cached VFS snapshots from old /workspace
+    // mounts, causing phantom builds where outputs are invisible (see issue #238)
+    envArgs.push('-e', 'GRADLE_OPTS=-Dorg.gradle.daemon=false');
     // Add NVIDIA environment variables for GPU access
     envArgs.push('-e', 'NVIDIA_VISIBLE_DEVICES=all');
     envArgs.push('-e', 'NVIDIA_DRIVER_CAPABILITIES=all');


### PR DESCRIPTION
## Summary
- Disables the Gradle daemon in runner containers to prevent stale daemons from the shared `/gradle-cache` volume from causing phantom builds
- Stale daemons retain cached VFS snapshots of old `/workspace` mounts, making build outputs invisible and reporting false UP-TO-DATE results
- Uses defense-in-depth: `GRADLE_OPTS` env var, `gradle.properties` in GRADLE_USER_HOME, and killing leftover daemon processes at container startup

## Changes
- `src/server/services/podman.ts`: Add `GRADLE_OPTS=-Dorg.gradle.daemon=false` env var to containers
- `docker/entrypoint.sh`: Write `org.gradle.daemon=false` to `/gradle-cache/gradle.properties` and kill stale `GradleDaemon` processes at startup
- `doc/DESIGN.md`: Document the daemon-disabled approach and rationale

Fixes #238

## Test plan
- [x] All 390 existing tests pass
- [ ] Verify Gradle builds work correctly in a new container session (daemon should not be running)
- [ ] Verify `./gradlew --status` shows no idle daemons after a build

🤖 Generated with [Claude Code](https://claude.com/claude-code)