### PR TITLE
Audit cost tracking to match Anthropic Agent SDK docs

### DIFF
--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -257,19 +257,9 @@ function getLatestPlanContent(messages: Message[]): string | null {
   return planContent || null;
 }
 
-// Extract total cost from result messages
-function getTotalCostUsd(messages: Message[]): number {
-  let totalCost = 0;
-  for (const msg of messages) {
-    if (msg.type === 'result') {
-      const content = msg.content as { total_cost_usd?: number } | undefined;
-      if (typeof content?.total_cost_usd === 'number') {
-        totalCost += content.total_cost_usd;
-      }
-    }
-  }
-  return totalCost;
-}
+// Total cost is now provided by tokenUsage.totalCostUsd from the server-side
+// estimateTokenUsage function, which uses the authoritative total_cost_usd
+// from result messages per Anthropic's cost tracking docs.
 
 interface MessageListProps {
   messages: Message[];
@@ -342,8 +332,7 @@ export function MessageList({
     return todoIds.length > 0 ? todoIds[todoIds.length - 1] : null;
   }, [messages]);
 
-  // Calculate total cost from result messages
-  const totalCostUsd = useMemo(() => getTotalCostUsd(messages), [messages]);
+  // Total cost comes from tokenUsage (server-computed from authoritative result messages)
 
   // Track the latest plan content from Write/Edit calls to plan files
   const latestPlanContent = useMemo(() => getLatestPlanContent(messages), [messages]);
@@ -494,7 +483,7 @@ export function MessageList({
       {/* Context usage indicator - positioned in bottom right */}
       <ContextUsageIndicator
         stats={tokenUsage}
-        totalCostUsd={totalCostUsd}
+        totalCostUsd={tokenUsage?.totalCostUsd}
         className="absolute bottom-3 right-3 shadow-sm"
       />
     </div>

--- a/src/lib/claude-messages.ts
+++ b/src/lib/claude-messages.ts
@@ -103,7 +103,10 @@ export const ServerToolUseSchema = z.object({
 export type ServerToolUse = z.infer<typeof ServerToolUseSchema>;
 
 /**
- * Aggregated usage for result messages
+ * Aggregated usage for result messages.
+ * Per the Anthropic Agent SDK, result messages use NonNullableUsage where
+ * all fields are required numbers. We keep them optional in our schema for
+ * backwards compatibility with older stored messages.
  */
 export const ResultUsageSchema = z.object({
   input_tokens: z.number().optional(),
@@ -113,6 +116,8 @@ export const ResultUsageSchema = z.object({
   server_tool_use: ServerToolUseSchema.optional(),
   service_tier: z.string().optional(),
   cache_creation: CacheCreationSchema.optional(),
+  inference_geo: z.string().nullable().optional(),
+  speed: z.enum(['standard', 'fast']).nullable().optional(),
 });
 export type ResultUsage = z.infer<typeof ResultUsageSchema>;
 
@@ -264,6 +269,7 @@ export const ResultContentSchema = z.object({
   duration_ms: z.number().optional(),
   duration_api_ms: z.number().optional(),
   num_turns: z.number().optional(),
+  stop_reason: z.string().nullable().optional(),
   result: z.string().optional(),
   errors: z.array(z.string()).optional(),
   session_id: z.string(),

--- a/src/lib/token-estimation.test.ts
+++ b/src/lib/token-estimation.test.ts
@@ -49,6 +49,7 @@ describe('token-estimation', () => {
       expect(result.totalTokens).toBe(0);
       expect(result.contextWindow).toBe(200_000); // Default
       expect(result.percentUsed).toBe(0);
+      expect(result.totalCostUsd).toBe(0);
     });
 
     it('should extract usage from assistant messages when no result messages', () => {
@@ -427,6 +428,209 @@ describe('token-estimation', () => {
 
       // Falls back to total tokens: (100k + 50k) / 200k = 75%
       expect(result.percentUsed).toBe(75);
+    });
+
+    it('should extract total_cost_usd from result messages', () => {
+      const messages = [
+        {
+          type: 'assistant',
+          content: {
+            type: 'assistant',
+            message: {
+              usage: { input_tokens: 1000, output_tokens: 500 },
+            },
+          },
+        },
+        {
+          type: 'result',
+          content: {
+            type: 'result',
+            total_cost_usd: 0.0523,
+            usage: {
+              input_tokens: 5000,
+              output_tokens: 2500,
+            },
+          },
+        },
+      ];
+
+      const result = estimateTokenUsage(messages);
+
+      expect(result.totalCostUsd).toBeCloseTo(0.0523, 4);
+    });
+
+    it('should sum total_cost_usd from multiple result messages', () => {
+      const messages = [
+        {
+          type: 'result',
+          content: {
+            type: 'result',
+            total_cost_usd: 0.05,
+            usage: { input_tokens: 1000, output_tokens: 500 },
+          },
+        },
+        {
+          type: 'result',
+          content: {
+            type: 'result',
+            total_cost_usd: 0.1,
+            usage: { input_tokens: 2000, output_tokens: 1000 },
+          },
+        },
+      ];
+
+      const result = estimateTokenUsage(messages);
+
+      expect(result.totalCostUsd).toBeCloseTo(0.15, 4);
+      expect(result.inputTokens).toBe(3000);
+      expect(result.outputTokens).toBe(1500);
+    });
+
+    it('should deduplicate assistant messages with the same id (parallel tool uses)', () => {
+      // Per Anthropic docs: when Claude sends multiple messages in the same step
+      // (text + parallel tool uses), they share the same message ID and usage.
+      // We should only count usage once per unique ID.
+      const messages = [
+        {
+          type: 'assistant',
+          content: {
+            type: 'assistant',
+            message: {
+              id: 'msg_123',
+              usage: { input_tokens: 1000, output_tokens: 500 },
+            },
+          },
+        },
+        {
+          type: 'assistant',
+          content: {
+            type: 'assistant',
+            message: {
+              id: 'msg_123', // Same ID - parallel tool use
+              usage: { input_tokens: 1000, output_tokens: 500 },
+            },
+          },
+        },
+        {
+          type: 'assistant',
+          content: {
+            type: 'assistant',
+            message: {
+              id: 'msg_123', // Same ID - another parallel tool use
+              usage: { input_tokens: 1000, output_tokens: 500 },
+            },
+          },
+        },
+      ];
+
+      const result = estimateTokenUsage(messages);
+
+      // Should only count once, not three times
+      expect(result.inputTokens).toBe(1000);
+      expect(result.outputTokens).toBe(500);
+      expect(result.totalTokens).toBe(1500);
+    });
+
+    it('should count assistant messages with different ids separately', () => {
+      // Different steps have different message IDs
+      const messages = [
+        {
+          type: 'assistant',
+          content: {
+            type: 'assistant',
+            message: {
+              id: 'msg_1',
+              usage: { input_tokens: 1000, output_tokens: 500 },
+            },
+          },
+        },
+        {
+          type: 'assistant',
+          content: {
+            type: 'assistant',
+            message: {
+              id: 'msg_2', // Different step
+              usage: { input_tokens: 2000, output_tokens: 1000 },
+            },
+          },
+        },
+      ];
+
+      const result = estimateTokenUsage(messages);
+
+      expect(result.inputTokens).toBe(3000);
+      expect(result.outputTokens).toBe(1500);
+      expect(result.totalTokens).toBe(4500);
+    });
+
+    it('should still sum assistant messages without ids (backwards compatibility)', () => {
+      // Older messages might not have an id field
+      const messages = [
+        {
+          type: 'assistant',
+          content: {
+            type: 'assistant',
+            message: {
+              usage: { input_tokens: 1000, output_tokens: 500 },
+            },
+          },
+        },
+        {
+          type: 'assistant',
+          content: {
+            type: 'assistant',
+            message: {
+              usage: { input_tokens: 2000, output_tokens: 1000 },
+            },
+          },
+        },
+      ];
+
+      const result = estimateTokenUsage(messages);
+
+      expect(result.inputTokens).toBe(3000);
+      expect(result.outputTokens).toBe(1500);
+    });
+
+    it('should extract total_cost_usd from result with modelUsage but no usage', () => {
+      const messages = [
+        {
+          type: 'result',
+          content: {
+            type: 'result',
+            total_cost_usd: 0.0842,
+            modelUsage: {
+              'claude-sonnet-4-20250514': {
+                inputTokens: 3000,
+                outputTokens: 1500,
+                costUSD: 0.0842,
+              },
+            },
+          },
+        },
+      ];
+
+      const result = estimateTokenUsage(messages);
+
+      expect(result.totalCostUsd).toBeCloseTo(0.0842, 4);
+    });
+
+    it('should return totalCostUsd of 0 when no result messages', () => {
+      const messages = [
+        {
+          type: 'assistant',
+          content: {
+            type: 'assistant',
+            message: {
+              usage: { input_tokens: 1000, output_tokens: 500 },
+            },
+          },
+        },
+      ];
+
+      const result = estimateTokenUsage(messages);
+
+      expect(result.totalCostUsd).toBe(0);
     });
   });
 });

--- a/src/lib/token-estimation.ts
+++ b/src/lib/token-estimation.ts
@@ -49,6 +49,12 @@ export interface TokenUsageStats {
   percentUsed: number;
   /** Detected model name */
   model?: string;
+  /**
+   * Authoritative total cost in USD from result messages.
+   * Per the Anthropic Agent SDK docs, total_cost_usd in the result message
+   * is the authoritative cost figure for billing purposes.
+   */
+  totalCostUsd: number;
 }
 
 /**
@@ -86,6 +92,7 @@ const SystemInitSchema = z.object({
 const AssistantContentSchema = z.object({
   type: z.literal('assistant'),
   message: z.object({
+    id: z.string().optional(),
     usage: MessageUsageSchema.optional(),
     model: z.string().optional(),
   }),
@@ -96,6 +103,7 @@ const AssistantContentSchema = z.object({
  */
 const ResultContentSchema = z.object({
   type: z.literal('result'),
+  total_cost_usd: z.number().optional(),
   usage: ResultUsageSchema.optional(),
   modelUsage: z
     .record(
@@ -121,9 +129,13 @@ interface Message {
 }
 
 /**
- * Extract usage from an assistant message
+ * Extract usage from an assistant message.
+ * Returns the message id for deduplication — per the Anthropic docs, multiple
+ * assistant messages in the same step share the same id and identical usage.
+ * We should only count usage once per unique message id.
  */
 function extractAssistantUsage(content: unknown): {
+  messageId?: string;
   inputTokens: number;
   outputTokens: number;
   cacheReadTokens: number;
@@ -137,6 +149,7 @@ function extractAssistantUsage(content: unknown): {
 
   const usage = parsed.data.message.usage;
   return {
+    messageId: parsed.data.message.id,
     inputTokens: usage.input_tokens ?? 0,
     outputTokens: usage.output_tokens ?? 0,
     cacheReadTokens: usage.cache_read_input_tokens ?? 0,
@@ -146,7 +159,9 @@ function extractAssistantUsage(content: unknown): {
 }
 
 /**
- * Extract usage from a result message
+ * Extract usage from a result message.
+ * Per the Anthropic Agent SDK docs, the result message contains authoritative
+ * cumulative usage and total_cost_usd for billing purposes.
  */
 function extractResultUsage(content: unknown): {
   inputTokens: number;
@@ -154,11 +169,14 @@ function extractResultUsage(content: unknown): {
   cacheReadTokens: number;
   cacheCreationTokens: number;
   contextWindow?: number;
+  totalCostUsd?: number;
 } | null {
   const parsed = ResultContentSchema.safeParse(content);
   if (!parsed.success) {
     return null;
   }
+
+  const totalCostUsd = parsed.data.total_cost_usd;
 
   // Try to get usage from top-level usage field
   const usage = parsed.data.usage;
@@ -168,6 +186,7 @@ function extractResultUsage(content: unknown): {
       outputTokens: usage.output_tokens ?? 0,
       cacheReadTokens: usage.cache_read_input_tokens ?? 0,
       cacheCreationTokens: usage.cache_creation_input_tokens ?? 0,
+      totalCostUsd,
     };
   }
 
@@ -190,7 +209,25 @@ function extractResultUsage(content: unknown): {
       }
     }
 
-    return { inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens, contextWindow };
+    return {
+      inputTokens,
+      outputTokens,
+      cacheReadTokens,
+      cacheCreationTokens,
+      contextWindow,
+      totalCostUsd,
+    };
+  }
+
+  // If we have a total_cost_usd but no usage breakdown, still return it
+  if (totalCostUsd !== undefined) {
+    return {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      totalCostUsd,
+    };
   }
 
   return null;
@@ -245,6 +282,7 @@ export function estimateTokenUsage(messages: Message[]): TokenUsageStats {
   let totalOutputTokens = 0;
   let totalCacheReadTokens = 0;
   let totalCacheCreationTokens = 0;
+  let totalCostUsd = 0;
   let detectedModel: string | undefined;
   let detectedContextWindow: number | undefined;
 
@@ -264,7 +302,9 @@ export function estimateTokenUsage(messages: Message[]): TokenUsageStats {
     }
   }
 
-  // Sum up total consumed tokens from result messages (for cost tracking)
+  // Sum up total consumed tokens and cost from result messages.
+  // Per the Anthropic Agent SDK docs, result messages contain authoritative
+  // cumulative usage and total_cost_usd for billing purposes.
   const resultMessages = messages.filter((m) => m.type === 'result');
   for (const resultMsg of resultMessages) {
     const usage = extractResultUsage(resultMsg.content);
@@ -275,6 +315,9 @@ export function estimateTokenUsage(messages: Message[]): TokenUsageStats {
       totalCacheCreationTokens += usage.cacheCreationTokens;
       if (usage.contextWindow) {
         detectedContextWindow = usage.contextWindow;
+      }
+      if (usage.totalCostUsd !== undefined) {
+        totalCostUsd += usage.totalCostUsd;
       }
     }
   }
@@ -299,12 +342,24 @@ export function estimateTokenUsage(messages: Message[]): TokenUsageStats {
     }
   }
 
-  // If we have no result messages yet, sum assistant messages for total consumed tokens
+  // If we have no result messages yet, sum assistant messages for total consumed tokens.
+  // Per the Anthropic Agent SDK docs, multiple assistant messages in the same step
+  // share the same message id and identical usage. We deduplicate by message id
+  // to avoid double-counting.
   if (resultMessages.length === 0) {
+    const processedMessageIds = new Set<string>();
     for (const msg of messages) {
       if (msg.type === 'assistant') {
         const usage = extractAssistantUsage(msg.content);
         if (usage) {
+          // Skip if we've already processed this message ID (parallel tool uses
+          // share the same id and usage per Anthropic docs)
+          if (usage.messageId) {
+            if (processedMessageIds.has(usage.messageId)) {
+              continue;
+            }
+            processedMessageIds.add(usage.messageId);
+          }
           totalInputTokens += usage.inputTokens;
           totalOutputTokens += usage.outputTokens;
           totalCacheReadTokens += usage.cacheReadTokens;
@@ -339,6 +394,7 @@ export function estimateTokenUsage(messages: Message[]): TokenUsageStats {
     contextWindow,
     percentUsed: Math.min(percentUsed, 100), // Cap at 100%
     model: detectedModel,
+    totalCostUsd,
   };
 }
 


### PR DESCRIPTION
## Summary
- Deduplicate assistant messages by message ID to prevent double-counting parallel tool uses, per the [Anthropic Agent SDK cost tracking docs](https://platform.claude.com/docs/en/agent-sdk/cost-tracking)
- Use authoritative `total_cost_usd` from result messages instead of computing cost client-side
- Updated Zod schemas to include `stop_reason`, `inference_geo`, `speed` fields from the SDK types
- Added 7 new tests covering deduplication, cost extraction, and backwards compatibility

## Test plan
- [x] All 413 unit tests pass (`pnpm test:run`)
- [x] All 161 integration tests pass (`pnpm test:integration`)
- [x] TypeScript type check passes (`tsc --noEmit`)
- [ ] Verify cost display still works correctly in the UI with a live session

Fixes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)