### PR TITLE
Add opus[1m] and sonnet[1m] model aliases, default to opus[1m]

### DIFF
--- a/src/components/settings/SystemPromptTab.tsx
+++ b/src/components/settings/SystemPromptTab.tsx
@@ -47,7 +47,7 @@ export function SystemPromptTab() {
         <CardContent>
           <ClaudeModelSection
             currentModel={settings?.claudeModel ?? null}
-            defaultModel={settings?.defaultClaudeModel ?? 'opus'}
+            defaultModel={settings?.defaultClaudeModel ?? 'opus[1m]'}
             onUpdate={refetch}
           />
         </CardContent>

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -9,7 +9,7 @@ const envSchema = z.object({
   CLAUDE_CODE_OAUTH_TOKEN: z.string().optional().default(''),
   // Claude model to use in runner containers (e.g., "opus", "sonnet", "claude-opus-4-5-20251101")
   // Passed as --model to the claude CLI
-  CLAUDE_MODEL: z.string().default('opus'),
+  CLAUDE_MODEL: z.string().default('opus[1m]'),
   // Named volume for pnpm store - shared across all runner containers
   // Speeds up package installs by caching downloaded packages
   PNPM_STORE_VOLUME: z.string().default('clawed-abode-pnpm-store'),

--- a/src/server/routers/globalSettings.integration.test.ts
+++ b/src/server/routers/globalSettings.integration.test.ts
@@ -56,7 +56,7 @@ describe('globalSettings router', () => {
         hasClaudeApiKey: false,
         ttsSpeed: null,
         voiceAutoSend: true,
-        defaultClaudeModel: 'opus',
+        defaultClaudeModel: 'opus[1m]',
         hasEnvApiKey: true,
       });
     });

--- a/src/server/services/anthropic-models.ts
+++ b/src/server/services/anthropic-models.ts
@@ -7,7 +7,7 @@ import { createLogger, toError } from '@/lib/logger';
 const log = createLogger('anthropic-models');
 
 /** Well-known short aliases that always appear as suggestions */
-const WELL_KNOWN_ALIASES = ['opus', 'sonnet', 'haiku'];
+const WELL_KNOWN_ALIASES = ['opus[1m]', 'sonnet[1m]', 'opus', 'sonnet', 'haiku'];
 
 /** Cache for model suggestions */
 let cachedModels: string[] | null = null;

--- a/src/server/services/podman-socket.test.ts
+++ b/src/server/services/podman-socket.test.ts
@@ -18,7 +18,7 @@ vi.mock('@/lib/env', () => ({
   env: {
     CLAUDE_RUNNER_IMAGE: 'claude-code-runner:test',
     CLAUDE_CODE_OAUTH_TOKEN: 'test-oauth-token',
-    CLAUDE_MODEL: 'opus',
+    CLAUDE_MODEL: 'opus[1m]',
     DATA_DIR: '/data',
     DATA_HOST_PATH: undefined,
     PNPM_STORE_PATH: undefined,


### PR DESCRIPTION
## Summary
- Add `opus[1m]` and `sonnet[1m]` to the well-known model aliases so they appear in the model selector dropdown (these don't show up from the Anthropic models API but are valid model names)
- Change the default model from `opus` to `opus[1m]`

## Test plan
- [x] All 439 tests pass
- [ ] Verify model selector shows opus[1m] and sonnet[1m] options
- [ ] Verify new sessions default to opus[1m]

🤖 Generated with [Claude Code](https://claude.com/claude-code)