### PR TITLE
Remove token rotation to fix frequent session invalidation

### DIFF
--- a/src/app/api/trpc/[trpc]/route.ts
+++ b/src/app/api/trpc/[trpc]/route.ts
@@ -2,32 +2,12 @@ import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
 import { appRouter } from '@/server/routers';
 import { createContext } from '@/server/trpc';
 
-// Custom header used to notify clients of token rotation
-export const TOKEN_ROTATION_HEADER = 'X-Rotated-Token';
-
-const handler = async (req: Request) => {
-  // Create context first to check for token rotation
-  const ctx = await createContext({ headers: req.headers });
-
-  const response = await fetchRequestHandler({
+const handler = (req: Request) =>
+  fetchRequestHandler({
     endpoint: '/api/trpc',
     req,
     router: appRouter,
-    createContext: () => Promise.resolve(ctx),
+    createContext: ({ req }) => createContext({ headers: req.headers }),
   });
-
-  // If token was rotated, add it as a header so client can update
-  if (ctx.rotatedToken) {
-    const newHeaders = new Headers(response.headers);
-    newHeaders.set(TOKEN_ROTATION_HEADER, ctx.rotatedToken);
-    return new Response(response.body, {
-      status: response.status,
-      statusText: response.statusText,
-      headers: newHeaders,
-    });
-  }
-
-  return response;
-};
 
 export { handler as GET, handler as POST };

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -5,7 +5,6 @@ import { z } from 'zod';
 const TOKEN_LENGTH = 32; // 256 bits of entropy
 export const SESSION_DURATION_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 export const IDLE_TIMEOUT_MS = 24 * 60 * 60 * 1000; // 24 hours
-export const TOKEN_ROTATION_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
 export const ACTIVITY_UPDATE_THROTTLE_MS = 60 * 1000; // 1 minute - minimum time between activity updates
 
 export const loginSchema = z.object({

--- a/src/lib/trpc.ts
+++ b/src/lib/trpc.ts
@@ -10,22 +10,10 @@ import type { AppRouter } from '@/server/routers';
 export const trpc = createTRPCReact<AppRouter>();
 
 const TOKEN_KEY = 'auth_token';
-const TOKEN_ROTATION_HEADER = 'x-rotated-token';
 
 function getAuthToken(): string | null {
   if (typeof window === 'undefined') return null;
   return localStorage.getItem(TOKEN_KEY);
-}
-
-/**
- * Updates the stored auth token if a rotated token is provided.
- * Called when the server rotates the session token.
- */
-function handleTokenRotation(headers: Headers) {
-  const rotatedToken = headers.get(TOKEN_ROTATION_HEADER);
-  if (rotatedToken && typeof window !== 'undefined') {
-    localStorage.setItem(TOKEN_KEY, rotatedToken);
-  }
 }
 
 /**
@@ -69,18 +57,6 @@ function authErrorLink(): TRPCLink<AppRouter> {
   };
 }
 
-/**
- * Custom fetch that intercepts responses to handle token rotation.
- */
-async function fetchWithTokenRotation(
-  input: RequestInfo | URL,
-  init?: RequestInit
-): Promise<Response> {
-  const response = await fetch(input, init);
-  handleTokenRotation(response.headers);
-  return response;
-}
-
 export function createTRPCClient() {
   return trpc.createClient({
     links: [
@@ -102,7 +78,6 @@ export function createTRPCClient() {
         false: httpBatchLink({
           url: '/api/trpc',
           transformer: superjson,
-          fetch: fetchWithTokenRotation,
           headers() {
             const token = getAuthToken();
             return token ? { authorization: `Bearer ${token}` } : {};

--- a/src/server/routers/auth.integration.test.ts
+++ b/src/server/routers/auth.integration.test.ts
@@ -31,7 +31,7 @@ const createCaller = (sessionId: string | null) => {
   const testRouter = router({
     auth: authRouter,
   });
-  return testRouter.createCaller({ sessionId, rotatedToken: null });
+  return testRouter.createCaller({ sessionId });
 };
 
 const TEST_PASSWORD = 'test-password-123';

--- a/src/server/routers/claude.integration.test.ts
+++ b/src/server/routers/claude.integration.test.ts
@@ -40,7 +40,7 @@ const createCaller = (sessionId: string | null) => {
   const testRouter = router({
     claude: claudeRouter,
   });
-  return testRouter.createCaller({ sessionId, rotatedToken: null });
+  return testRouter.createCaller({ sessionId });
 };
 
 describe('claudeRouter integration', () => {

--- a/src/server/routers/github.test.ts
+++ b/src/server/routers/github.test.ts
@@ -44,7 +44,7 @@ const createCaller = (sessionId: string | null) => {
   const testRouter = router({
     github: githubRouter,
   });
-  return testRouter.createCaller({ sessionId, rotatedToken: null });
+  return testRouter.createCaller({ sessionId });
 };
 
 // Helper to create mock Response

--- a/src/server/routers/globalSettings.integration.test.ts
+++ b/src/server/routers/globalSettings.integration.test.ts
@@ -21,7 +21,7 @@ const createCaller = () => {
     globalSettings: globalSettingsRouter,
   });
   // Use a fake session ID to pass the auth check
-  return testRouter.createCaller({ sessionId: 'test-session', rotatedToken: null });
+  return testRouter.createCaller({ sessionId: 'test-session' });
 };
 
 describe('globalSettings router', () => {

--- a/src/server/routers/repoSettings.integration.test.ts
+++ b/src/server/routers/repoSettings.integration.test.ts
@@ -21,7 +21,7 @@ const createCaller = () => {
     repoSettings: repoSettingsRouter,
   });
   // Use a fake session ID to pass the auth check
-  return testRouter.createCaller({ sessionId: 'test-session', rotatedToken: null });
+  return testRouter.createCaller({ sessionId: 'test-session' });
 };
 
 describe('repoSettings router', () => {

--- a/src/server/routers/sessions.integration.test.ts
+++ b/src/server/routers/sessions.integration.test.ts
@@ -84,7 +84,7 @@ const createCaller = (sessionId: string | null) => {
   const testRouter = router({
     sessions: sessionsRouter,
   });
-  return testRouter.createCaller({ sessionId, rotatedToken: null });
+  return testRouter.createCaller({ sessionId });
 };
 
 describe('sessionsRouter integration', () => {

--- a/src/server/trpc.integration.test.ts
+++ b/src/server/trpc.integration.test.ts
@@ -1,11 +1,6 @@
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
 import { setupTestDb, teardownTestDb, testPrisma, clearTestDb } from '@/test/setup-test-db';
-import {
-  IDLE_TIMEOUT_MS,
-  TOKEN_ROTATION_INTERVAL_MS,
-  ACTIVITY_UPDATE_THROTTLE_MS,
-  generateSessionToken,
-} from '@/lib/auth';
+import { IDLE_TIMEOUT_MS, ACTIVITY_UPDATE_THROTTLE_MS, generateSessionToken } from '@/lib/auth';
 
 // Mock logger (just to reduce noise)
 vi.mock('@/lib/logger', () => ({
@@ -21,7 +16,7 @@ vi.mock('@/lib/logger', () => ({
 // Will be set in beforeAll after test DB is set up
 let createContext: Awaited<typeof import('./trpc')>['createContext'];
 
-describe('createContext - activity tracking and token rotation', () => {
+describe('createContext - activity tracking', () => {
   beforeAll(async () => {
     await setupTestDb();
 
@@ -68,13 +63,11 @@ describe('createContext - activity tracking and token rotation', () => {
     it('should return null sessionId for missing token', async () => {
       const ctx = await createContext({ headers: createHeaders(null) });
       expect(ctx.sessionId).toBeNull();
-      expect(ctx.rotatedToken).toBeNull();
     });
 
     it('should return null sessionId for invalid token', async () => {
       const ctx = await createContext({ headers: createHeaders('invalid-token') });
       expect(ctx.sessionId).toBeNull();
-      expect(ctx.rotatedToken).toBeNull();
     });
 
     it('should return sessionId for valid token', async () => {
@@ -125,54 +118,8 @@ describe('createContext - activity tracking and token rotation', () => {
     });
   });
 
-  describe('token rotation', () => {
-    it('should rotate token when activity exceeds rotation interval', async () => {
-      const lastActivity = new Date(Date.now() - TOKEN_ROTATION_INTERVAL_MS - 1000); // Past rotation interval
-      const { session, token } = await createTestSession({ lastActivityAt: lastActivity });
-
-      const ctx = await createContext({ headers: createHeaders(token) });
-
-      // Session should still be valid
-      expect(ctx.sessionId).toBe(session.id);
-
-      // Should have a rotated token
-      expect(ctx.rotatedToken).toBeDefined();
-      expect(ctx.rotatedToken).not.toBe(token);
-
-      // Database should have the new token
-      const updatedSession = await testPrisma.authSession.findFirst({
-        where: { id: session.id },
-      });
-      expect(updatedSession).toBeDefined();
-      expect(updatedSession!.token).toBe(ctx.rotatedToken);
-
-      // Last activity should be updated
-      expect(updatedSession!.lastActivityAt.getTime()).toBeGreaterThan(lastActivity.getTime());
-    });
-
-    it('should not rotate token when activity is within rotation interval', async () => {
-      const lastActivity = new Date(Date.now() - TOKEN_ROTATION_INTERVAL_MS / 2); // Half of rotation interval
-      const { session, token } = await createTestSession({ lastActivityAt: lastActivity });
-
-      const ctx = await createContext({ headers: createHeaders(token) });
-
-      // Session should still be valid
-      expect(ctx.sessionId).toBe(session.id);
-
-      // Should NOT have a rotated token
-      expect(ctx.rotatedToken).toBeNull();
-
-      // Token should remain unchanged
-      const updatedSession = await testPrisma.authSession.findFirst({
-        where: { id: session.id },
-      });
-      expect(updatedSession!.token).toBe(token);
-    });
-  });
-
   describe('activity update throttling', () => {
-    it('should update activity when exceeding throttle interval but not rotation interval', async () => {
-      // Set last activity to just past the throttle interval but within rotation interval
+    it('should update activity when exceeding throttle interval', async () => {
       const lastActivity = new Date(Date.now() - ACTIVITY_UPDATE_THROTTLE_MS - 1000);
       const { session, token } = await createTestSession({ lastActivityAt: lastActivity });
 
@@ -180,9 +127,6 @@ describe('createContext - activity tracking and token rotation', () => {
 
       // Session should be valid
       expect(ctx.sessionId).toBe(session.id);
-
-      // Should NOT have a rotated token
-      expect(ctx.rotatedToken).toBeNull();
 
       // Wait a bit for the async update to complete
       await new Promise((resolve) => setTimeout(resolve, 100));
@@ -203,9 +147,6 @@ describe('createContext - activity tracking and token rotation', () => {
       // Session should be valid
       expect(ctx.sessionId).toBe(session.id);
 
-      // Should NOT have a rotated token
-      expect(ctx.rotatedToken).toBeNull();
-
       // Wait a bit
       await new Promise((resolve) => setTimeout(resolve, 100));
 
@@ -214,6 +155,23 @@ describe('createContext - activity tracking and token rotation', () => {
         where: { id: session.id },
       });
       expect(updatedSession!.lastActivityAt.getTime()).toBe(lastActivity.getTime());
+    });
+
+    it('should not change token regardless of idle time', async () => {
+      // Even with long idle time (but within idle timeout), token should remain the same
+      const lastActivity = new Date(Date.now() - IDLE_TIMEOUT_MS / 2);
+      const { session, token } = await createTestSession({ lastActivityAt: lastActivity });
+
+      await createContext({ headers: createHeaders(token) });
+
+      // Wait for async update
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Token should remain unchanged
+      const updatedSession = await testPrisma.authSession.findFirst({
+        where: { id: session.id },
+      });
+      expect(updatedSession!.token).toBe(token);
     });
   });
 });

--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -1,12 +1,6 @@
 import { initTRPC, TRPCError } from '@trpc/server';
 import superjson from 'superjson';
-import {
-  parseAuthHeader,
-  generateSessionToken,
-  IDLE_TIMEOUT_MS,
-  TOKEN_ROTATION_INTERVAL_MS,
-  ACTIVITY_UPDATE_THROTTLE_MS,
-} from '@/lib/auth';
+import { parseAuthHeader, IDLE_TIMEOUT_MS, ACTIVITY_UPDATE_THROTTLE_MS } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { createLogger } from '@/lib/logger';
 
@@ -14,7 +8,6 @@ const log = createLogger('trpc');
 
 export interface Context {
   sessionId: string | null;
-  rotatedToken: string | null; // New token if rotation occurred
 }
 
 export async function createContext(opts: { headers: Headers }): Promise<Context> {
@@ -22,7 +15,7 @@ export async function createContext(opts: { headers: Headers }): Promise<Context
   const token = parseAuthHeader(authHeader);
 
   if (!token) {
-    return { sessionId: null, rotatedToken: null };
+    return { sessionId: null };
   }
 
   const session = await prisma.authSession.findUnique({
@@ -31,19 +24,19 @@ export async function createContext(opts: { headers: Headers }): Promise<Context
   });
 
   if (!session) {
-    return { sessionId: null, rotatedToken: null };
+    return { sessionId: null };
   }
 
   const now = new Date();
 
   // Check if session has been revoked
   if (session.revokedAt) {
-    return { sessionId: null, rotatedToken: null };
+    return { sessionId: null };
   }
 
   // Check if session has expired
   if (session.expiresAt < now) {
-    return { sessionId: null, rotatedToken: null };
+    return { sessionId: null };
   }
 
   // Check for idle timeout
@@ -51,27 +44,11 @@ export async function createContext(opts: { headers: Headers }): Promise<Context
   if (idleTime > IDLE_TIMEOUT_MS) {
     // Session is idle, reject it (but don't delete - keep for audit/display)
     log.info('Session rejected due to idle timeout', { sessionId: session.id });
-    return { sessionId: null, rotatedToken: null };
+    return { sessionId: null };
   }
 
-  // Check if token rotation is needed (more than TOKEN_ROTATION_INTERVAL_MS since last activity)
-  let rotatedToken: string | null = null;
-  if (idleTime > TOKEN_ROTATION_INTERVAL_MS) {
-    // Rotate the token
-    const newToken = generateSessionToken();
-    try {
-      await prisma.authSession.update({
-        where: { id: session.id },
-        data: { token: newToken, lastActivityAt: now },
-      });
-      rotatedToken = newToken;
-      log.info('Session token rotated', { sessionId: session.id });
-    } catch {
-      // If update fails (e.g., race condition), just continue with activity update
-      log.warn('Token rotation failed, continuing with activity update', { sessionId: session.id });
-    }
-  } else if (idleTime > ACTIVITY_UPDATE_THROTTLE_MS) {
-    // Just update last activity (throttled to avoid excessive DB writes)
+  // Update last activity (throttled to avoid excessive DB writes)
+  if (idleTime > ACTIVITY_UPDATE_THROTTLE_MS) {
     prisma.authSession
       .update({
         where: { id: session.id },
@@ -82,7 +59,7 @@ export async function createContext(opts: { headers: Headers }): Promise<Context
       });
   }
 
-  return { sessionId: session.id, rotatedToken };
+  return { sessionId: session.id };
 }
 
 const t = initTRPC.context<Context>().create({


### PR DESCRIPTION
## Summary

- Removed token rotation mechanism that was replacing auth tokens in-place after 1 hour of inactivity
- This fixes frequent unexpected logouts caused by race conditions between concurrent HTTP requests and SSE subscriptions
- Sessions still have 24-hour idle timeout and 7-day absolute expiry for security

## Problem

Token rotation was invalidating the old token immediately when issuing a new one. With 5 active SSE subscriptions and regular HTTP polls, when a user returned after >1 hour idle:

1. Multiple requests would fire simultaneously (SSE reconnects + HTTP polls)
2. The first request to reach the server would trigger rotation, invalidating the old token
3. Other in-flight requests still using the old token would get UNAUTHORIZED
4. The client would clear the token and redirect to login

## Test plan

- [x] All 390 unit tests pass
- [x] All 161 integration tests pass
- [x] New test verifies token is never changed regardless of idle time
- [ ] Verify no more unexpected logouts when switching devices or returning after idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)