### PR TITLE
Build clean-room environment for Claude agent sessions

### DIFF
--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -267,6 +267,16 @@ The SDK's `canUseTool` callback handles interactive tools:
 - **ExitPlanMode**: Similar flow — user approves/rejects the plan.
 - **All other tools**: Auto-approved (`bypassPermissions` mode).
 
+### Agent Environment
+
+Agent sessions run with a **clean-room environment** — they do NOT inherit the Next.js server's `process.env`. Instead, the environment is built from scratch:
+
+1. **Base**: A login shell (`env -i bash -l -c env`) provides `PATH`, `HOME`, `LANG`, etc. from `~/.bashrc` — cached at first use since it doesn't change at runtime.
+2. **Explicit tokens**: Only `GITHUB_TOKEN` (for git operations) and `CLAUDE_CODE_OAUTH_TOKEN` (for the Claude API, from DB setting or server env fallback) are added.
+3. **User-defined env vars**: Global and per-repo env vars from the database are merged on top (per-repo takes precedence).
+
+This ensures server secrets (`PASSWORD_HASH`, `ENCRYPTION_KEY`, `DATABASE_URL`) are never exposed to agent sessions.
+
 ### Streaming
 
 The SDK emits `stream_event` messages which are accumulated by `StreamAccumulator` into partial assistant messages for real-time UI updates. These are emitted to the browser via SSE but not persisted.

--- a/src/server/routers/claude.ts
+++ b/src/server/routers/claude.ts
@@ -74,6 +74,8 @@ export const claudeRouter = router({
         customSystemPrompt: settings.customSystemPrompt,
         globalSettings: settings.globalSettings,
         claudeModel: settings.claudeModel,
+        claudeApiKey: settings.claudeApiKey,
+        envVars: settings.envVars,
         mcpServers: settings.mcpServers,
       }).catch((err) => {
         log.error('Claude command failed', toError(err), { sessionId: input.sessionId });

--- a/src/server/services/claude-runner.test.ts
+++ b/src/server/services/claude-runner.test.ts
@@ -48,6 +48,10 @@ import {
   isClaudeRunning,
   isClaudeRunningAsync,
   markAllSessionsStopped,
+  parseShellEnv,
+  buildAgentEnv,
+  getBaseShellEnv,
+  resetBaseShellEnvCache,
 } from './claude-runner';
 
 describe('claude-runner', () => {
@@ -159,6 +163,141 @@ describe('claude-runner', () => {
       mockPrisma.session.updateMany.mockResolvedValue({ count: 0 });
       const result = await markAllSessionsStopped();
       expect(result).toBe(0);
+    });
+  });
+
+  describe('parseShellEnv', () => {
+    it('parses null-delimited env output', () => {
+      const input = 'HOME=/home/user\0PATH=/usr/bin:/bin\0LANG=en_US.UTF-8\0';
+      const result = parseShellEnv(input);
+      expect(result).toEqual({
+        HOME: '/home/user',
+        PATH: '/usr/bin:/bin',
+        LANG: 'en_US.UTF-8',
+      });
+    });
+
+    it('handles values containing equals signs', () => {
+      const input = 'FOO=bar=baz\0';
+      const result = parseShellEnv(input);
+      expect(result).toEqual({ FOO: 'bar=baz' });
+    });
+
+    it('handles empty input', () => {
+      expect(parseShellEnv('')).toEqual({});
+    });
+
+    it('handles values containing newlines', () => {
+      const input = 'MULTI=line1\nline2\0SIMPLE=value\0';
+      const result = parseShellEnv(input);
+      expect(result).toEqual({
+        MULTI: 'line1\nline2',
+        SIMPLE: 'value',
+      });
+    });
+
+    it('skips entries without an equals sign', () => {
+      const input = 'VALID=yes\0invalid\0ALSO_VALID=yep\0';
+      const result = parseShellEnv(input);
+      expect(result).toEqual({
+        VALID: 'yes',
+        ALSO_VALID: 'yep',
+      });
+    });
+
+    it('handles empty values', () => {
+      const input = 'EMPTY=\0';
+      const result = parseShellEnv(input);
+      expect(result).toEqual({ EMPTY: '' });
+    });
+  });
+
+  describe('getBaseShellEnv', () => {
+    beforeEach(() => {
+      resetBaseShellEnvCache();
+    });
+
+    it('returns a shell environment with PATH and HOME', async () => {
+      const env = await getBaseShellEnv();
+      expect(env.PATH).toBeDefined();
+      expect(env.PATH).toContain('/usr');
+      expect(env.HOME).toBeDefined();
+    });
+
+    it('does not include server secrets', async () => {
+      const env = await getBaseShellEnv();
+      expect(env.PASSWORD_HASH).toBeUndefined();
+      expect(env.ENCRYPTION_KEY).toBeUndefined();
+      expect(env.DATABASE_URL).toBeUndefined();
+      expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+      expect(env.GITHUB_TOKEN).toBeUndefined();
+    });
+
+    it('caches the result across calls', async () => {
+      const env1 = await getBaseShellEnv();
+      const env2 = await getBaseShellEnv();
+      expect(env1).toBe(env2); // Same reference = cached
+    });
+  });
+
+  describe('buildAgentEnv', () => {
+    beforeEach(() => {
+      resetBaseShellEnvCache();
+    });
+
+    it('includes base shell env vars like PATH', async () => {
+      const env = await buildAgentEnv({});
+      expect(env.PATH).toBeDefined();
+      expect(env.HOME).toBeDefined();
+    });
+
+    it('does not include server secrets from process.env', async () => {
+      const env = await buildAgentEnv({});
+      expect(env.PASSWORD_HASH).toBeUndefined();
+      expect(env.ENCRYPTION_KEY).toBeUndefined();
+      expect(env.DATABASE_URL).toBeUndefined();
+    });
+
+    it('sets GITHUB_TOKEN when provided', async () => {
+      const env = await buildAgentEnv({ githubToken: 'ghp_test123' });
+      expect(env.GITHUB_TOKEN).toBe('ghp_test123');
+    });
+
+    it('sets CLAUDE_CODE_OAUTH_TOKEN when claudeApiKey is provided', async () => {
+      const env = await buildAgentEnv({ claudeApiKey: 'sk-ant-test' });
+      expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe('sk-ant-test');
+    });
+
+    it('does not set tokens when not provided', async () => {
+      const env = await buildAgentEnv({});
+      expect(env.GITHUB_TOKEN).toBeUndefined();
+      expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+    });
+
+    it('merges user-defined env vars', async () => {
+      const env = await buildAgentEnv({
+        envVars: [
+          { name: 'MY_API_KEY', value: 'secret123' },
+          { name: 'DEBUG', value: 'true' },
+        ],
+      });
+      expect(env.MY_API_KEY).toBe('secret123');
+      expect(env.DEBUG).toBe('true');
+    });
+
+    it('user env vars override base shell env', async () => {
+      const env = await buildAgentEnv({
+        envVars: [{ name: 'HOME', value: '/custom/home' }],
+      });
+      expect(env.HOME).toBe('/custom/home');
+    });
+
+    it('user env vars can override explicit tokens', async () => {
+      const env = await buildAgentEnv({
+        githubToken: 'ghp_default',
+        envVars: [{ name: 'GITHUB_TOKEN', value: 'ghp_override' }],
+      });
+      expect(env.GITHUB_TOKEN).toBe('ghp_override');
     });
   });
 });

