### PR TITLE
Fix session stuck in Stopping state when interrupt hangs

### DIFF
--- a/src/hooks/useClaudeState.ts
+++ b/src/hooks/useClaudeState.ts
@@ -61,7 +61,13 @@ export function useClaudeState(sessionId: string) {
   );
 
   const sendMutation = trpc.claude.send.useMutation();
-  const interruptMutation = trpc.claude.interrupt.useMutation();
+  const interruptMutation = trpc.claude.interrupt.useMutation({
+    onError: () => {
+      // If interrupt fails (e.g. timeout), refetch running state
+      // so the UI doesn't stay stuck on "Interrupting..."
+      void refetch();
+    },
+  });
   const answerMutation = trpc.claude.answerQuestion.useMutation();
 
   const send = useCallback(

--- a/src/hooks/useSessionState.ts
+++ b/src/hooks/useSessionState.ts
@@ -41,6 +41,11 @@ export function useSessionState(sessionId: string) {
     onSuccess: (data) => {
       utils.sessions.get.setData({ sessionId }, { session: data.session });
     },
+    onError: () => {
+      // If the stop mutation fails (e.g. timeout or server error),
+      // refetch session state so we don't stay stuck on "Stopping..."
+      void refetch();
+    },
   });
 
   // The API endpoint is "delete" but it now archives instead of permanently deleting

--- a/src/server/services/claude-runner.ts
+++ b/src/server/services/claude-runner.ts
@@ -731,12 +731,24 @@ export async function markLastMessageAsInterrupted(sessionId: string): Promise<v
 }
 
 /**
- * Force-clean a session's in-memory state without waiting for the SDK.
- * Used as a fallback when interrupt/close hangs or fails.
+ * Force-clean a session's in-memory state and kill the subprocess.
+ * Used as a fallback when interrupt() hangs or fails.
+ *
+ * Calls close() on the query to trigger the SDK's subprocess kill
+ * (SIGTERM immediately, SIGKILL after 5s), then cleans up our state.
  */
 function forceCleanSession(sessionId: string): void {
   const state = sessions.get(sessionId);
   if (!state) return;
+
+  // close() is synchronous (fire-and-forget) and kills the subprocess
+  if (state.currentQuery) {
+    try {
+      state.currentQuery.close();
+    } catch {
+      // Ignore close errors
+    }
+  }
 
   if (state.pendingInput) {
     state.pendingInput.reject(new Error('Session force-cleaned'));

--- a/src/server/services/claude-runner.ts
+++ b/src/server/services/claude-runner.ts
@@ -604,7 +604,20 @@ export function getPendingInput(
 }
 
 /**
+ * Race a promise against a timeout. Resolves with `undefined` if the timeout fires first.
+ */
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T | undefined> {
+  return Promise.race([
+    promise,
+    new Promise<undefined>((resolve) => setTimeout(() => resolve(undefined), ms)),
+  ]);
+}
+
+const INTERRUPT_TIMEOUT_MS = 5_000;
+
+/**
  * Interrupt a running Claude query.
+ * Uses a timeout to prevent hanging if the SDK's interrupt() never resolves.
  */
 export async function interruptClaude(sessionId: string): Promise<boolean> {
   const state = sessions.get(sessionId);
@@ -614,10 +627,18 @@ export async function interruptClaude(sessionId: string): Promise<boolean> {
   }
 
   try {
-    await state.currentQuery.interrupt();
+    const result = await withTimeout(state.currentQuery.interrupt(), INTERRUPT_TIMEOUT_MS);
+    if (result === undefined) {
+      log.warn('interruptClaude: Timed out, force-cleaning state', { sessionId });
+      forceCleanSession(sessionId);
+    }
     return true;
   } catch (err) {
-    log.warn('interruptClaude: Failed', { sessionId, error: toError(err).message });
+    log.warn('interruptClaude: Failed, force-cleaning state', {
+      sessionId,
+      error: toError(err).message,
+    });
+    forceCleanSession(sessionId);
     return false;
   }
 }
@@ -707,6 +728,25 @@ export async function markLastMessageAsInterrupted(sessionId: string): Promise<v
     content: interruptContent,
     createdAt: new Date(),
   });
+}
+
+/**
+ * Force-clean a session's in-memory state without waiting for the SDK.
+ * Used as a fallback when interrupt/close hangs or fails.
+ */
+function forceCleanSession(sessionId: string): void {
+  const state = sessions.get(sessionId);
+  if (!state) return;
+
+  if (state.pendingInput) {
+    state.pendingInput.reject(new Error('Session force-cleaned'));
+    state.pendingInput = null;
+  }
+
+  state.isRunning = false;
+  state.currentQuery = null;
+  sessions.delete(sessionId);
+  sseEvents.emitClaudeRunning(sessionId, false);
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fixes sessions getting permanently stuck in "Stopping..." state when the SDK's `interrupt()` or `close()` calls hang
- The stuck session `cfe89d5c-9ebf-4240-bf7c-7b6ae2ef6da9` was manually fixed in the prod DB
- Adds a 5-second timeout to `interruptClaude()` with fallback to force-clean the in-memory state
- Adds `onError` handlers to the client-side stop/interrupt mutations so the UI recovers by refetching state instead of showing "Stopping..." forever

## Root cause

The SDK's `interrupt()` can hang indefinitely if the agent is already dead or unresponsive. Since `claude.interrupt` awaits this call, the HTTP request never completes, and the client's mutation stays in `isPending` state forever.

## Test plan

- [x] All 369 existing tests pass
- [x] TypeScript compiles cleanly
- [ ] Test stopping a session that has no active agent (should complete immediately)
- [ ] Test stopping a session with an active agent (should complete within 5 seconds even if SDK hangs)
- [ ] Test that UI recovers from a failed stop attempt (should refetch and show actual state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)