### PR TITLE
Fix streaming TTS delay and missing audio

### DIFF
--- a/src/app/api/voice/speak-stream/route.ts
+++ b/src/app/api/voice/speak-stream/route.ts
@@ -9,6 +9,7 @@ import {
   splitTextForTTS,
   generateSpeechChunk,
   ttsVoiceSchema,
+  TTS_STREAM_TARGET_CHARS,
 } from '@/server/services/voice';
 import { createLogger } from '@/lib/logger';
 
@@ -75,7 +76,7 @@ export async function POST(req: Request) {
     }
   }
 
-  const chunks = splitTextForTTS(text);
+  const chunks = splitTextForTTS(text, TTS_STREAM_TARGET_CHARS);
   const openai = new OpenAI({ apiKey: openaiSettings.apiKey });
   const speed = openaiSettings.ttsSpeed;
 

--- a/src/lib/streaming-audio-player.ts
+++ b/src/lib/streaming-audio-player.ts
@@ -40,6 +40,11 @@ export class StreamingAudioPlayer {
       this.mediaSource.addEventListener('sourceopen', () => {
         if (this.destroyed) return;
         this.sourceBuffer = this.mediaSource.addSourceBuffer('audio/mp4; codecs="mp4a.40.2"');
+        // Use 'sequence' mode so each segment is appended after the previous one,
+        // regardless of timestamps in the media. This is critical when concatenating
+        // audio from independent TTS calls — their fMP4 segments may have overlapping
+        // timestamps which would cause 'segments' mode to overwrite earlier audio.
+        this.sourceBuffer.mode = 'sequence';
         this.sourceBuffer.addEventListener('updateend', () => {
           this.drainQueue();
         });

--- a/src/server/services/voice.test.ts
+++ b/src/server/services/voice.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { needsTransformation, splitTextForTTS, splitTextAtWordBoundary } from './voice';
+import {
+  needsTransformation,
+  splitTextForTTS,
+  splitTextAtWordBoundary,
+  TTS_STREAM_TARGET_CHARS,
+} from './voice';
 
 describe('needsTransformation', () => {
   it('should return true for text with markdown tables', () => {
@@ -135,5 +140,62 @@ describe('splitTextForTTS', () => {
     const totalChars = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
     // Allow for whitespace differences but total content should be close
     expect(totalChars).toBeGreaterThanOrEqual(longSentence.length * 0.95);
+  });
+
+  it('should accept a custom targetSize for smaller streaming chunks', () => {
+    const text =
+      'First sentence here. Second sentence here. Third sentence here. Fourth sentence here.';
+    // With default (4096), this short text is one chunk
+    expect(splitTextForTTS(text)).toHaveLength(1);
+    // With a small target, it should split into multiple chunks
+    const chunks = splitTextForTTS(text, 50);
+    expect(chunks.length).toBeGreaterThan(1);
+    // All content should be preserved
+    expect(chunks.join(' ')).toBe(text);
+  });
+
+  it('should split at sentence boundaries with streaming target', () => {
+    const text =
+      'I made the changes you requested. The function now handles edge cases. ' +
+      'Here is what I changed. First I added input validation. Second I updated error handling. ' +
+      'Third I added a test case for the empty input scenario. Let me know if you want adjustments.';
+    const chunks = splitTextForTTS(text, TTS_STREAM_TARGET_CHARS);
+    expect(chunks.length).toBeGreaterThan(1);
+    // Each chunk should end at a sentence boundary (or be the last chunk)
+    for (const chunk of chunks.slice(0, -1)) {
+      expect(chunk).toMatch(/[.!?]$/);
+    }
+    // No chunk should exceed the TTS API hard limit
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(4096);
+    }
+  });
+
+  it('should keep single sentences intact even if they exceed targetSize', () => {
+    // A single sentence of ~300 chars (exceeds TTS_STREAM_TARGET_CHARS but below TTS_MAX_CHARS)
+    const longSentence =
+      'This is a single sentence that is deliberately quite long because we want to make sure ' +
+      'that the splitting function does not break it apart at word boundaries just because it ' +
+      'exceeds the streaming target size, since that would create unnatural speech breaks.';
+    expect(longSentence.length).toBeGreaterThan(TTS_STREAM_TARGET_CHARS);
+    const chunks = splitTextForTTS(longSentence, TTS_STREAM_TARGET_CHARS);
+    // Should be kept as one chunk since it's a single sentence under 4096
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toBe(longSentence);
+  });
+
+  it('should produce multiple chunks from typical assistant messages with streaming target', () => {
+    const text =
+      'I have completed the implementation. The new feature adds user authentication ' +
+      'using JWT tokens. I created three new files for this. The auth middleware validates ' +
+      'tokens on each request. The login endpoint generates new tokens. The refresh endpoint ' +
+      'handles token renewal. All tests are passing. Let me know if you need any changes.';
+    const chunks = splitTextForTTS(text, TTS_STREAM_TARGET_CHARS);
+    // Should produce multiple chunks for good streaming latency (text is ~330 chars)
+    expect(chunks.length).toBeGreaterThanOrEqual(2);
+    // Each chunk should be reasonably small
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(TTS_STREAM_TARGET_CHARS + 100);
+    }
   });
 });

--- a/src/server/services/voice.ts
+++ b/src/server/services/voice.ts
@@ -11,6 +11,12 @@ const GLOBAL_SETTINGS_ID = 'global';
 
 const TTS_MAX_CHARS = 4096;
 
+/**
+ * Target chunk size for streaming TTS. Small enough for low-latency first audio
+ * (~1-2 sentences), while still sending meaningful text to the TTS model.
+ */
+export const TTS_STREAM_TARGET_CHARS = 200;
+
 const TRANSFORM_PROMPT = `You are converting markdown text into natural speech. The text will be read aloud by a text-to-speech system.
 
 Rules:
@@ -122,11 +128,23 @@ export function splitTextAtWordBoundary(text: string, maxLength: number): [strin
 }
 
 /**
- * Split text into chunks that fit within TTS character limits.
- * Splits on paragraph boundaries when possible, then sentences, then word boundaries.
+ * Split text into chunks for TTS generation.
+ *
+ * @param text - The text to split.
+ * @param targetSize - Target chunk size in characters. Defaults to TTS_MAX_CHARS (4096).
+ *   For streaming TTS, pass TTS_STREAM_TARGET_CHARS (~200) for low-latency first audio.
+ *   Chunks will generally be at or below this size, except when a single sentence
+ *   exceeds it (sentences are never split unless they exceed the TTS API hard limit).
+ *
+ * Splitting hierarchy:
+ * 1. Paragraph boundaries (\n\n)
+ * 2. Sentence boundaries (after . ! ?)
+ * 3. Word boundaries (last resort, only when a sentence exceeds TTS_MAX_CHARS)
  */
-export function splitTextForTTS(text: string): string[] {
-  if (text.length <= TTS_MAX_CHARS) {
+export function splitTextForTTS(text: string, targetSize: number = TTS_MAX_CHARS): string[] {
+  const target = Math.min(targetSize, TTS_MAX_CHARS);
+
+  if (text.length <= target) {
     return [text];
   }
 
@@ -135,21 +153,21 @@ export function splitTextForTTS(text: string): string[] {
   let current = '';
 
   for (const paragraph of paragraphs) {
-    if (current.length + paragraph.length + 2 > TTS_MAX_CHARS) {
+    if (current.length + paragraph.length + 2 > target) {
       if (current) {
         chunks.push(current.trim());
         current = '';
       }
-      // If a single paragraph exceeds the limit, split it by sentences
-      if (paragraph.length > TTS_MAX_CHARS) {
+      // If a single paragraph exceeds the target, split it by sentences
+      if (paragraph.length > target) {
         const sentences = paragraph.split(/(?<=[.!?])\s+/);
         for (const sentence of sentences) {
-          if (current.length + sentence.length + 1 > TTS_MAX_CHARS) {
+          if (current.length + sentence.length + 1 > target) {
             if (current) {
               chunks.push(current.trim());
               current = '';
             }
-            // If even a single sentence is too long, split at word boundaries
+            // Only split within a sentence if it exceeds the TTS API hard limit
             if (sentence.length > TTS_MAX_CHARS) {
               let remaining = sentence;
               while (remaining.length > TTS_MAX_CHARS) {


### PR DESCRIPTION
## Summary
- **Sentence-level chunking for streaming**: `splitTextForTTS()` now accepts a `targetSize` parameter. The streaming endpoint uses ~200 chars (sentence-level) instead of 4096 (OpenAI API limit), so the first audio chunk arrives much faster.
- **SourceBuffer sequence mode**: Set `mode = 'sequence'` on the MSE SourceBuffer to prevent audio from independent TTS calls overwriting each other due to overlapping fMP4 timestamps. This fixes the issue where only the last few words of a message would play.
- Single sentences that exceed the streaming target are kept intact (not split mid-sentence) — only sentences exceeding the 4096 API hard limit are split at word boundaries.

## Test plan
- [x] All 439 existing tests pass
- [x] New tests verify sentence-level splitting, content preservation, and single-sentence integrity
- [ ] Manual test: play a multi-sentence assistant message and verify audio starts quickly and plays completely

🤖 Generated with [Claude Code](https://claude.com/claude-code)