--- a/src/server/services/claude-runner.ts
+++ b/src/server/services/claude-runner.ts
@@ -11,6 +11,7 @@
  */
 
 import { query, type McpServerConfig } from '@anthropic-ai/claude-agent-sdk';
+import { execFile } from 'child_process';
 import { prisma } from '@/lib/prisma';
 import { getMessageType } from '@/lib/claude-messages';
 import { extractRepoFullName } from '@/lib/utils';
@@ -20,11 +21,111 @@ import { createLogger, toError } from '@/lib/logger';
 import { fetchPullRequestForBranch } from './github';
 import { getCurrentBranch } from './worktree-manager';
 import { StreamAccumulator } from './stream-accumulator';
+import type { ContainerEnvVar } from './repo-settings';
 
 const log = createLogger('claude-runner');
 
 // Namespace UUID for generating deterministic IDs from error content
 const ERROR_LINE_NAMESPACE = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
+
+/**
+ * Parse null-delimited `env -0` output into a Record.
+ * Each entry is KEY=VALUE separated by null bytes.
+ */
+export function parseShellEnv(envOutput: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  // Split on null bytes, filter empty trailing entry
+  const entries = envOutput.split('\0').filter((e) => e.length > 0);
+  for (const entry of entries) {
+    const eqIndex = entry.indexOf('=');
+    if (eqIndex > 0) {
+      env[entry.slice(0, eqIndex)] = entry.slice(eqIndex + 1);
+    }
+  }
+  return env;
+}
+
+/** Cached base shell environment (loaded once at first use). */
+let baseShellEnvCache: Record<string, string> | null = null;
+
+/**
+ * Get the base shell environment by spawning a clean login shell.
+ * Uses `env -i` to start with an empty environment, then `bash -l` to load
+ * the user's shell profile (~/.bashrc, etc.). This ensures the agent gets
+ * a normal shell environment (PATH, HOME, etc.) without inheriting any
+ * server-specific env vars (PASSWORD_HASH, ENCRYPTION_KEY, etc.).
+ *
+ * The result is cached since the shell environment doesn't change at runtime.
+ */
+export async function getBaseShellEnv(): Promise<Record<string, string>> {
+  if (baseShellEnvCache) return baseShellEnvCache;
+
+  const result = await new Promise<string>((resolve, reject) => {
+    execFile(
+      'env',
+      [
+        '-i',
+        `HOME=${process.env.HOME ?? '/root'}`,
+        `USER=${process.env.USER ?? 'root'}`,
+        'bash',
+        '-l',
+        '-c',
+        'env -0',
+      ],
+      { timeout: 5000 },
+      (error, stdout) => {
+        if (error) reject(error);
+        else resolve(stdout);
+      }
+    );
+  });
+
+  baseShellEnvCache = parseShellEnv(result);
+  return baseShellEnvCache;
+}
+
+/** Reset the cached shell env (for testing). */
+export function resetBaseShellEnvCache(): void {
+  baseShellEnvCache = null;
+}
+
+/**
+ * Build the environment for a Claude agent session.
+ *
+ * Starts from a clean login shell environment (no server secrets),
+ * then explicitly adds only what the agent needs:
+ * - GITHUB_TOKEN for git operations
+ * - CLAUDE_CODE_OAUTH_TOKEN for the Claude API
+ * - User-defined env vars from global + per-repo settings
+ */
+export async function buildAgentEnv(options: {
+  /** GitHub token for git push/pull */
+  githubToken?: string;
+  /** Claude API key (from DB setting or server env) */
+  claudeApiKey?: string;
+  /** User-defined env vars (already merged global + per-repo) */
+  envVars?: ContainerEnvVar[];
+}): Promise<Record<string, string | undefined>> {
+  const shellEnv = await getBaseShellEnv();
+  const agentEnv: Record<string, string | undefined> = { ...shellEnv };
+
+  // Explicitly set tokens the agent needs
+  if (options.githubToken) {
+    agentEnv.GITHUB_TOKEN = options.githubToken;
+  }
+  if (options.claudeApiKey) {
+    agentEnv.CLAUDE_CODE_OAUTH_TOKEN = options.claudeApiKey;
+  }
+
+  // Merge user-defined env vars (highest precedence)
+  if (options.envVars) {
+    for (const envVar of options.envVars) {
+      agentEnv[envVar.name] = envVar.value;
+    }
+  }
+
+  return agentEnv;
+}
 
 /**
  * State for a pending user input request (AskUserQuestion / ExitPlanMode).
@@ -172,6 +273,10 @@ export interface RunClaudeCommandOptions {
   } | null;
   /** Claude model override */
   claudeModel?: string | null;
