### PR TITLE
Fix crash when selecting a repo with no branches

### DIFF
--- a/src/components/BranchSelector.tsx
+++ b/src/components/BranchSelector.tsx
@@ -39,11 +39,11 @@ export function BranchSelector({
     if (
       data?.defaultBranch &&
       !selectedBranch &&
-      branches.some((b) => b.name === data.defaultBranch)
+      data.branches.some((b) => b.name === data.defaultBranch)
     ) {
       handleSelect(data.defaultBranch);
     }
-  }, [data, selectedBranch, branches, handleSelect]);
+  }, [data, selectedBranch, handleSelect]);
 
   if (isLoading) {
     return (

--- a/src/components/BranchSelector.tsx
+++ b/src/components/BranchSelector.tsx
@@ -33,11 +33,17 @@ export function BranchSelector({
     [onSelect]
   );
 
+  const branches = data?.branches ?? [];
+
   useEffect(() => {
-    if (data?.defaultBranch && !selectedBranch) {
+    if (
+      data?.defaultBranch &&
+      !selectedBranch &&
+      branches.some((b) => b.name === data.defaultBranch)
+    ) {
       handleSelect(data.defaultBranch);
     }
-  }, [data, selectedBranch, handleSelect]);
+  }, [data, selectedBranch, branches, handleSelect]);
 
   if (isLoading) {
     return (
@@ -48,7 +54,16 @@ export function BranchSelector({
     );
   }
 
-  const branches = data?.branches || [];
+  if (branches.length === 0) {
+    return (
+      <div className="space-y-2">
+        <Label>Branch</Label>
+        <p className="text-sm text-muted-foreground">
+          No branches found. The repository may be empty.
+        </p>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-2">


### PR DESCRIPTION
## Summary
- When selecting a newly created repo (like `brendanlong/personal-agent-skills`) with no branches, the New Session page would crash
- The GitHub API returns `{"branches":[],"defaultBranch":"main"}` — BranchSelector would auto-select "main" even though it didn't exist in the empty branches list, causing the Select component to crash
- Now checks that `defaultBranch` actually exists in the branches array before auto-selecting
- Shows a "No branches found" message when the branches list is empty

## Test plan
- [x] All 362 existing tests pass
- [ ] Select a repo with no branches — should show "No branches found" instead of crashing
- [ ] Select a repo with branches — should auto-select default branch as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)