### PR TITLE
Fix env vars not passed to agents and server secrets leaking

### DIFF
--- a/src/server/routers/claude.ts
+++ b/src/server/routers/claude.ts
@@ -75,6 +75,8 @@ export const claudeRouter = router({
         customSystemPrompt: settings.customSystemPrompt,
         globalSettings: settings.globalSettings,
         claudeModel: settings.claudeModel,
+        envVars: settings.envVars,
+        claudeApiKey: settings.claudeApiKey,
         mcpServers: settings.mcpServers,
       }).catch((err) => {
         log.error('Claude command failed', toError(err), { sessionId: input.sessionId });

--- a/src/server/routers/sessions.ts
+++ b/src/server/routers/sessions.ts
@@ -88,6 +88,8 @@ async function setupSessionBackground(
         customSystemPrompt: settings.customSystemPrompt,
         globalSettings: settings.globalSettings,
         claudeModel: settings.claudeModel,
+        envVars: settings.envVars,
+        claudeApiKey: settings.claudeApiKey,
         mcpServers: settings.mcpServers,
       }).catch((err) => {
         log.error('Initial prompt failed', toError(err), { sessionId });

--- a/src/server/services/claude-runner.test.ts
+++ b/src/server/services/claude-runner.test.ts
@@ -43,6 +43,9 @@ vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
 
 import {
   buildSystemPrompt,
+  buildAgentEnv,
+  getBaseEnv,
+  resetBaseEnvCache,
   mergeSlashCommands,
   getSessionCommands,
   answerUserInput,
@@ -55,6 +58,81 @@ import {
 describe('claude-runner', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  describe('getBaseEnv', () => {
+    beforeEach(() => {
+      resetBaseEnvCache();
+    });
+
+    it('should capture environment from a login shell', async () => {
+      const baseEnv = await getBaseEnv();
+      // A login shell should always have PATH and HOME
+      expect(baseEnv.PATH).toBeDefined();
+      expect(baseEnv.HOME).toBeDefined();
+    });
+
+    it('should not include server-specific env vars', async () => {
+      // These are set in the server process but should not appear
+      // in a fresh login shell's environment
+      const baseEnv = await getBaseEnv();
+      expect(baseEnv.PASSWORD_HASH).toBeUndefined();
+      expect(baseEnv.ENCRYPTION_KEY).toBeUndefined();
+      expect(baseEnv.DATABASE_URL).toBeUndefined();
+      expect(baseEnv.NEXT_RUNTIME).toBeUndefined();
+    });
+
+    it('should cache results across calls', async () => {
+      const first = await getBaseEnv();
+      const second = await getBaseEnv();
+      expect(first).toBe(second); // Same reference = cached
+    });
+  });
+
+  describe('buildAgentEnv', () => {
+    beforeEach(() => {
+      resetBaseEnvCache();
+    });
+
+    it('should include base env vars from login shell', async () => {
+      const env = await buildAgentEnv([]);
+      // Should have standard shell vars
+      expect(env.PATH).toBeDefined();
+      expect(env.HOME).toBeDefined();
+    });
+
+    it('should not include server-only env vars', async () => {
+      const env = await buildAgentEnv([]);
+      expect(env.PASSWORD_HASH).toBeUndefined();
+      expect(env.ENCRYPTION_KEY).toBeUndefined();
+      expect(env.DATABASE_URL).toBeUndefined();
+    });
+
+    it('should overlay user-configured env vars', async () => {
+      const env = await buildAgentEnv([
+        { name: 'MY_API_KEY', value: 'key-123' },
+        { name: 'MY_SECRET', value: 'decrypted-secret' },
+      ]);
+      expect(env.MY_API_KEY).toBe('key-123');
+      expect(env.MY_SECRET).toBe('decrypted-secret');
+    });
+
+    it('should allow user env vars to override base env vars', async () => {
+      const env = await buildAgentEnv([{ name: 'HOME', value: '/custom/home' }]);
+      expect(env.HOME).toBe('/custom/home');
+    });
+
+    it('should set CLAUDE_CODE_OAUTH_TOKEN when claudeApiKey is provided', async () => {
+      const env = await buildAgentEnv([], 'custom-api-key');
+      expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe('custom-api-key');
+    });
+
+    it('should not set CLAUDE_CODE_OAUTH_TOKEN when claudeApiKey is null', async () => {
+      const env = await buildAgentEnv([], null);
+      // Should not have CLAUDE_CODE_OAUTH_TOKEN from the server process
+      // (it wouldn't be in a clean login shell either)
+      expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+    });
   });
 
   describe('buildSystemPrompt', () => {

--- a/src/server/services/claude-runner.test.ts
+++ b/src/server/services/claude-runner.test.ts
@@ -87,6 +87,13 @@ describe('claude-runner', () => {
       const second = await getBaseEnv();
       expect(first).toBe(second); // Same reference = cached
     });
+
+    it('should coalesce concurrent calls', async () => {
+      // Fire two calls before the first resolves
+      const [first, second] = await Promise.all([getBaseEnv(), getBaseEnv()]);
+      // Both should return the same cached object
+      expect(first).toBe(second);
+    });
   });
 
   describe('buildAgentEnv', () => {
@@ -132,6 +139,15 @@ describe('claude-runner', () => {
       // Should not have CLAUDE_CODE_OAUTH_TOKEN from the server process
       // (it wouldn't be in a clean login shell either)
       expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+    });
+
+    it('should allow per-repo env var to override claudeApiKey', async () => {
+      const env = await buildAgentEnv(
+        [{ name: 'CLAUDE_CODE_OAUTH_TOKEN', value: 'per-repo-key' }],
+        'global-api-key'
+      );
+      // Per-repo env var should take precedence over global API key
+      expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe('per-repo-key');
     });
   });
 

--- a/src/server/services/claude-runner.ts
+++ b/src/server/services/claude-runner.ts
@@ -20,6 +20,7 @@ import { createLogger, toError } from '@/lib/logger';
 import { fetchPullRequestForBranch } from './github';
 import { getCurrentBranch } from './worktree-manager';
 import { StreamAccumulator } from './stream-accumulator';
+import type { ContainerEnvVar } from './repo-settings';
 
 const log = createLogger('claude-runner');
 
@@ -190,6 +191,112 @@ function getSessionState(sessionId: string, workingDir: string): SessionState {
   return state;
 }
 
+/**
+ * Cached base environment from a fresh login shell.
+ * Populated lazily on first call to getBaseEnv().
+ * This gives us the user's default shell environment (PATH, HOME, etc.)
+ * without any of the server's runtime env vars (PASSWORD_HASH, ENCRYPTION_KEY, etc.).
+ */
+let cachedBaseEnv: Record<string, string> | null = null;
+
+/**
+ * Get the base environment by spawning a fresh login shell.
+ * Uses `env -0` for null-separated output to safely handle values with newlines.
+ * Result is cached for the lifetime of the process.
+ */
+export async function getBaseEnv(): Promise<Record<string, string>> {
+  if (cachedBaseEnv) return cachedBaseEnv;
+
+  const { execFile } = await import('child_process');
+  const { promisify } = await import('util');
+  const execFileAsync = promisify(execFile);
+
+  try {
+    // Spawn a fresh login shell and capture its environment.
+    // -l: login shell (sources .profile, .bash_profile, etc.)
+    // env -0: null-separated output for safe parsing
+    //
+    // We seed with the minimal vars that the OS login process normally provides
+    // (HOME, USER, SHELL, LOGNAME, PATH) so profile scripts can source properly.
+    // This avoids inheriting any server-specific vars from process.env.
+    const seedEnv: Record<string, string> = {};
+    for (const key of ['HOME', 'USER', 'SHELL', 'LOGNAME', 'PATH', 'LANG', 'TERM']) {
+      if (process.env[key]) seedEnv[key] = process.env[key]!;
+    }
+    const { stdout } = await execFileAsync('bash', ['-lc', 'env -0'], {
+      timeout: 5000,
+      maxBuffer: 1024 * 1024,
+      env: seedEnv,
+    });
+
+    const baseEnv: Record<string, string> = {};
+    for (const entry of stdout.split('\0')) {
+      if (!entry) continue;
+      const eqIdx = entry.indexOf('=');
+      if (eqIdx === -1) continue;
+      baseEnv[entry.slice(0, eqIdx)] = entry.slice(eqIdx + 1);
+    }
+
+    cachedBaseEnv = baseEnv;
+    log.info('Captured base environment from login shell', {
+      varCount: Object.keys(baseEnv).length,
+    });
+    return baseEnv;
+  } catch (err) {
+    log.error(
+      'Failed to capture base environment from login shell, falling back to minimal env',
+      toError(err)
+    );
+    // Fallback: use a minimal set of essential vars from process.env
+    const fallback: Record<string, string> = {};
+    for (const key of [
+      'PATH',
+      'HOME',
+      'USER',
+      'SHELL',
+      'LANG',
+      'TERM',
+      'TMPDIR',
+      'XDG_RUNTIME_DIR',
+    ]) {
+      if (process.env[key]) fallback[key] = process.env[key]!;
+    }
+    cachedBaseEnv = fallback;
+    return fallback;
+  }
+}
+
+/** Reset the cached base env (for testing). */
+export function resetBaseEnvCache(): void {
+  cachedBaseEnv = null;
+}
+
+/**
+ * Build the environment variables to pass to the Claude SDK.
+ *
+ * Starts with a fresh login shell's environment (so agents get PATH, HOME, etc.
+ * but NOT server secrets like PASSWORD_HASH), then overlays user-configured env vars.
+ */
+export async function buildAgentEnv(
+  userEnvVars: ContainerEnvVar[],
+  claudeApiKey?: string | null
+): Promise<Record<string, string | undefined>> {
+  const baseEnv = await getBaseEnv();
+  const agentEnv: Record<string, string | undefined> = { ...baseEnv };
+
+  // Overlay user-configured env vars (merged global + per-repo, already decrypted)
+  for (const { name, value } of userEnvVars) {
+    agentEnv[name] = value;
+  }
+
+  // Override Claude API key if configured in settings
+  if (claudeApiKey) {
+    agentEnv['CLAUDE_CODE_OAUTH_TOKEN'] = claudeApiKey;
+  }
+
+  return agentEnv;
+}
+
 export interface RunClaudeCommandOptions {
   sessionId: string;
   prompt: string;
@@ -204,6 +311,10 @@ export interface RunClaudeCommandOptions {
   } | null;
   /** Claude model override */
   claudeModel?: string | null;
+  /** Environment variables to pass to the agent (merged global + per-repo, decrypted) */
+  envVars?: ContainerEnvVar[];
+  /** Claude API key override from settings */
+  claudeApiKey?: string | null;
   /** MCP server configurations passed to the SDK */
   mcpServers?: Array<
     | {
@@ -312,9 +423,13 @@ export async function runClaudeCommand(options: RunClaudeCommandOptions): Promis
   // Emit Claude running event
   sseEvents.emitClaudeRunning(sessionId, true);
 
+  // Build environment for the agent
+  const agentEnv = await buildAgentEnv(options.envVars ?? [], options.claudeApiKey);
+
   // Build SDK query options
   const denyAllTools = options.denyAllTools ?? false;
   const sdkOptions: Parameters<typeof query>[0]['options'] = {
+    env: agentEnv,
     permissionMode: 'bypassPermissions' as const,
     allowDangerouslySkipPermissions: true,
     includePartialMessages: true,

--- a/src/server/services/claude-runner.ts
+++ b/src/server/services/claude-runner.ts
@@ -257,7 +257,7 @@ async function fetchBaseEnv(): Promise<Record<string, string>> {
     const { stdout } = await execFileAsync('bash', ['-lc', 'env -0'], {
       timeout: 5000,
       maxBuffer: 1024 * 1024,
-      env: seedEnv,
+      env: seedEnv as NodeJS.ProcessEnv,
     });
 
     const baseEnv: Record<string, string> = {};

--- a/src/server/services/claude-runner.ts
+++ b/src/server/services/claude-runner.ts
@@ -10,6 +10,8 @@
  * parking a promise that resolves when the user answers via tRPC.
  */
 
+import { execFile } from 'child_process';
+import { promisify } from 'util';
 import { query, type McpServerConfig, type SlashCommand } from '@anthropic-ai/claude-agent-sdk';
 import { prisma } from '@/lib/prisma';
 import { getMessageType, SystemInitContentSchema } from '@/lib/claude-messages';
@@ -21,6 +23,8 @@ import { fetchPullRequestForBranch } from './github';
 import { getCurrentBranch } from './worktree-manager';
 import { StreamAccumulator } from './stream-accumulator';
 import type { ContainerEnvVar } from './repo-settings';
+
+const execFileAsync = promisify(execFile);
 
 const log = createLogger('claude-runner');
 
@@ -192,6 +196,23 @@ function getSessionState(sessionId: string, workingDir: string): SessionState {
 }
 
 /**
+ * Env vars to seed the login shell with (and to use as fallback).
+ * These are the minimal vars that the OS login process normally provides
+ * so profile scripts can source properly.
+ */
+const SEED_ENV_VARS = [
+  'HOME',
+  'USER',
+  'SHELL',
+  'LOGNAME',
+  'PATH',
+  'LANG',
+  'TERM',
+  'TMPDIR',
+  'XDG_RUNTIME_DIR',
+];
+
+/**
  * Cached base environment from a fresh login shell.
  * Populated lazily on first call to getBaseEnv().
  * This gives us the user's default shell environment (PATH, HOME, etc.)
@@ -199,28 +220,38 @@ function getSessionState(sessionId: string, workingDir: string): SessionState {
  */
 let cachedBaseEnv: Record<string, string> | null = null;
 
+/** In-flight promise for getBaseEnv() to coalesce concurrent calls. */
+let pendingBaseEnv: Promise<Record<string, string>> | null = null;
+
 /**
  * Get the base environment by spawning a fresh login shell.
  * Uses `env -0` for null-separated output to safely handle values with newlines.
- * Result is cached for the lifetime of the process.
+ * Successfully captured env is cached for the lifetime of the process.
+ * Concurrent calls are coalesced into a single shell spawn.
  */
 export async function getBaseEnv(): Promise<Record<string, string>> {
   if (cachedBaseEnv) return cachedBaseEnv;
+  if (pendingBaseEnv) return pendingBaseEnv;
 
-  const { execFile } = await import('child_process');
-  const { promisify } = await import('util');
-  const execFileAsync = promisify(execFile);
+  pendingBaseEnv = fetchBaseEnv();
+  try {
+    return await pendingBaseEnv;
+  } finally {
+    pendingBaseEnv = null;
+  }
+}
 
+async function fetchBaseEnv(): Promise<Record<string, string>> {
   try {
     // Spawn a fresh login shell and capture its environment.
     // -l: login shell (sources .profile, .bash_profile, etc.)
     // env -0: null-separated output for safe parsing
     //
     // We seed with the minimal vars that the OS login process normally provides
-    // (HOME, USER, SHELL, LOGNAME, PATH) so profile scripts can source properly.
+    // so profile scripts can source properly.
     // This avoids inheriting any server-specific vars from process.env.
     const seedEnv: Record<string, string> = {};
-    for (const key of ['HOME', 'USER', 'SHELL', 'LOGNAME', 'PATH', 'LANG', 'TERM']) {
+    for (const key of SEED_ENV_VARS) {
       if (process.env[key]) seedEnv[key] = process.env[key]!;
     }
     const { stdout } = await execFileAsync('bash', ['-lc', 'env -0'], {
@@ -247,21 +278,12 @@ export async function getBaseEnv(): Promise<Record<string, string>> {
       'Failed to capture base environment from login shell, falling back to minimal env',
       toError(err)
     );
-    // Fallback: use a minimal set of essential vars from process.env
+    // Fallback: use a minimal set of essential vars from process.env.
+    // NOT cached so a retry can succeed if the failure was transient.
     const fallback: Record<string, string> = {};
-    for (const key of [
-      'PATH',
-      'HOME',
-      'USER',
-      'SHELL',
-      'LANG',
-      'TERM',
-      'TMPDIR',
-      'XDG_RUNTIME_DIR',
-    ]) {
+    for (const key of SEED_ENV_VARS) {
       if (process.env[key]) fallback[key] = process.env[key]!;
     }
-    cachedBaseEnv = fallback;
     return fallback;
   }
 }
@@ -269,6 +291,7 @@ export async function getBaseEnv(): Promise<Record<string, string>> {
 /** Reset the cached base env (for testing). */
 export function resetBaseEnvCache(): void {
   cachedBaseEnv = null;
+  pendingBaseEnv = null;
 }
 
 /**
@@ -284,14 +307,16 @@ export async function buildAgentEnv(
   const baseEnv = await getBaseEnv();
   const agentEnv: Record<string, string | undefined> = { ...baseEnv };
 
-  // Overlay user-configured env vars (merged global + per-repo, already decrypted)
-  for (const { name, value } of userEnvVars) {
-    agentEnv[name] = value;
-  }
-
-  // Override Claude API key if configured in settings
+  // Apply global Claude API key before user env vars, so per-repo
+  // CLAUDE_CODE_OAUTH_TOKEN env vars can override the global key.
   if (claudeApiKey) {
     agentEnv['CLAUDE_CODE_OAUTH_TOKEN'] = claudeApiKey;
+  }
+
+  // Overlay user-configured env vars (merged global + per-repo, already decrypted).
+  // Applied last so per-repo vars take highest precedence.
+  for (const { name, value } of userEnvVars) {
+    agentEnv[name] = value;
   }
 
   return agentEnv;


### PR DESCRIPTION
## Summary

- **User-configured env vars never reached agents**: `settings.envVars` was computed by `loadMergedSessionSettings()` (global + per-repo, decrypted) but never passed to `runClaudeCommand()` — the `envVars` field didn't exist on `RunClaudeCommandOptions` at all.
- **Server secrets leaked to agents**: The SDK defaults `env` to `process.env` when not explicitly set, so agents could see `PASSWORD_HASH`, `ENCRYPTION_KEY`, `DATABASE_URL`, etc.

### Changes

1. **`getBaseEnv()`** (new): Spawns a fresh login shell (`bash -lc 'env -0'`) and captures its environment. This gives agents the user's standard shell env (PATH, HOME, etc.) without any server-specific vars. Seeded with minimal OS-level vars (HOME, USER, SHELL, LOGNAME, PATH, LANG, TERM) so profile scripts can run. Result is cached for the process lifetime. Falls back to a minimal env on failure.
2. **`buildAgentEnv()`** (new, exported, tested): Builds the full agent env by starting from the login shell's env, overlaying user-configured env vars (merged global + per-repo, already decrypted), and applying the Claude API key override.
3. **`RunClaudeCommandOptions`**: Added `envVars` and `claudeApiKey` fields.
4. **`claude.ts` and `sessions.ts` routers**: Now pass `settings.envVars` and `settings.claudeApiKey` when calling `runClaudeCommand()`.
5. **SDK `query()` call**: Now passes `env: agentEnv` explicitly instead of inheriting `process.env`.

## Test plan

- [x] 3 tests for `getBaseEnv()`: captures PATH/HOME from login shell, excludes server vars, caches results
- [x] 6 tests for `buildAgentEnv()`: includes login shell vars, excludes server vars, overlays user vars, overrides base vars, handles Claude API key
- [x] All 378 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)