+  /** Claude API key (from DB global settings or server env fallback) */
+  claudeApiKey?: string | null;
+  /** User-defined environment variables (merged global + per-repo) */
+  envVars?: ContainerEnvVar[];
   /** MCP server configurations passed to the SDK */
   mcpServers?: Array<
     | {
@@ -240,6 +345,13 @@ export async function runClaudeCommand(options: RunClaudeCommandOptions): Promis
       )
     : undefined;
 
+  // Build clean-room environment for the agent
+  const agentEnv = await buildAgentEnv({
+    githubToken: process.env.GITHUB_TOKEN,
+    claudeApiKey: options.claudeApiKey ?? process.env.CLAUDE_CODE_OAUTH_TOKEN,
+    envVars: options.envVars,
+  });
+
   // Determine if we should resume (has existing messages)
   const existingMessages = await prisma.message.count({
     where: { sessionId },
@@ -287,6 +399,7 @@ export async function runClaudeCommand(options: RunClaudeCommandOptions): Promis
     allowDangerouslySkipPermissions: true,
     includePartialMessages: true,
     cwd: workingDir,
+    env: agentEnv,
     settingSources: ['project'],
     systemPrompt: {
       type: 'preset' as const,

--- a/vitest.component.config.ts
+++ b/vitest.component.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from 'vitest/config';
 import path from 'path';
 
 export default defineConfig({
+  define: {
+    'process.env.NODE_ENV': JSON.stringify('test'),
+  },
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
## Summary
- Agent sessions no longer inherit the server's `process.env`, which contained secrets like `PASSWORD_HASH`, `ENCRYPTION_KEY`, and `DATABASE_URL`
- Environment is now built from a clean login shell (`env -i bash -l`), then only `GITHUB_TOKEN` and `CLAUDE_CODE_OAUTH_TOKEN` are explicitly added
- User-defined env vars (global + per-repo) are now actually passed to the SDK — they were previously loaded/merged but silently discarded
- Also wires through the `claudeApiKey` from global settings (DB-configured Claude API key override)

## Test plan
- [x] 17 new unit tests for `parseShellEnv`, `getBaseShellEnv`, and `buildAgentEnv`
- [x] All 378 unit tests pass (`pnpm test:unit`)
- [x] All 92 component tests pass (`pnpm test:component`)
- [x] TypeScript typecheck passes
- [ ] Manual: verify a session can still run Claude queries (PATH, tokens available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)