### PR TITLE
Fix /context response showing as error

### DIFF
--- a/src/components/messages/messageHelpers.test.ts
+++ b/src/components/messages/messageHelpers.test.ts
@@ -44,6 +44,24 @@ describe('extractTextContent', () => {
     expect(extractTextContent(content)).toBeNull();
   });
 
+  it('extracts text from string message.content and strips XML tags', () => {
+    const content: MessageContent = {
+      message: {
+        content: '<local-command-stdout>\n## Context Usage\nSome content\n</local-command-stdout>',
+      },
+    };
+    expect(extractTextContent(content)).toBe('## Context Usage\nSome content');
+  });
+
+  it('extracts text from string message.content without XML tags', () => {
+    const content: MessageContent = {
+      message: {
+        content: 'plain text content',
+      },
+    };
+    expect(extractTextContent(content)).toBe('plain text content');
+  });
+
   it('skips non-text blocks in message content', () => {
     const content: MessageContent = {
       message: {
@@ -163,6 +181,19 @@ describe('isRecognizedMessage', () => {
   it('recognizes user messages with message content array', () => {
     const content: MessageContent = {
       message: { content: [{ type: 'text', text: 'hello' }] },
+    };
+    expect(isRecognizedMessage('user', content)).toEqual({
+      recognized: true,
+      category: 'user',
+    });
+  });
+
+  it('recognizes user messages with string message.content (e.g., /context output)', () => {
+    const content: MessageContent = {
+      message: {
+        role: 'user',
+        content: '<local-command-stdout>\n## Context Usage\n</local-command-stdout>',
+      },
     };
     expect(isRecognizedMessage('user', content)).toEqual({
       recognized: true,
@@ -355,6 +386,16 @@ describe('getDisplayContent', () => {
   it('returns content.content for user messages', () => {
     const content: MessageContent = { content: 'user text' };
     expect(getDisplayContent(content, 'user')).toBe('user text');
+  });
+
+  it('returns stripped string message.content for user messages with local command output', () => {
+    const content: MessageContent = {
+      message: {
+        role: 'user',
+        content: '<local-command-stdout>\n## Context Usage\nSome content\n</local-command-stdout>',
+      },
+    };
+    expect(getDisplayContent(content, 'user')).toBe('## Context Usage\nSome content');
   });
 
   it('returns content.content for system messages', () => {

--- a/src/components/messages/messageHelpers.ts
+++ b/src/components/messages/messageHelpers.ts
@@ -1,6 +1,15 @@
 import type { ContentBlock, MessageContent, ToolCall, ToolResultMap } from './types';
 import { formatAsJson, buildToolMessages } from './types';
 
+/**
+ * Strip XML wrapper tags from Claude Code local command output.
+ * Messages from slash commands like /context are wrapped in tags like
+ * <local-command-stdout>...</local-command-stdout>.
+ */
+function stripXmlTags(text: string): string {
+  return text.replace(/^<local-command-stdout>\n?/, '').replace(/\n?<\/local-command-stdout>$/, '');
+}
+
 export type MessageCategory =
   | 'assistant'
   | 'user'
@@ -33,6 +42,10 @@ export function extractTextContent(content: MessageContent): string | null {
     if (textBlocks.length > 0) {
       return textBlocks.join('\n');
     }
+  }
+  // For messages with string content in message.content (e.g., /context command output)
+  if (typeof content.message?.content === 'string') {
+    return stripXmlTags(content.message.content);
   }
   // For simple content strings
   if (typeof content.content === 'string') {
@@ -90,6 +103,10 @@ export function isRecognizedMessage(type: string, content: MessageContent): Reco
   if (type === 'user') {
     // User prompts typically have message.content with text blocks
     if (content.message?.content && Array.isArray(content.message.content)) {
+      return { recognized: true, category: 'user' };
+    }
+    // Or message.content as a string (e.g., /context command output)
+    if (typeof content.message?.content === 'string') {
       return { recognized: true, category: 'user' };
     }
     // Or simple content string
@@ -211,6 +228,10 @@ export function getDisplayContent(
 ): unknown {
   if (category === 'assistant' && content.message?.content) {
     return content.message.content;
+  }
+  // For user messages with string content in message.content (e.g., /context command output)
+  if (category === 'user' && typeof content.message?.content === 'string') {
+    return stripXmlTags(content.message.content);
   }
   return content.content;
 }

--- a/src/components/messages/types.ts
+++ b/src/components/messages/types.ts
@@ -26,7 +26,7 @@ export interface AssistantMessage {
   id?: string;
   model?: string;
   role?: string;
-  content?: ContentBlock[];
+  content?: ContentBlock[] | string;
   stop_reason?: string | null;
   usage?: {
     input_tokens?: number;


### PR DESCRIPTION
## Summary
- Fix `/context` command response displaying as raw JSON with "Unknown: user" label instead of rendering the markdown content
- The issue was that user messages with string `message.content` (like `/context` output wrapped in `<local-command-stdout>` tags) were not recognized by `isRecognizedMessage()`, causing them to fall through to `RawJsonDisplay`
- Strip `<local-command-stdout>` XML wrapper tags when extracting/displaying the text content

## Test plan
- [x] Added unit tests for `isRecognizedMessage` with string `message.content`
- [x] Added unit tests for `extractTextContent` with XML-wrapped content
- [x] Added unit tests for `getDisplayContent` with local command output
- [x] All 428 tests pass
- [ ] Manually verify `/context` command output renders as styled markdown in session view

Fixes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)