### PR TITLE
Fix GitHub API 401 errors causing app logout redirect

### DIFF
--- a/src/server/routers/github.test.ts
+++ b/src/server/routers/github.test.ts
@@ -519,7 +519,7 @@ describe('githubRouter', () => {
       });
     });
 
-    it('should throw UNAUTHORIZED for invalid token', async () => {
+    it('should throw PRECONDITION_FAILED for invalid token', async () => {
       mockFetch.mockResolvedValue(createMockResponse({}, 401));
 
       const caller = createCaller('auth-session-id');
@@ -530,7 +530,7 @@ describe('githubRouter', () => {
           issueNumber: 123,
         })
       ).rejects.toMatchObject({
-        code: 'UNAUTHORIZED',
+        code: 'PRECONDITION_FAILED',
         message: 'GitHub token is invalid or expired',
       });
     });

--- a/src/server/routers/github.ts
+++ b/src/server/routers/github.ts
@@ -52,7 +52,7 @@ async function githubFetchResponse(path: string, token?: string): Promise<Respon
   if (!response.ok) {
     if (response.status === 401) {
       throw new TRPCError({
-        code: 'UNAUTHORIZED',
+        code: 'PRECONDITION_FAILED',
         message: 'GitHub token is invalid or expired',
       });
     }


### PR DESCRIPTION
## Summary
- GitHub API 401 errors (invalid/expired token) were mapped to tRPC `UNAUTHORIZED` error code
- The client-side `authErrorLink` intercepts `UNAUTHORIZED` and redirects to `/login`, clearing the auth token
- This incorrectly logged users out when their GitHub token was invalid, not their app session

## Fix
Changed `githubFetchResponse` in `src/server/routers/github.ts` to throw `PRECONDITION_FAILED` instead of `UNAUTHORIZED` for GitHub API 401 responses. This way only actual app authentication failures trigger the logout redirect.

## Test plan
- [ ] Verify that an invalid GitHub token shows an error message instead of redirecting to login
- [ ] Verify that an expired app session still redirects to login correctly
- [ ] All existing tests pass

Fixes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)