### PR TITLE
Switch agent service to persistent streaming input mode

### DIFF
--- a/agent-service/src/index.ts
+++ b/agent-service/src/index.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import { execFile } from 'node:child_process';
 import { z } from 'zod';
 import { MessageStore } from './message-store.js';
-import { QueryRunner, type QueryOptions } from './query-runner.js';
+import { QueryRunner, type InitOptions } from './query-runner.js';
 import { createLogger, toError } from './logger.js';
 import type { SDKMessage, SlashCommand } from '@anthropic-ai/claude-agent-sdk';
 import type { PartialAssistantMessage } from './stream-accumulator.js';
@@ -44,12 +44,16 @@ const McpServerConfigSchema = z.union([
   McpHttpServerConfigSchema,
 ]);
 
-const QueryRequestSchema = z.object({
-  prompt: z.string().min(1).max(1_000_000),
+const InitRequestSchema = z.object({
   sessionId: z.string().min(1),
   resume: z.boolean().optional().default(false),
   cwd: z.string().min(1).optional(),
   mcpServers: z.record(z.string(), McpServerConfigSchema).optional(),
+});
+
+const SendRequestSchema = z.object({
+  prompt: z.string().min(1).max(1_000_000),
+  sessionId: z.string().min(1),
 });
 
 const MessagesQuerySchema = z.object({
@@ -92,13 +96,14 @@ function sendError(res: http.ServerResponse, status: number, message: string): v
 }
 
 /**
- * Handle POST /query
- * Starts a query and streams results via SSE.
- * Body: { prompt: string, sessionId: string, resume?: boolean, cwd?: string, mcpServers?: Record<string, McpServerConfig> }
+ * Handle POST /init
+ * Initializes the persistent query session. Must be called before /send.
+ * Returns initialization data (commands, etc.) and starts the message processing loop.
+ * Body: { sessionId: string, resume?: boolean, cwd?: string, mcpServers?: Record<string, McpServerConfig> }
  */
-async function handleQuery(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+async function handleInit(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
   const raw = await parseBody(req);
-  const parsed = QueryRequestSchema.safeParse(raw);
+  const parsed = InitRequestSchema.safeParse(raw);
 
   if (!parsed.success) {
     sendError(
@@ -111,8 +116,60 @@ async function handleQuery(req: http.IncomingMessage, res: http.ServerResponse):
 
   const body = parsed.data;
 
-  if (runner.isRunning) {
-    sendError(res, 409, 'A query is already running');
+  if (runner.isInitialized) {
+    sendError(res, 409, 'Query session is already initialized');
+    return;
+  }
+
+  const initOptions: InitOptions = {
+    sessionId: body.sessionId,
+    resume: body.resume,
+    systemPrompt: SYSTEM_PROMPT || undefined,
+    model: CLAUDE_MODEL || undefined,
+    cwd: body.cwd,
+    mcpServers: body.mcpServers,
+  };
+
+  try {
+    await runner.initialize(initOptions);
+    sendJson(res, 200, {
+      initialized: true,
+      commands: runner.supportedCommands,
+    });
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    log.error('Init failed', toError(err));
+    sendError(res, 500, errorMessage);
+  }
+}
+
+/**
+ * Handle POST /send
+ * Sends a user prompt into the persistent query session and streams results via SSE.
+ * Body: { prompt: string, sessionId: string }
+ */
+async function handleSend(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+  const raw = await parseBody(req);
+  const parsed = SendRequestSchema.safeParse(raw);
+
+  if (!parsed.success) {
+    sendError(
+      res,
+      400,
+      parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ')
+    );
+    return;
+  }
+
+  const body = parsed.data;
+
+  if (!runner.isInitialized) {
+    sendError(res, 400, 'Query session is not initialized. Call /init first.');
+    return;
+  }
+
+  if (runner.isProcessing) {
+    sendError(res, 409, 'A prompt is already being processed');
     return;
   }
 
@@ -148,23 +205,13 @@ async function handleQuery(req: http.IncomingMessage, res: http.ServerResponse):
     unsubscribeCommands();
   });
 
-  const options: QueryOptions = {
-    prompt: body.prompt,
-    sessionId: body.sessionId,
-    resume: body.resume,
-    systemPrompt: SYSTEM_PROMPT || undefined,
-    model: CLAUDE_MODEL || undefined,
-    cwd: body.cwd,
-    mcpServers: body.mcpServers,
-  };
-
   try {
-    await runner.run(options);
+    await runner.sendPrompt(body.prompt, body.sessionId);
     // Send completion event
     res.write(`data: ${JSON.stringify({ done: true })}\n\n`);
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : String(err);
-    log.error('Query failed', toError(err));
+    log.error('Send failed', toError(err));
     res.write(`data: ${JSON.stringify({ error: errorMessage })}\n\n`);
   } finally {
     unsubscribeMessages();
@@ -190,7 +237,8 @@ async function handleInterrupt(
  */
 function handleStatus(_req: http.IncomingMessage, res: http.ServerResponse): void {
   sendJson(res, 200, {
-    running: runner.isRunning,
+    running: runner.isProcessing,
+    initialized: runner.isInitialized,
     messageCount: store.getLastSequence(),
     lastSequence: store.getLastSequence(),
     commands: runner.supportedCommands,
@@ -262,8 +310,10 @@ const server = http.createServer(async (req, res) => {
   const method = req.method?.toUpperCase();
 
   try {
-    if (method === 'POST' && path === '/query') {
-      await handleQuery(req, res);
+    if (method === 'POST' && path === '/init') {
+      await handleInit(req, res);
+    } else if (method === 'POST' && path === '/send') {
+      await handleSend(req, res);
     } else if (method === 'POST' && path === '/interrupt') {
       await handleInterrupt(req, res);
     } else if (method === 'GET' && path === '/status') {
@@ -321,32 +371,38 @@ server.on('error', (err: NodeJS.ErrnoException) => {
 // Graceful shutdown
 process.on('SIGTERM', () => {
   log.info('Received SIGTERM, shutting down');
-  server.close(() => {
-    // Clean up socket file
-    try {
-      if (fs.existsSync(SOCKET_PATH)) {
-        fs.unlinkSync(SOCKET_PATH);
+  // Shut down the persistent query session
+  void runner.shutdown().finally(() => {
+    server.close(() => {
+      // Clean up socket file
+      try {
+        if (fs.existsSync(SOCKET_PATH)) {
+          fs.unlinkSync(SOCKET_PATH);
+        }
+      } catch (err) {
+        log.error('Failed to clean up socket file', toError(err));
       }
-    } catch (err) {
-      log.error('Failed to clean up socket file', toError(err));
-    }
-    store.close();
-    process.exit(0);
+      store.close();
+      process.exit(0);
+    });
   });
 });
 
 process.on('SIGINT', () => {
   log.info('Received SIGINT, shutting down');
-  server.close(() => {
-    // Clean up socket file
-    try {
-      if (fs.existsSync(SOCKET_PATH)) {
-        fs.unlinkSync(SOCKET_PATH);
+  // Shut down the persistent query session
+  void runner.shutdown().finally(() => {
+    server.close(() => {
+      // Clean up socket file
+      try {
+        if (fs.existsSync(SOCKET_PATH)) {
+          fs.unlinkSync(SOCKET_PATH);
+        }
+      } catch (err) {
+        log.error('Failed to clean up socket file', toError(err));
       }
-    } catch (err) {
-      log.error('Failed to clean up socket file', toError(err));
-    }
-    store.close();
-    process.exit(0);
+      store.close();
+      process.exit(0);
+    });
   });
 });

--- a/agent-service/src/query-runner.ts
+++ b/agent-service/src/query-runner.ts
@@ -2,6 +2,7 @@ import {
   query,
   type Query,
   type SDKMessage,
+  type SDKUserMessage,
   type McpServerConfig,
   type SlashCommand,
 } from '@anthropic-ai/claude-agent-sdk';
@@ -20,10 +21,9 @@ function getMessageType(message: SDKMessage): string {
 }
 
 /**
- * Options for starting a new query.
+ * Options for initializing the persistent query session.
  */
-export interface QueryOptions {
-  prompt: string;
+export interface InitOptions {
   sessionId: string;
   /** If true, resume the session instead of starting a new one */
   resume: boolean;
@@ -58,28 +58,140 @@ export type PartialMessageCallback = (partial: PartialAssistantMessage) => void;
 export type CommandsCallback = (commands: SlashCommand[]) => void;
 
 /**
- * Manages SDK query() execution with message persistence.
- * Only one query can run at a time per QueryRunner instance.
+ * Controller for the async generator that feeds prompts to the SDK.
+ * Allows external code to yield new messages into the persistent query.
+ */
+interface PromptController {
+  /** Yield a new user message to the query. Resolves when the SDK consumes it. */
+  send(message: SDKUserMessage): void;
+  /** Signal that no more messages will be sent (session ending). */
+  close(): void;
+}
+
+/**
+ * Creates an async generator and a controller to push messages into it.
+ * The generator yields SDKUserMessages that are sent via the controller.
+ */
+function createPromptStream(): {
+  stream: AsyncIterable<SDKUserMessage>;
+  controller: PromptController;
+} {
+  // Queue of messages waiting to be yielded
+  const queue: SDKUserMessage[] = [];
+  // Resolve function for the current wait (when queue is empty and generator is waiting)
+  let resolveWait: (() => void) | null = null;
+  let closed = false;
+
+  const stream: AsyncIterable<SDKUserMessage> = {
+    [Symbol.asyncIterator]() {
+      return {
+        async next(): Promise<IteratorResult<SDKUserMessage>> {
+          // If there are queued messages, yield the next one
+          if (queue.length > 0) {
+            return { value: queue.shift()!, done: false };
+          }
+
+          // If closed, we're done
+          if (closed) {
+            return { value: undefined as unknown as SDKUserMessage, done: true };
+          }
+
+          // Wait for a new message or close
+          await new Promise<void>((resolve) => {
+            resolveWait = resolve;
+          });
+
+          // After waking up, check again
+          if (queue.length > 0) {
+            return { value: queue.shift()!, done: false };
+          }
+
+          // Must be closed
+          return { value: undefined as unknown as SDKUserMessage, done: true };
+        },
+        async return(): Promise<IteratorResult<SDKUserMessage>> {
+          closed = true;
+          return { value: undefined as unknown as SDKUserMessage, done: true };
+        },
+        async throw(err: Error): Promise<IteratorResult<SDKUserMessage>> {
+          closed = true;
+          throw err;
+        },
+      };
+    },
+  };
+
+  const controller: PromptController = {
+    send(message: SDKUserMessage) {
+      if (closed) {
+        throw new Error('Prompt stream is closed');
+      }
+      queue.push(message);
+      if (resolveWait) {
+        const resolve = resolveWait;
+        resolveWait = null;
+        resolve();
+      }
+    },
+    close() {
+      closed = true;
+      if (resolveWait) {
+        const resolve = resolveWait;
+        resolveWait = null;
+        resolve();
+      }
+    },
+  };
+
+  return { stream, controller };
+}
+
+/**
+ * Manages a persistent SDK query() session with streaming input mode.
+ *
+ * Instead of creating a new query() per user prompt, this class maintains
+ * a single long-lived query that receives messages through an async generator.
+ * This enables:
+ * - Commands available at session startup (before any user message)
+ * - No re-initialization per prompt
+ * - Plan mode / AskUserQuestion work correctly with persistent sessions
+ * - setModel() / setPermissionMode() become available
  */
 export class QueryRunner {
   private store: MessageStore;
   private currentQuery: Query | null = null;
-  private currentAbortController: AbortController | null = null;
-  private running = false;
+  private promptController: PromptController | null = null;
   private messageCallbacks: Set<MessageCallback> = new Set();
   private partialCallbacks: Set<PartialMessageCallback> = new Set();
   private commandsCallbacks: Set<CommandsCallback> = new Set();
   private _supportedCommands: SlashCommand[] = [];
+  /** Whether a user prompt is currently being processed (assistant is responding) */
+  private _isProcessing = false;
+  /** Whether the persistent query session is active (initialized and running) */
+  private _isInitialized = false;
+  /** Session ID for the persistent query */
+  private _sessionId: string | null = null;
+  /** Promise that resolves when the message processing loop finishes */
+  private messageLoopPromise: Promise<void> | null = null;
+  /** Resolves when the current turn (user prompt → result) completes */
+  private turnCompleteResolve: (() => void) | null = null;
 
   constructor(store: MessageStore) {
     this.store = store;
   }
 
   /**
-   * Whether a query is currently running.
+   * Whether a user prompt is currently being processed by the agent.
    */
-  get isRunning(): boolean {
-    return this.running;
+  get isProcessing(): boolean {
+    return this._isProcessing;
+  }
+
+  /**
+   * Whether the persistent query session has been initialized.
+   */
+  get isInitialized(): boolean {
+    return this._isInitialized;
   }
 
   /**
@@ -122,115 +234,182 @@ export class QueryRunner {
   }
 
   /**
-   * Start a new query. Throws if a query is already running.
-   * This method runs the query to completion and returns when done.
+   * Initialize the persistent query session.
+   * This starts the SDK query with an async generator for streaming input,
+   * fetches initialization data (commands, etc.), and begins processing messages.
+   *
+   * Must be called before sendPrompt(). Can only be called once per QueryRunner lifetime
+   * (unless the previous session has been shut down).
    */
-  async run(options: QueryOptions): Promise<void> {
-    if (this.running) {
-      throw new Error('A query is already running');
+  async initialize(options: InitOptions): Promise<void> {
+    if (this._isInitialized) {
+      throw new Error('Query session is already initialized');
     }
 
-    this.running = true;
-    this.currentAbortController = new AbortController();
+    const { stream, controller } = createPromptStream();
+    this.promptController = controller;
+    this._sessionId = options.sessionId;
+
+    const sdkOptions: Parameters<typeof query>[0]['options'] = {
+      permissionMode: 'bypassPermissions' as const,
+      allowDangerouslySkipPermissions: true,
+      // Enable partial message streaming for real-time UI updates
+      includePartialMessages: true,
+    };
+
+    // System prompt configuration
+    if (options.systemPrompt) {
+      sdkOptions.systemPrompt = {
+        type: 'preset' as const,
+        preset: 'claude_code' as const,
+        append: options.systemPrompt,
+      };
+    } else {
+      sdkOptions.systemPrompt = {
+        type: 'preset' as const,
+        preset: 'claude_code' as const,
+      };
+    }
+
+    // Tools configuration - use Claude Code preset
+    sdkOptions.tools = { type: 'preset' as const, preset: 'claude_code' as const };
+
+    // Resume or start fresh
+    if (options.resume) {
+      sdkOptions.resume = options.sessionId;
+    } else {
+      sdkOptions.sessionId = options.sessionId;
+    }
+
+    // Model configuration
+    if (options.model) {
+      sdkOptions.model = options.model;
+    }
+
+    // Working directory
+    if (options.cwd) {
+      sdkOptions.cwd = options.cwd;
+    }
+
+    // MCP server configurations
+    if (options.mcpServers && Object.keys(options.mcpServers).length > 0) {
+      sdkOptions.mcpServers = options.mcpServers;
+    }
+
+    // Load project settings (for CLAUDE.md)
+    sdkOptions.settingSources = ['project'];
+
+    // Start the persistent query with the streaming input
+    this.currentQuery = query({
+      prompt: stream,
+      options: sdkOptions,
+    });
+
+    this._isInitialized = true;
+
+    // Fetch supported commands from the query object.
+    // In streaming input mode, initializationResult() resolves before any user message.
+    try {
+      let commands: SlashCommand[] = [];
+
+      try {
+        const initResult = await this.currentQuery.initializationResult();
+        commands = initResult.commands ?? [];
+        log.debug('initializationResult() returned commands', { count: commands.length });
+      } catch (initErr) {
+        log.warn(
+          'initializationResult() failed, trying supportedCommands()',
+          undefined,
+          toError(initErr)
+        );
+        commands = await this.currentQuery.supportedCommands();
+        log.debug('supportedCommands() returned commands', { count: commands.length });
+      }
+
+      if (commands.length > 0) {
+        this._supportedCommands = commands;
+        for (const callback of this.commandsCallbacks) {
+          try {
+            callback(commands);
+          } catch {
+            // Don't let callback errors break anything
+          }
+        }
+      }
+    } catch (err) {
+      log.error('Failed to fetch supported commands', toError(err));
+    }
+
+    // Start the message processing loop in the background.
+    // This loop runs for the lifetime of the persistent query, processing
+    // messages from all user prompts.
+    this.messageLoopPromise = this.processMessages();
+    // Attach error handler to prevent unhandled rejection
+    this.messageLoopPromise.catch((err) => {
+      log.error('Message processing loop failed', toError(err));
+    });
+
+    log.info('Persistent query session initialized', { sessionId: options.sessionId });
+  }
+
+  /**
+   * Send a user prompt into the persistent query session.
+   * The prompt is yielded to the SDK through the async generator.
+   *
+   * Returns a promise that resolves when the turn completes (result message received).
+   * Throws if the session is not initialized or if a prompt is already being processed.
+   */
+  async sendPrompt(prompt: string, sessionId: string): Promise<void> {
+    if (!this._isInitialized || !this.promptController) {
+      throw new Error('Query session is not initialized. Call initialize() first.');
+    }
+
+    if (this._isProcessing) {
+      throw new Error('A prompt is already being processed');
+    }
+
+    this._isProcessing = true;
+
+    // Create a promise that resolves when the turn completes
+    const turnComplete = new Promise<void>((resolve) => {
+      this.turnCompleteResolve = resolve;
+    });
+
+    try {
+      // Create the SDKUserMessage to yield to the SDK
+      const userMessage: SDKUserMessage = {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: prompt,
+        },
+        parent_tool_use_id: null,
+        session_id: sessionId,
+      };
+
+      // Yield the message to the SDK
+      this.promptController.send(userMessage);
+
+      // Wait for the turn to complete (result message received)
+      await turnComplete;
+    } finally {
+      this._isProcessing = false;
+      this.turnCompleteResolve = null;
+    }
+  }
+
+  /**
+   * Process messages from the SDK query in a long-running loop.
+   * This runs for the lifetime of the persistent query session.
+   */
+  private async processMessages(): Promise<void> {
+    if (!this.currentQuery || !this._sessionId) {
+      throw new Error('No active query');
+    }
+
     const accumulator = new StreamAccumulator();
 
     try {
-      const sdkOptions: Parameters<typeof query>[0]['options'] = {
-        abortController: this.currentAbortController,
-        permissionMode: 'bypassPermissions' as const,
-        allowDangerouslySkipPermissions: true,
-        // Enable partial message streaming for real-time UI updates
-        includePartialMessages: true,
-      };
-
-      // System prompt configuration
-      if (options.systemPrompt) {
-        sdkOptions.systemPrompt = {
-          type: 'preset' as const,
-          preset: 'claude_code' as const,
-          append: options.systemPrompt,
-        };
-      } else {
-        sdkOptions.systemPrompt = {
-          type: 'preset' as const,
-          preset: 'claude_code' as const,
-        };
-      }
-
-      // Tools configuration - use Claude Code preset
-      sdkOptions.tools = { type: 'preset' as const, preset: 'claude_code' as const };
-
-      // Resume or start fresh
-      // We use our own sessionId so resume can find it by the same ID
-      if (options.resume) {
-        sdkOptions.resume = options.sessionId;
-      } else {
-        sdkOptions.sessionId = options.sessionId;
-      }
-
-      // Model configuration
-      if (options.model) {
-        sdkOptions.model = options.model;
-      }
-
-      // Working directory
-      if (options.cwd) {
-        sdkOptions.cwd = options.cwd;
-      }
-
-      // MCP server configurations
-      if (options.mcpServers && Object.keys(options.mcpServers).length > 0) {
-        sdkOptions.mcpServers = options.mcpServers;
-      }
-
-      // Load project settings (for CLAUDE.md)
-      sdkOptions.settingSources = ['project'];
-
-      this.currentQuery = query({
-        prompt: options.prompt,
-        options: sdkOptions,
-      });
-
-      // Fetch supported commands from the query object.
-      // We try initializationResult() first (which includes commands along with
-      // other init data), then fall back to supportedCommands().
-      // We await this before iterating messages so the commands are available
-      // to send via SSE while the response is still open.
-      try {
-        let commands: SlashCommand[] = [];
-
-        // Try initializationResult() first - it returns the full init response
-        // including commands from the SDK control channel
-        try {
-          const initResult = await this.currentQuery.initializationResult();
-          commands = initResult.commands ?? [];
-          log.debug('initializationResult() returned commands', { count: commands.length });
-        } catch (initErr) {
-          log.warn(
-            'initializationResult() failed, trying supportedCommands()',
-            undefined,
-            toError(initErr)
-          );
-          // Fall back to supportedCommands()
-          commands = await this.currentQuery.supportedCommands();
-          log.debug('supportedCommands() returned commands', { count: commands.length });
-        }
-
-        if (commands.length > 0) {
-          this._supportedCommands = commands;
-          for (const callback of this.commandsCallbacks) {
-            try {
-              callback(commands);
-            } catch {
-              // Don't let callback errors break anything
-            }
-          }
-        }
-      } catch (err) {
-        log.error('Failed to fetch supported commands', toError(err));
-      }
-
-      // Iterate through all messages from the SDK
       for await (const message of this.currentQuery) {
         // Handle stream_events: accumulate into partial messages for real-time UI
         if (message.type === 'stream_event') {
@@ -264,7 +443,7 @@ export class QueryRunner {
 
         const type = getMessageType(message);
         const content = JSON.stringify(message);
-        const sequence = this.store.append(options.sessionId, type, content);
+        const sequence = this.store.append(this._sessionId, type, content);
 
         // Notify all connected SSE clients
         for (const callback of this.messageCallbacks) {
@@ -274,11 +453,24 @@ export class QueryRunner {
             // Don't let callback errors break the query loop
           }
         }
+
+        // When a result message arrives, the turn is complete.
+        // Signal the waiting sendPrompt() call.
+        if (message.type === 'result') {
+          if (this.turnCompleteResolve) {
+            this.turnCompleteResolve();
+          }
+        }
       }
     } finally {
-      this.running = false;
+      log.info('Message processing loop ended', { sessionId: this._sessionId });
+      this._isInitialized = false;
       this.currentQuery = null;
-      this.currentAbortController = null;
+      this.promptController = null;
+      // If a prompt was in progress, resolve it so it doesn't hang
+      if (this.turnCompleteResolve) {
+        this.turnCompleteResolve();
+      }
     }
   }
 
@@ -287,20 +479,53 @@ export class QueryRunner {
    * Uses the SDK's interrupt() method for clean interruption.
    */
   async interrupt(): Promise<boolean> {
-    if (!this.running || !this.currentQuery) {
+    if (!this._isInitialized || !this.currentQuery) {
       return false;
     }
 
     try {
       await this.currentQuery.interrupt();
       return true;
-    } catch {
-      // If interrupt fails, try aborting via the controller
-      if (this.currentAbortController) {
-        this.currentAbortController.abort();
-        return true;
-      }
+    } catch (err) {
+      log.warn('Interrupt failed', undefined, toError(err));
       return false;
     }
+  }
+
+  /**
+   * Shut down the persistent query session.
+   * Closes the prompt stream and waits for the message loop to finish.
+   */
+  async shutdown(): Promise<void> {
+    if (!this._isInitialized) {
+      return;
+    }
+
+    log.info('Shutting down persistent query session', { sessionId: this._sessionId });
+
+    // Close the prompt stream, which will end the query
+    if (this.promptController) {
+      this.promptController.close();
+    }
+
+    // Close the query
+    if (this.currentQuery) {
+      this.currentQuery.close();
+    }
+
+    // Wait for the message loop to finish
+    if (this.messageLoopPromise) {
+      try {
+        await this.messageLoopPromise;
+      } catch {
+        // Expected - the loop may error when the query is closed
+      }
+    }
+
+    this._isInitialized = false;
+    this.currentQuery = null;
+    this.promptController = null;
+    this._sessionId = null;
+    this.messageLoopPromise = null;
   }
 }

--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -248,18 +248,22 @@ claude.getHistory({
 ### Interaction Flow
 
 1. User sends prompt via `claude.send()`
-2. Next.js server sends HTTP POST to the agent service inside the container (`/query` endpoint)
-3. Agent service calls `query()` from `@anthropic-ai/claude-agent-sdk` with `includePartialMessages: true`
-4. Agent service streams results back as Server-Sent Events (SSE):
+2. Next.js server ensures the agent service has an initialized persistent session:
+   - Calls `GET /status` to check if already initialized
+   - If not initialized, calls `POST /init` with session ID, resume flag, working directory, and MCP servers
+   - The `/init` call starts the SDK `query()` with an `AsyncIterable<SDKUserMessage>` prompt stream, fetches slash commands via `initializationResult()`, and begins the background message processing loop
+3. Next.js server sends the prompt via `POST /send` to the agent service
+4. Agent service yields the user message into the persistent query's async generator
+5. Agent service streams results back as Server-Sent Events (SSE):
    - **Partial messages**: `stream_event` messages from the SDK are accumulated by `StreamAccumulator` into synthetic partial assistant messages. These are emitted as `{ partial }` SSE events for real-time UI updates (text streaming, tool call progress) but are **not persisted** to the database.
    - **Complete messages**: Full `assistant`, `user`, `result`, and `system` messages are emitted as `{ sequence, message }` SSE events and persisted.
-5. Next.js server reads SSE stream:
+6. Next.js server reads SSE stream:
    - For partial messages: emits SSE event with `partial-{uuid}` ID to browser (not saved to DB)
    - For complete messages: saves to database with incrementing sequence number, emits SSE event
-6. Browser client receives SSE events and updates the message cache:
+7. Browser client receives SSE events and updates the message cache:
    - Partial messages replace any existing partial in the cache (only one active partial at a time)
    - Complete messages remove any partial messages and are added to the cache
-7. On completion, `result` message marks end of turn
+8. On completion, `result` message marks end of turn. The persistent session stays alive for the next prompt.
 
 ### System Prompt
 
@@ -340,20 +344,28 @@ Runner containers are created with (see [`createAndStartContainer`](../src/serve
 
 Each runner container includes a built-in agent service (`/opt/agent-service/`) that uses the `@anthropic-ai/claude-agent-sdk` to interact with Claude programmatically instead of spawning CLI processes.
 
+The agent service uses **persistent streaming input mode**: instead of creating a new `query()` call per user prompt, it maintains a single long-lived `query()` per session lifetime with an `AsyncIterable<SDKUserMessage>` prompt stream. User messages are yielded into this stream as they arrive.
+
 **Agent service endpoints:**
 
-- `POST /query` — Start a new Claude query. Streams results as SSE (Server-Sent Events). Emits two types of events: `{ partial }` for real-time streaming updates (accumulated from SDK `stream_event` messages) and `{ sequence, message }` for complete persisted messages.
+- `POST /init` — Initialize the persistent query session. Sets up the SDK `query()` with streaming input, fetches initialization data (slash commands, supported models, etc.), and starts the background message processing loop. Must be called before `/send`. Returns `{ initialized, commands }`.
+- `POST /send` — Send a user prompt into the persistent session. Yields the message through the async generator and streams results as SSE (Server-Sent Events). Emits: `{ partial }` for real-time streaming updates, `{ sequence, message }` for complete persisted messages, `{ commands }` for slash command updates, and `{ done: true }` on completion.
 - `POST /interrupt` — Interrupt the currently running query.
-- `GET /status` — Check if a query is running and get the last sequence number.
+- `GET /status` — Check if a prompt is being processed (`running`), whether the session is initialized (`initialized`), and get the last sequence number and cached commands.
 - `GET /messages?after=N` — Fetch complete messages after a given sequence number (for reconnection/catch-up).
+- `GET /commands` — Get the currently known supported slash commands.
+- `GET /branch` — Get the current git branch in the container's working directory.
 - `GET /health` — Health check endpoint.
 
-**Benefits over the previous CLI approach:**
+**Benefits of persistent streaming input mode:**
 
+- **Commands available at session startup** — `initializationResult()` resolves before any user message is sent, so slash commands are available immediately
+- **No re-initialization per prompt** — session stays alive between prompts, avoiding repeated loading of CLAUDE.md, MCP servers, skills, etc.
+- **Plan mode / AskUserQuestion work correctly** — interactive tools work naturally since the session persists between prompts
+- **`setModel()` / `setPermissionMode()` become available** — these SDK methods only work in streaming input mode
 - No file-based communication (output files, tailing, PID tracking)
 - Clean interrupt via SDK API instead of signal-based process management
 - Message persistence inside the container (SQLite) for reconnection
-- Simpler error handling and lifecycle management
 - Direct programmatic access to Claude sessions, resume, and settings
 
 **Implementation:**

--- a/src/server/services/agent-client.test.ts
+++ b/src/server/services/agent-client.test.ts
@@ -175,11 +175,47 @@ describe('AgentClient', () => {
     });
   });
 
-  describe('query', () => {
+  describe('init', () => {
+    it('should send init request and return result', async () => {
+      mockServer.setHandler((req, res) => {
+        expect(req.method).toBe('POST');
+        expect(req.url).toBe('/init');
+
+        let body = '';
+        req.on('data', (chunk: Buffer) => {
+          body += chunk.toString();
+        });
+        req.on('end', () => {
+          const parsed = JSON.parse(body);
+          expect(parsed.sessionId).toBe('test-session');
+          expect(parsed.resume).toBe(false);
+
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(
+            JSON.stringify({
+              initialized: true,
+              commands: [{ name: '/help', description: 'Show help' }],
+            })
+          );
+        });
+      });
+
+      const result = await client.init({
+        sessionId: 'test-session',
+        resume: false,
+      });
+
+      expect(result.initialized).toBe(true);
+      expect(result.commands).toHaveLength(1);
+      expect(result.commands[0].name).toBe('/help');
+    });
+  });
+
+  describe('send', () => {
     it('should stream messages from SSE response', async () => {
       mockServer.setHandler((req, res) => {
         expect(req.method).toBe('POST');
-        expect(req.url).toBe('/query');
+        expect(req.url).toBe('/send');
 
         res.writeHead(200, {
           'Content-Type': 'text/event-stream',
@@ -212,7 +248,7 @@ describe('AgentClient', () => {
       });
 
       const messages: AgentStreamEvent[] = [];
-      for await (const msg of client.query({
+      for await (const msg of client.send({
         prompt: 'test',
         sessionId: 'test-session',
       })) {
@@ -263,7 +299,7 @@ describe('AgentClient', () => {
       });
 
       const events: AgentStreamEvent[] = [];
-      for await (const msg of client.query({
+      for await (const msg of client.send({
         prompt: 'test',
         sessionId: 'test-session',
       })) {
@@ -279,7 +315,7 @@ describe('AgentClient', () => {
       }
     });
 
-    it('should throw on query error event', async () => {
+    it('should throw on send error event', async () => {
       mockServer.setHandler((_req, res) => {
         res.writeHead(200, {
           'Content-Type': 'text/event-stream',
@@ -291,7 +327,7 @@ describe('AgentClient', () => {
 
       const messages: unknown[] = [];
       await expect(async () => {
-        for await (const msg of client.query({
+        for await (const msg of client.send({
           prompt: 'test',
           sessionId: 'test-session',
         })) {
@@ -318,11 +354,9 @@ describe('AgentClient', () => {
         });
       });
 
-      for await (const _msg of client.query({
+      for await (const _msg of client.send({
         prompt: 'hello',
         sessionId: 'sess-123',
-        resume: true,
-        cwd: '/workspace/repo',
       })) {
         // consume iterator
       }
@@ -330,8 +364,6 @@ describe('AgentClient', () => {
       const parsed = JSON.parse(receivedBody);
       expect(parsed.prompt).toBe('hello');
       expect(parsed.sessionId).toBe('sess-123');
-      expect(parsed.resume).toBe(true);
-      expect(parsed.cwd).toBe('/workspace/repo');
     });
   });
 });
@@ -340,7 +372,8 @@ describe('waitForAgentHealth', () => {
   it('should return true when health check passes', async () => {
     const mockClient: AgentClient = {
       health: vi.fn().mockResolvedValue(true),
-      query: vi.fn() as unknown as AgentClient['query'],
+      init: vi.fn() as unknown as AgentClient['init'],
+      send: vi.fn() as unknown as AgentClient['send'],
       interrupt: vi.fn(),
       getStatus: vi.fn(),
       getMessages: vi.fn(),
@@ -363,7 +396,8 @@ describe('waitForAgentHealth', () => {
         attempts++;
         return attempts >= 3;
       }),
-      query: vi.fn() as unknown as AgentClient['query'],
+      init: vi.fn() as unknown as AgentClient['init'],
+      send: vi.fn() as unknown as AgentClient['send'],
       interrupt: vi.fn(),
       getStatus: vi.fn(),
       getMessages: vi.fn(),
@@ -382,7 +416,8 @@ describe('waitForAgentHealth', () => {
   it('should return false after max attempts', async () => {
     const mockClient: AgentClient = {
       health: vi.fn().mockResolvedValue(false),
-      query: vi.fn() as unknown as AgentClient['query'],
+      init: vi.fn() as unknown as AgentClient['init'],
+      send: vi.fn() as unknown as AgentClient['send'],
       interrupt: vi.fn(),
       getStatus: vi.fn(),
       getMessages: vi.fn(),

--- a/src/server/services/agent-client.ts
+++ b/src/server/services/agent-client.ts
@@ -1,9 +1,9 @@
 /**
  * HTTP client for communicating with the agent service running inside containers.
  *
- * The agent service exposes an HTTP API with endpoints for querying Claude,
- * interrupting queries, checking status, and fetching persisted messages.
- * This client provides a typed interface for all those operations.
+ * The agent service exposes an HTTP API with endpoints for initializing a persistent
+ * query session, sending prompts, interrupting queries, checking status, and fetching
+ * persisted messages. This client provides a typed interface for all those operations.
  *
  * Uses Unix domain sockets for communication instead of TCP ports.
  */
@@ -11,7 +11,7 @@
 import http from 'node:http';
 import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
-import type { SDKMessage, SlashCommand } from '@anthropic-ai/claude-agent-sdk';
+import type { SDKMessage, SlashCommand, McpServerConfig } from '@anthropic-ai/claude-agent-sdk';
 import { createLogger, toError } from '@/lib/logger';
 import { env } from '@/lib/env';
 import type { PartialAssistantMessage } from '../../../shared/agent-types';
@@ -53,13 +53,22 @@ export type AgentStreamEvent = AgentMessage | AgentPartialMessage | AgentCommand
  */
 export interface AgentStatus {
   running: boolean;
+  initialized: boolean;
   messageCount: number;
   lastSequence: number;
   commands: SlashCommand[];
 }
 
 /**
- * SSE event from the /query endpoint.
+ * Response from the /init endpoint.
+ */
+export interface AgentInitResponse {
+  initialized: boolean;
+  commands: SlashCommand[];
+}
+
+/**
+ * SSE event from the /send endpoint.
  * Either a complete message, a partial message, a completion marker, or an error.
  */
 type SSEEvent =
@@ -74,17 +83,23 @@ type SSEEvent =
  */
 export interface AgentClient {
   /**
-   * Start a query and stream results as an async iterable.
-   * Yields both complete messages (with sequence numbers, persisted) and
-   * partial messages (transient streaming updates for real-time UI).
+   * Initialize the persistent query session.
+   * Must be called before send(). Sets up the SDK query with streaming input mode,
+   * fetches initialization data (commands, etc.).
    */
-  query(options: {
-    prompt: string;
+  init(options: {
     sessionId: string;
     resume?: boolean;
     cwd?: string;
-    mcpServers?: Record<string, unknown>;
-  }): AsyncGenerator<AgentStreamEvent>;
+    mcpServers?: Record<string, McpServerConfig>;
+  }): Promise<AgentInitResponse>;
+
+  /**
+   * Send a prompt to the persistent query session and stream results.
+   * Yields both complete messages (with sequence numbers, persisted) and
+   * partial messages (transient streaming updates for real-time UI).
+   */
+  send(options: { prompt: string; sessionId: string }): AsyncGenerator<AgentStreamEvent>;
 
   /**
    * Interrupt the currently running query.
@@ -192,27 +207,33 @@ export function createAgentClient(socketPath: string): AgentClient {
   }
 
   return {
-    async *query(options) {
+    async init(options) {
+      return fetchJson<AgentInitResponse>('/init', 'POST', {
+        sessionId: options.sessionId,
+        resume: options.resume ?? false,
+        cwd: options.cwd,
+        mcpServers: options.mcpServers,
+      });
+    },
+
+    async *send(options) {
       const res = await httpRequest(
         socketPath,
         {
-          path: '/query',
+          path: '/send',
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
         },
         JSON.stringify({
           prompt: options.prompt,
           sessionId: options.sessionId,
-          resume: options.resume ?? false,
-          cwd: options.cwd,
-          mcpServers: options.mcpServers,
         })
       );
 
       if (res.statusCode && (res.statusCode < 200 || res.statusCode >= 300)) {
         const text = await readJsonResponse<{ error?: string }>(res);
         throw new Error(
-          `Agent service query failed (${res.statusCode}): ${text.error || 'Unknown error'}`
+          `Agent service send failed (${res.statusCode}): ${text.error || 'Unknown error'}`
         );
       }
 

--- a/src/server/services/claude-runner.test.ts
+++ b/src/server/services/claude-runner.test.ts
@@ -37,7 +37,8 @@ const { mockPodmanFunctions, mockPrisma, mockSseEvents, mockAgentClient } = vi.h
   };
 
   const mockAgentClient = {
-    query: vi.fn(),
+    init: vi.fn(),
+    send: vi.fn(),
     interrupt: vi.fn(),
     getStatus: vi.fn(),
     getMessages: vi.fn(),
@@ -134,7 +135,13 @@ describe('claude-runner service', () => {
     mockPodmanFunctions.getContainerLogs.mockResolvedValue(null);
 
     mockAgentClient.health.mockResolvedValue(true);
-    mockAgentClient.getStatus.mockResolvedValue({ running: false, lastSequence: 0, commands: [] });
+    mockAgentClient.getStatus.mockResolvedValue({
+      running: false,
+      initialized: false,
+      lastSequence: 0,
+      commands: [],
+    });
+    mockAgentClient.init.mockResolvedValue({ initialized: true, commands: [] });
     mockAgentClient.interrupt.mockResolvedValue({ success: true });
     mockAgentClient.getMessages.mockResolvedValue([]);
     mockAgentClient.getCurrentBranch.mockResolvedValue(null);
@@ -301,7 +308,12 @@ describe('claude-runner service', () => {
         containerId: 'container-123',
       });
       mockPodmanFunctions.getContainerStatus.mockResolvedValue('running');
-      mockAgentClient.getStatus.mockResolvedValue({ running: true, lastSequence: 5, commands: [] });
+      mockAgentClient.getStatus.mockResolvedValue({
+        running: true,
+        initialized: true,
+        lastSequence: 5,
+        commands: [],
+      });
 
       const result = await isClaudeRunningAsync('test-session-running');
       expect(result).toBe(true);
@@ -546,7 +558,12 @@ describe('claude-runner service', () => {
       mockPrisma.session.findUnique.mockResolvedValue({ repoPath: 'my-repo' });
       mockPodmanFunctions.getContainerStatus.mockResolvedValue('running');
       mockAgentClient.health.mockResolvedValue(true);
-      mockAgentClient.getStatus.mockResolvedValue({ running: true, lastSequence: 5, commands: [] });
+      mockAgentClient.getStatus.mockResolvedValue({
+        running: true,
+        initialized: true,
+        lastSequence: 5,
+        commands: [],
+      });
 
       await expect(
         runClaudeCommand({
@@ -563,12 +580,13 @@ describe('claude-runner service', () => {
       mockAgentClient.health.mockResolvedValue(true);
       mockAgentClient.getStatus.mockResolvedValue({
         running: false,
+        initialized: false,
         lastSequence: 0,
         commands: [],
       });
 
       // Return empty async generator
-      mockAgentClient.query.mockReturnValue(
+      mockAgentClient.send.mockReturnValue(
         (async function* () {
           // no messages
         })()
@@ -595,11 +613,12 @@ describe('claude-runner service', () => {
       mockAgentClient.health.mockResolvedValue(true);
       mockAgentClient.getStatus.mockResolvedValue({
         running: false,
+        initialized: false,
         lastSequence: 0,
         commands: [],
       });
 
-      mockAgentClient.query.mockReturnValue(
+      mockAgentClient.send.mockReturnValue(
         (async function* () {
           // no messages
         })()
@@ -625,6 +644,7 @@ describe('claude-runner service', () => {
       mockAgentClient.health.mockResolvedValue(true);
       mockAgentClient.getStatus.mockResolvedValue({
         running: false,
+        initialized: false,
         lastSequence: 0,
         commands: [],
       });
@@ -638,9 +658,9 @@ describe('claude-runner service', () => {
         },
       };
 
-      mockAgentClient.query.mockReturnValue(
+      mockAgentClient.send.mockReturnValue(
         (async function* () {
-          yield { sequence: 1, message: assistantMessage };
+          yield { kind: 'complete', sequence: 1, message: assistantMessage };
         })()
       );
 
@@ -666,6 +686,7 @@ describe('claude-runner service', () => {
       mockAgentClient.health.mockResolvedValue(true);
       mockAgentClient.getStatus.mockResolvedValue({
         running: false,
+        initialized: false,
         lastSequence: 0,
         commands: [],
       });
@@ -676,9 +697,9 @@ describe('claude-runner service', () => {
         message: { role: 'assistant', content: [] },
       };
 
-      mockAgentClient.query.mockReturnValue(
+      mockAgentClient.send.mockReturnValue(
         (async function* () {
-          yield { sequence: 1, message: agentMessage };
+          yield { kind: 'complete', sequence: 1, message: agentMessage };
         })()
       );
 
@@ -701,11 +722,12 @@ describe('claude-runner service', () => {
       mockAgentClient.health.mockResolvedValue(true);
       mockAgentClient.getStatus.mockResolvedValue({
         running: false,
+        initialized: false,
         lastSequence: 0,
         commands: [],
       });
 
-      mockAgentClient.query.mockReturnValue(
+      mockAgentClient.send.mockReturnValue(
         (async function* () {
           throw new Error('Connection lost');
         })()
@@ -722,18 +744,19 @@ describe('claude-runner service', () => {
       expect(mockSseEvents.emitClaudeRunning).toHaveBeenCalledWith('test-session', false);
     });
 
-    it('should use resume=false when agent has no prior messages (fresh container)', async () => {
+    it('should call init with resume=false when agent has no prior messages (fresh container)', async () => {
       mockPrisma.session.findUnique.mockResolvedValue({ repoPath: 'my-repo' });
       mockPrisma.message.findFirst.mockResolvedValue(null); // no existing messages
       mockPodmanFunctions.getContainerStatus.mockResolvedValue('running');
       mockAgentClient.health.mockResolvedValue(true);
       mockAgentClient.getStatus.mockResolvedValue({
         running: false,
+        initialized: false,
         lastSequence: 0,
         commands: [],
       });
 
-      mockAgentClient.query.mockReturnValue(
+      mockAgentClient.send.mockReturnValue(
         (async function* () {
           // no messages
         })()
@@ -745,15 +768,21 @@ describe('claude-runner service', () => {
         prompt: 'First message',
       });
 
-      expect(mockAgentClient.query).toHaveBeenCalledWith(
+      expect(mockAgentClient.init).toHaveBeenCalledWith(
         expect.objectContaining({
           resume: false,
+          sessionId: 'test-session',
+        })
+      );
+      expect(mockAgentClient.send).toHaveBeenCalledWith(
+        expect.objectContaining({
           prompt: 'First message',
+          sessionId: 'test-session',
         })
       );
     });
 
-    it('should use resume=false after container restart even with DB messages', async () => {
+    it('should call init with resume=false after container restart even with DB messages', async () => {
       mockPrisma.session.findUnique.mockResolvedValue({ repoPath: 'my-repo' });
       mockPrisma.message.findFirst.mockResolvedValue({ sequence: 5 }); // DB has messages from previous run
       mockPodmanFunctions.getContainerStatus.mockResolvedValue('running');
@@ -761,11 +790,12 @@ describe('claude-runner service', () => {
       // Agent has lastSequence: 0 (fresh container, no prior messages in agent)
       mockAgentClient.getStatus.mockResolvedValue({
         running: false,
+        initialized: false,
         lastSequence: 0,
         commands: [],
       });
 
-      mockAgentClient.query.mockReturnValue(
+      mockAgentClient.send.mockReturnValue(
         (async function* () {
           // no messages
         })()
@@ -777,15 +807,15 @@ describe('claude-runner service', () => {
         prompt: 'Follow-up after restart',
       });
 
-      expect(mockAgentClient.query).toHaveBeenCalledWith(
+      expect(mockAgentClient.init).toHaveBeenCalledWith(
         expect.objectContaining({
           resume: false,
-          prompt: 'Follow-up after restart',
+          sessionId: 'test-session',
         })
       );
     });
 
-    it('should use resume=true when agent has prior messages', async () => {
+    it('should call init with resume=true when agent has prior messages', async () => {
       mockPrisma.session.findUnique.mockResolvedValue({ repoPath: 'my-repo' });
       mockPrisma.message.findFirst.mockResolvedValue({ sequence: 5 }); // has existing messages
       mockPodmanFunctions.getContainerStatus.mockResolvedValue('running');
@@ -793,11 +823,12 @@ describe('claude-runner service', () => {
       // Agent has lastSequence: 3 (has prior messages from an earlier query in same container lifecycle)
       mockAgentClient.getStatus.mockResolvedValue({
         running: false,
+        initialized: false,
         lastSequence: 3,
         commands: [],
       });
 
-      mockAgentClient.query.mockReturnValue(
+      mockAgentClient.send.mockReturnValue(
         (async function* () {
           // no messages
         })()
@@ -809,10 +840,45 @@ describe('claude-runner service', () => {
         prompt: 'Follow-up in same session',
       });
 
-      expect(mockAgentClient.query).toHaveBeenCalledWith(
+      expect(mockAgentClient.init).toHaveBeenCalledWith(
         expect.objectContaining({
           resume: true,
-          prompt: 'Follow-up in same session',
+          sessionId: 'test-session',
+        })
+      );
+    });
+
+    it('should skip init when agent is already initialized', async () => {
+      mockPrisma.session.findUnique.mockResolvedValue({ repoPath: 'my-repo' });
+      mockPodmanFunctions.getContainerStatus.mockResolvedValue('running');
+      mockAgentClient.health.mockResolvedValue(true);
+      // Agent already initialized from a previous prompt
+      mockAgentClient.getStatus.mockResolvedValue({
+        running: false,
+        initialized: true,
+        lastSequence: 5,
+        commands: [{ name: '/help', description: 'Show help' }],
+      });
+
+      mockAgentClient.send.mockReturnValue(
+        (async function* () {
+          // no messages
+        })()
+      );
+
+      await runClaudeCommand({
+        sessionId: 'test-session',
+        containerId: 'container-1',
+        prompt: 'Second prompt',
+      });
+
+      // Should NOT call init since already initialized
+      expect(mockAgentClient.init).not.toHaveBeenCalled();
+      // Should still send the prompt
+      expect(mockAgentClient.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          prompt: 'Second prompt',
+          sessionId: 'test-session',
         })
       );
     });

--- a/src/server/services/claude-runner.ts
+++ b/src/server/services/claude-runner.ts
@@ -235,6 +235,52 @@ function getClientForSession(sessionId: string): AgentClient {
   return createAgentClient(getAgentSocketPath(sessionId));
 }
 
+/**
+ * Ensure the agent service has an initialized persistent query session.
+ * If not yet initialized, calls /init to set it up.
+ * Returns the commands from initialization (if newly initialized) or from status.
+ */
+async function ensureAgentInitialized(
+  client: AgentClient,
+  options: {
+    sessionId: string;
+    lastSequence: number;
+    workingDir: string;
+    mcpServersRecord?: Record<string, unknown>;
+  }
+): Promise<{ commands: import('@anthropic-ai/claude-agent-sdk').SlashCommand[] }> {
+  const status = await client.getStatus();
+
+  if (status.initialized) {
+    // Already initialized - check if a prompt is being processed
+    if (status.running) {
+      throw new Error('A Claude process is already running for this session');
+    }
+    return { commands: status.commands };
+  }
+
+  // Need to initialize the persistent session
+  const shouldResume = status.lastSequence > 0;
+
+  log.info('Initializing agent persistent session', {
+    sessionId: options.sessionId,
+    resume: shouldResume,
+    lastSequence: status.lastSequence,
+  });
+
+  const initResult = await client.init({
+    sessionId: options.sessionId,
+    resume: shouldResume,
+    cwd: options.workingDir,
+    mcpServers: options.mcpServersRecord as Record<
+      string,
+      import('@anthropic-ai/claude-agent-sdk').McpServerConfig
+    >,
+  });
+
+  return { commands: initResult.commands };
+}
+
 export interface RunClaudeCommandOptions {
   sessionId: string;
   containerId: string;
@@ -264,6 +310,10 @@ export interface RunClaudeCommandOptions {
 /**
  * Run a Claude command via the agent service running inside the container.
  * Streams messages from the agent service, saves them to DB, and emits SSE events.
+ *
+ * The agent service uses persistent streaming input mode: one long-lived query()
+ * per session lifetime. This function initializes the session if needed, then
+ * sends the prompt through the persistent query.
  */
 export async function runClaudeCommand(options: RunClaudeCommandOptions): Promise<void> {
   const { sessionId, containerId, prompt } = options;
@@ -302,15 +352,40 @@ export async function runClaudeCommand(options: RunClaudeCommandOptions): Promis
     throw new Error('Agent service is not healthy');
   }
 
-  // Check if agent already has a running query
-  const status = await client.getStatus();
-  if (status.running) {
-    throw new Error('A Claude process is already running for this session');
-  }
+  // Build working directory
+  const workingDir = session.repoPath ? `/workspace/${session.repoPath}` : '/workspace';
 
-  // Emit any cached commands from the agent service (from a previous query in this container)
-  if (status.commands?.length > 0) {
-    sseEvents.emitCommands(sessionId, status.commands);
+  // Build MCP servers config as Record<string, McpServerConfig> for the SDK
+  const mcpServersRecord = options.mcpServers?.length
+    ? Object.fromEntries(
+        options.mcpServers.map((server) => {
+          if (server.type === 'http' || server.type === 'sse') {
+            const config: Record<string, unknown> = { type: server.type, url: server.url };
+            if (server.headers && Object.keys(server.headers).length > 0) {
+              config.headers = server.headers;
+            }
+            return [server.name, config];
+          }
+          // stdio (default)
+          const config: Record<string, unknown> = { command: server.command };
+          if (server.args?.length) config.args = server.args;
+          if (server.env && Object.keys(server.env).length > 0) config.env = server.env;
+          return [server.name, config];
+        })
+      )
+    : undefined;
+
+  // Ensure the agent has an initialized persistent session
+  const { commands } = await ensureAgentInitialized(client, {
+    sessionId,
+    lastSequence: 0, // Will be checked by the agent service
+    workingDir,
+    mcpServersRecord,
+  });
+
+  // Emit any commands from initialization
+  if (commands.length > 0) {
+    sseEvents.emitCommands(sessionId, commands);
   }
 
   // Get the next sequence number for this session
@@ -346,13 +421,6 @@ export async function runClaudeCommand(options: RunClaudeCommandOptions): Promis
     createdAt: new Date(),
   });
 
-  // Determine if we should resume an existing SDK session.
-  // We ask the agent service for its last sequence number. If it has processed
-  // messages before (sequence > 0), it has an active Claude Code session
-  // that we can resume. If it's 0 (fresh container), we start a new session
-  // even if our DB has messages from a previous container lifecycle.
-  const shouldResume = status.lastSequence > 0;
-
   // Track the active query
   activeQueries.set(sessionId, { client });
 
@@ -360,41 +428,15 @@ export async function runClaudeCommand(options: RunClaudeCommandOptions): Promis
   sseEvents.emitClaudeRunning(sessionId, true);
 
   try {
-    // Build working directory
-    const workingDir = session.repoPath ? `/workspace/${session.repoPath}` : '/workspace';
-
-    // Build MCP servers config as Record<string, McpServerConfig> for the SDK
-    const mcpServersRecord = options.mcpServers?.length
-      ? Object.fromEntries(
-          options.mcpServers.map((server) => {
-            if (server.type === 'http' || server.type === 'sse') {
-              const config: Record<string, unknown> = { type: server.type, url: server.url };
-              if (server.headers && Object.keys(server.headers).length > 0) {
-                config.headers = server.headers;
-              }
-              return [server.name, config];
-            }
-            // stdio (default)
-            const config: Record<string, unknown> = { command: server.command };
-            if (server.args?.length) config.args = server.args;
-            if (server.env && Object.keys(server.env).length > 0) config.env = server.env;
-            return [server.name, config];
-          })
-        )
-      : undefined;
-
     // Use a stable ID for partial messages so the frontend can track and replace them.
     // The partial message UUID from the stream_event is used as the partial ID.
     // When the final assistant message arrives, the frontend removes the partial.
     const PARTIAL_MESSAGE_ID_PREFIX = 'partial-';
 
-    // Start the query through the agent service
-    for await (const agentEvent of client.query({
+    // Send the prompt through the persistent query session
+    for await (const agentEvent of client.send({
       prompt,
       sessionId,
-      resume: shouldResume,
-      cwd: workingDir,
-      mcpServers: mcpServersRecord,
     })) {
       // Handle commands update - emit via SSE for frontend autocomplete
       if (agentEvent.kind === 'commands') {
@@ -821,6 +863,11 @@ export async function reconcileOrphanedProcesses(): Promise<{
             });
           }
         }
+      }
+
+      // Emit any cached commands
+      if (agentStatus.commands?.length > 0) {
+        sseEvents.emitCommands(session.id, agentStatus.commands);
       }
 
       if (agentStatus.running) {


### PR DESCRIPTION
## Summary

- Switches from creating a new `query()` call per user prompt to using the SDK's **persistent streaming input mode** (`AsyncIterable<SDKUserMessage>`)
- Splits the `/query` endpoint into `/init` (one-time session setup) and `/send` (per-prompt streaming) 
- The persistent session initializes once per container lifecycle, with subsequent prompts reusing the same query

## What changed

**Agent service (`agent-service/src/`):**
- `QueryRunner`: Now manages a persistent `Query` object with an async generator. `initialize()` starts the session and fetches commands via `initializationResult()` before any user message. `sendPrompt()` yields messages into the generator and waits for the turn to complete.
- `index.ts`: `POST /query` replaced with `POST /init` + `POST /send`. `/status` now reports `initialized` state.

**Next.js server (`src/server/services/`):**
- `agent-client.ts`: Updated interface with `init()` and `send()` methods replacing `query()`.
- `claude-runner.ts`: `runClaudeCommand()` now calls `ensureAgentInitialized()` before each prompt. First call initializes the persistent session; subsequent calls reuse it.

**Documentation:**
- `doc/DESIGN.md`: Updated Agent Service Architecture and Interaction Flow sections.

## Benefits

- **Slash commands available at session startup** — `initializationResult()` resolves before any user message
- **No re-initialization per prompt** — avoids repeated loading of CLAUDE.md, MCP servers, skills
- **Enables plan mode / AskUserQuestion** — persistent session handles interactive tools naturally
- **`setModel()` / `setPermissionMode()` become available** — only work in streaming input mode

## Test plan

- [x] All 461 existing tests pass (24 test files)
- [x] TypeScript compilation clean for both agent-service and main app
- [x] Updated agent-client tests for new `init`/`send` API
- [x] Updated claude-runner tests for new initialization flow
- [x] Added test for "skip init when already initialized" case
- [ ] Manual testing with a running session to verify end-to-end flow

Fixes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)