### PR TITLE
Fix CLAUDE_MODEL env var not used as fallback when DB model is unset

### DIFF
--- a/src/server/services/settings-merger.ts
+++ b/src/server/services/settings-merger.ts
@@ -2,6 +2,7 @@ import type { ContainerEnvVar, ContainerMcpServer } from './repo-settings';
 import { getRepoSettingsForContainer } from './repo-settings';
 import { getGlobalSettingsForContainer, type GlobalContainerSettings } from './global-settings';
 import { buildSystemPrompt } from './claude-runner';
+import { env } from '@/lib/env';
 
 /**
  * Fully merged session settings ready for container creation and Claude queries.
@@ -41,7 +42,7 @@ export async function loadMergedSessionSettings(
     systemPrompt,
     envVars,
     mcpServers,
-    claudeModel: globalSettings.claudeModel ?? undefined,
+    claudeModel: globalSettings.claudeModel ?? env.CLAUDE_MODEL,
     claudeApiKey: globalSettings.claudeApiKey ?? undefined,
     customSystemPrompt: repoSettings?.customSystemPrompt,
     globalSettings,


### PR DESCRIPTION
## Summary
- The `CLAUDE_MODEL` env var (`opus[1m]`) was never used when no model override was stored in the database
- `settings-merger.ts` returned `undefined` for `claudeModel` when DB had no value, causing `claude-runner.ts` to skip setting `sdkOptions.model`
- The Claude Agent SDK then fell back to its own default (`claude-sonnet-4-6`)

## Fix
Added `env.CLAUDE_MODEL` as the fallback in `settings-merger.ts`:
```typescript
claudeModel: globalSettings.claudeModel ?? env.CLAUDE_MODEL,
```

## Test plan
- [ ] All 361 existing tests pass
- [ ] New sessions should now use `opus[1m]` (or whatever `CLAUDE_MODEL` is set to) when no DB override is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)