### PR TITLE
Fix flaky auto-scroll with IntersectionObserver

### DIFF
--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -378,17 +378,22 @@ export function MessageList({
     [messages, pairedMessageIds, completedHookIds]
   );
 
-  const scrollToBottom = useCallback((instant = false) => {
-    bottomRef.current?.scrollIntoView({ behavior: instant ? 'instant' : 'smooth' });
+  const scrollToBottom = useCallback(() => {
+    // Always use instant scroll to avoid race conditions with smooth animation.
+    // Smooth scroll can cause auto-scroll to break: if messages arrive faster than
+    // the animation completes, the IntersectionObserver sees the sentinel as
+    // not-intersecting mid-animation, isAtBottomRef becomes false, and subsequent
+    // messages don't trigger auto-scroll.
+    bottomRef.current?.scrollIntoView({ behavior: 'instant' });
   }, []);
 
-  // Initial scroll to bottom - instant, no animation
+  // Initial scroll to bottom
   useEffect(() => {
     if (!hasInitialScrolled.current && messages.length > 0) {
       hasInitialScrolled.current = true;
       // Use requestAnimationFrame to ensure DOM has rendered
       requestAnimationFrame(() => {
-        scrollToBottom(true);
+        scrollToBottom();
       });
     }
   }, [messages, scrollToBottom]);


### PR DESCRIPTION
## Summary
- Replaces scroll-position math (`scrollHeight - scrollTop - clientHeight < 50`) with an IntersectionObserver on the bottom sentinel div
- Fixes auto-scroll breaking when PromptInput textarea resizes or tool calls expand (layout changes don't fire scroll events)
- Uses 150px rootMargin for a generous "at bottom" threshold
- Removes the `onScroll` handler since it's no longer needed

Fixes #274

## Test plan
- [x] All 439 tests pass
- [ ] Verify auto-scroll works when sending messages
- [ ] Verify auto-scroll persists when textarea grows/shrinks
- [ ] Verify scrolling up still disables auto-scroll
- [ ] Verify scrolling back to bottom re-enables auto-scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)