### PR TITLE
Make initial prompt optional when creating a session

### DIFF
--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -166,13 +166,13 @@ sessions.create({
   name: string,
   repoFullName: string,    // e.g., "brendanlong/math-llm"
   branch: string,
-  initialPrompt: string    // Prompt to auto-send when session starts
+  initialPrompt?: string   // Optional prompt to auto-send when session starts
 })
   → { session: Session }
   // Returns immediately with session in "creating" status
   // Cloning and container setup continues in background
   // UI polls session.get() to track progress via statusMessage
-  // initialPrompt is sent automatically server-side when session becomes running
+  // If initialPrompt is provided, it is sent automatically server-side when session becomes running
 
 sessions.list({ status?: SessionStatus })
   → { sessions: Session[] }
@@ -243,7 +243,7 @@ claude.getHistory({
 12. Background: Container starts the agent service (Node.js HTTP server using Claude Agent SDK)
 13. Background: Server waits for agent service health check to pass
 14. Session status → `running`, statusMessage → null
-15. Background: Server sends the initial prompt via `runClaudeCommand()` (no client interaction needed)
+15. Background: If an initial prompt was provided, server sends it via `runClaudeCommand()` (no client interaction needed)
 
 ### Interaction Flow
 
@@ -589,8 +589,9 @@ On error: `event: error` with `data: {"message": "TTS failed for chunk N"}`
   - When selected, auto-fills session name with issue title
   - Pre-fills initial prompt asking Claude to fix the issue (editable)
 - Name the session (optional, auto-filled from issue if selected)
-- Initial prompt (required) — editable textarea, pre-filled when issue is selected
-  - Sent server-side after session setup completes (works even if client disconnects)
+- Initial prompt (optional) — editable textarea, pre-filled when issue is selected
+  - If provided, sent server-side after session setup completes (works even if client disconnects)
+  - When omitted, session starts without a prompt (useful for voice mode)
 - Create button
 
 ### Session View (Chat)

--- a/src/app/new/page.tsx
+++ b/src/app/new/page.tsx
@@ -112,16 +112,11 @@ function NewSessionForm() {
       return;
     }
 
-    if (!form.initialPrompt.trim()) {
-      setError('Please provide an initial prompt');
-      return;
-    }
-
     createMutation.mutate({
       name: form.sessionName || `${form.selectedRepo.name} - ${form.selectedBranch}`,
       repoFullName: form.selectedRepo.fullName,
       branch: form.selectedBranch,
-      initialPrompt: form.initialPrompt.trim(),
+      initialPrompt: form.initialPrompt.trim() || undefined,
     });
   };
 
@@ -161,7 +156,7 @@ function NewSessionForm() {
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="initialPrompt">Initial prompt</Label>
+            <Label htmlFor="initialPrompt">Initial prompt (optional)</Label>
             <Textarea
               id="initialPrompt"
               value={form.initialPrompt}
@@ -170,7 +165,7 @@ function NewSessionForm() {
               rows={6}
             />
             <p className="text-xs text-muted-foreground">
-              This prompt will be sent to Claude automatically when the session starts.
+              If provided, this prompt will be sent to Claude automatically when the session starts.
             </p>
           </div>
         </>
@@ -182,12 +177,7 @@ function NewSessionForm() {
         </Button>
         <Button
           type="submit"
-          disabled={
-            !form.selectedRepo ||
-            !form.selectedBranch ||
-            !form.initialPrompt.trim() ||
-            createMutation.isPending
-          }
+          disabled={!form.selectedRepo || !form.selectedBranch || createMutation.isPending}
         >
           {createMutation.isPending ? (
             <span className="flex items-center gap-2">

--- a/src/server/routers/sessions.ts
+++ b/src/server/routers/sessions.ts
@@ -32,7 +32,7 @@ async function setupSession(
   sessionId: string,
   repoFullName: string,
   branch: string,
-  initialPrompt: string,
+  initialPrompt: string | undefined,
   githubToken?: string
 ): Promise<void> {
   log.info('Starting session setup', { sessionId, repoFullName, branch });
@@ -100,20 +100,23 @@ async function setupSession(
     });
     sseEvents.emitSessionUpdate(sessionId, session);
 
-    log.info('Session setup complete, sending initial prompt', { sessionId });
+    log.info('Session setup complete', { sessionId });
 
-    // Send the initial prompt now that the session is running
+    // Send the initial prompt if provided
     // Reuse settings already loaded above for container creation
-    runClaudeCommand({
-      sessionId,
-      containerId,
-      prompt: initialPrompt,
-      customSystemPrompt: settings.customSystemPrompt,
-      globalSettings: settings.globalSettings,
-      mcpServers: settings.mcpServers,
-    }).catch((err) => {
-      log.error('Initial prompt failed', toError(err), { sessionId });
-    });
+    if (initialPrompt?.trim()) {
+      log.info('Sending initial prompt', { sessionId });
+      runClaudeCommand({
+        sessionId,
+        containerId,
+        prompt: initialPrompt.trim(),
+        customSystemPrompt: settings.customSystemPrompt,
+        globalSettings: settings.globalSettings,
+        mcpServers: settings.mcpServers,
+      }).catch((err) => {
+        log.error('Initial prompt failed', toError(err), { sessionId });
+      });
+    }
   } catch (error) {
     // Log the full error with stack trace
     log.error('Session setup failed', toError(error), { sessionId, repoFullName, branch });
@@ -138,7 +141,7 @@ export const sessionsRouter = router({
         name: z.string().min(1).max(100),
         repoFullName: z.string().regex(/^[\w-]+\/[\w.-]+$/),
         branch: z.string().min(1),
-        initialPrompt: z.string().min(1).max(100000),
+        initialPrompt: z.string().max(100000).optional(),
       })
     )
     .mutation(async ({ input }) => {


### PR DESCRIPTION
## Summary
- Makes `initialPrompt` optional in session creation (Zod schema, API, and UI)
- Server skips sending initial prompt if blank/empty
- Submit button no longer requires a prompt to be filled
- Updates DESIGN.md to reflect the change

Fixes #275

## Test plan
- [x] All 439 tests pass
- [ ] Verify creating a session with a prompt still works (sends automatically)
- [ ] Verify creating a session without a prompt starts the container but waits for user input
- [ ] Verify the form label shows "Initial prompt (optional)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)