### PR TITLE
Support KVM passthrough for Android emulator testing

### DIFF
--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -315,7 +315,7 @@ The runner container image is defined in [`docker/Dockerfile.claude-code`](../do
 
 - NVIDIA CUDA base for GPU workloads
 - Podman for container-in-container operations
-- Common development tools (Node.js, Python, JDK, Android SDK)
+- Common development tools (Node.js, Python, JDK, Android SDK with emulator and system images)
 - Passwordless sudo for package installation
 - Docker/docker-compose aliases pointing to Podman equivalents
 - Rootless Podman configured with fuse-overlayfs
@@ -334,6 +334,7 @@ Runner containers are created with (see [`createAndStartContainer`](../src/serve
 - **pnpm store**: Named volume mounted at `/pnpm-store` for shared package cache
 - **Gradle cache**: Named volumes for `caches/` and `wrapper/` subdirectories mounted under `/gradle-cache`. The `daemon/` directory is ephemeral per-container to prevent stale daemon issues.
 - **Agent service**: Configured via `AGENT_PORT`, `SYSTEM_PROMPT`, and `CLAUDE_MODEL` environment variables. The container's CMD runs the agent service, which provides an HTTP API for the Next.js server to interact with Claude.
+- **KVM access**: `/dev/kvm` is passed through when available on the host, enabling hardware-accelerated Android emulator for instrumented tests (Espresso, Compose UI tests). The entrypoint script fixes device permissions so the container user can access it. See [issue #245](https://github.com/brendanlong/clawed-abode/issues/245).
 
 ### Agent Service Architecture
 

--- a/docker/Dockerfile.claude-code
+++ b/docker/Dockerfile.claude-code
@@ -18,9 +18,11 @@ RUN mkdir -p ${ANDROID_HOME}/cmdline-tools && \
     chmod +x ${ANDROID_HOME}/cmdline-tools/latest/bin/*
 
 # Accept Android SDK licenses and install common components
+# Includes emulator and a system image for Android instrumented tests (see issue #245)
 ENV PATH="${ANDROID_HOME}/cmdline-tools/latest/bin:${PATH}"
 RUN yes | sdkmanager --licenses > /dev/null 2>&1 && \
-    sdkmanager "platform-tools" "platforms;android-35" "build-tools;35.0.0"
+    sdkmanager "platform-tools" "platforms;android-35" "build-tools;35.0.0" \
+    "emulator" "system-images;android-35;google_apis;x86_64"
 
 # Stage 2: Final image
 FROM docker.io/nvidia/cuda:12.6.3-base-ubuntu24.04

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -49,5 +49,11 @@ if [ -e /var/run/docker.sock ]; then
   sudo chmod 666 /var/run/docker.sock 2>/dev/null || true
 fi
 
+# Fix KVM device permissions for Android emulator hardware acceleration (see issue #245)
+# When /dev/kvm is passed through via --device, the container user needs write access
+if [ -e /dev/kvm ]; then
+  sudo chmod 666 /dev/kvm 2>/dev/null || true
+fi
+
 # --- Launch agent service ---
 exec node /opt/agent-service/dist/agent-service/src/index.js

--- a/src/server/services/podman.ts
+++ b/src/server/services/podman.ts
@@ -671,6 +671,9 @@ export async function createAndStartContainer(config: ContainerConfig): Promise<
     // GPU access via CDI (Container Device Interface) - requires nvidia-container-toolkit
     // and CDI specs generated via: nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
     //
+    // KVM access for Android emulator hardware acceleration (see issue #245).
+    // Passed through only if /dev/kvm exists on the host.
+    //
     // Network mode is configurable via CONTAINER_NETWORK_MODE:
     // - "host": Share host's network namespace. Allows containers to connect to
     //   services started via podman-compose on localhost. Recommended when agents
@@ -678,6 +681,11 @@ export async function createAndStartContainer(config: ContainerConfig): Promise<
     // - "bridge": Standard container networking with NAT.
     // - "pasta": Rootless Podman's default.
     // See: https://github.com/brendanlong/clawed-abode/issues/147
+    const deviceArgs: string[] = ['--device', 'nvidia.com/gpu=all'];
+    if (existsSync('/dev/kvm')) {
+      deviceArgs.push('--device', '/dev/kvm');
+    }
+
     const createArgs = [
       'create',
       '--name',
@@ -686,8 +694,7 @@ export async function createAndStartContainer(config: ContainerConfig): Promise<
       env.CONTAINER_NETWORK_MODE,
       '--security-opt',
       'label=disable',
-      '--device',
-      'nvidia.com/gpu=all',
+      ...deviceArgs,
       '-w',
       workingDir,
       ...envArgs,


### PR DESCRIPTION
## Summary

- Pass `/dev/kvm` into runner containers when available on the host, enabling hardware-accelerated Android emulator for instrumented tests (Espresso, Compose UI tests)
- Install `emulator` and `system-images;android-35;google_apis;x86_64` in the container image
- Fix `/dev/kvm` device permissions in the entrypoint so the container user can access it

## Changes

- **`src/server/services/podman.ts`**: Conditionally add `--device /dev/kvm` to container creation when `/dev/kvm` exists on the host
- **`docker/Dockerfile.claude-code`**: Install Android emulator and x86_64 system image via sdkmanager
- **`docker/entrypoint.sh`**: `chmod 666 /dev/kvm` when the device is present (same pattern as the podman socket fix)
- **`doc/DESIGN.md`**: Document KVM passthrough in Base Image and Container Launch sections

## Test plan

- [ ] Verify all existing tests pass (`pnpm test:run` — 390 tests passing)
- [ ] On a host with `/dev/kvm`: confirm container gets `--device /dev/kvm` flag and emulator can start in headless mode
- [ ] On a host without `/dev/kvm`: confirm container creation still works (no KVM device passed)
- [ ] Rebuild container image and verify emulator and system image are installed

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)