### PR TITLE
Fix slash commands always returning empty

### DIFF
--- a/src/server/routers/sessions.integration.test.ts
+++ b/src/server/routers/sessions.integration.test.ts
@@ -19,7 +19,8 @@ vi.mock('../services/worktree-manager', () => ({
 vi.mock('../services/claude-runner', () => ({
   buildSystemPrompt: vi.fn().mockReturnValue('test system prompt'),
   runClaudeCommand: vi.fn().mockResolvedValue(undefined),
-  stopSession: vi.fn().mockResolvedValue(undefined),
+  stopSession: vi.fn(),
+  cleanupSession: vi.fn(),
 }));
 
 // Mock settings-merger

--- a/src/server/routers/sessions.ts
+++ b/src/server/routers/sessions.ts
@@ -9,7 +9,7 @@ import {
   getSessionWorkingDir,
 } from '../services/worktree-manager';
 import { loadMergedSessionSettings } from '../services/settings-merger';
-import { runClaudeCommand, stopSession } from '../services/claude-runner';
+import { runClaudeCommand, stopSession, cleanupSession } from '../services/claude-runner';
 import { sseEvents } from '../services/events';
 import { createLogger, toError } from '@/lib/logger';
 import { env } from '@/lib/env';
@@ -276,8 +276,8 @@ export const sessionsRouter = router({
         return { success: true };
       }
 
-      // Stop any running query
-      await stopSession(input.sessionId);
+      // Stop any running query and clean up all in-memory state
+      cleanupSession(input.sessionId);
 
       // Remove workspace directory
       await removeWorkspace(session.id);

--- a/src/server/services/claude-runner.test.ts
+++ b/src/server/services/claude-runner.test.ts
@@ -53,6 +53,9 @@ import {
   isClaudeRunning,
   isClaudeRunningAsync,
   markAllSessionsStopped,
+  cleanupSession,
+  _setPersistedCommands,
+  _clearPersistedCommands,
 } from './claude-runner';
 
 describe('claude-runner', () => {
@@ -280,6 +283,37 @@ describe('claude-runner', () => {
   describe('getSessionCommands', () => {
     it('should return empty array for nonexistent sessions', () => {
       expect(getSessionCommands('nonexistent-session')).toEqual([]);
+    });
+
+    it('should return persisted commands after they are set', () => {
+      const sessionId = 'test-persisted-commands';
+      const commands = [
+        { name: 'commit', description: 'Commit changes', argumentHint: '' },
+        { name: 'review', description: 'Review code', argumentHint: '<pr>' },
+      ];
+      _setPersistedCommands(sessionId, commands);
+      expect(getSessionCommands(sessionId)).toEqual(commands);
+      _clearPersistedCommands(sessionId);
+    });
+
+    it('should still return persisted commands after session state is cleaned up', () => {
+      const sessionId = 'test-persist-after-cleanup';
+      const commands = [{ name: 'compact', description: '', argumentHint: '' }];
+      _setPersistedCommands(sessionId, commands);
+      // Simulates what happens after a query completes (sessions.delete is called)
+      // getSessionCommands should still return persisted commands
+      expect(getSessionCommands(sessionId)).toEqual(commands);
+      _clearPersistedCommands(sessionId);
+    });
+
+    it('should return empty after cleanupSession removes persisted commands', () => {
+      const sessionId = 'test-cleanup-session';
+      const commands = [{ name: 'compact', description: '', argumentHint: '' }];
+      _setPersistedCommands(sessionId, commands);
+      expect(getSessionCommands(sessionId)).toEqual(commands);
+
+      cleanupSession(sessionId);
+      expect(getSessionCommands(sessionId)).toEqual([]);
     });
   });
 

--- a/src/server/services/claude-runner.ts
+++ b/src/server/services/claude-runner.ts
@@ -90,6 +90,13 @@ interface SessionState {
 /** Active sessions tracked in memory */
 const sessions = new Map<string, SessionState>();
 
+/**
+ * Persisted commands per session — survives query completion.
+ * The `sessions` map is cleared after each query, but commands should remain
+ * available so the frontend can fetch them between queries and after page reloads.
+ */
+const persistedCommands = new Map<string, SlashCommand[]>();
+
 // Default system prompt appended to all Claude sessions
 export const DEFAULT_SYSTEM_PROMPT = `IMPORTANT: The user is accessing this session remotely through a web interface and has no local access to the files. They can only see your changes through GitHub. Therefore, you MUST follow this workflow for ANY code changes:
 
@@ -188,7 +195,7 @@ function getSessionState(sessionId: string, workingDir: string): SessionState {
       currentQuery: null,
       pendingInput: null,
       workingDir,
-      commands: [],
+      commands: persistedCommands.get(sessionId) ?? [],
     };
     sessions.set(sessionId, state);
   }
@@ -292,6 +299,16 @@ async function fetchBaseEnv(): Promise<Record<string, string>> {
 export function resetBaseEnvCache(): void {
   cachedBaseEnv = null;
   pendingBaseEnv = null;
+}
+
+/** Set persisted commands for a session (for testing). */
+export function _setPersistedCommands(sessionId: string, commands: SlashCommand[]): void {
+  persistedCommands.set(sessionId, commands);
+}
+
+/** Clear persisted commands for a session (for testing). */
+export function _clearPersistedCommands(sessionId: string): void {
+  persistedCommands.delete(sessionId);
 }
 
 /**
@@ -531,6 +548,7 @@ export async function runClaudeCommand(options: RunClaudeCommandOptions): Promis
       .then((commands) => {
         const alreadyDiscovered = state.commands.map((c) => c.name);
         state.commands = mergeSlashCommands(commands, alreadyDiscovered);
+        persistedCommands.set(sessionId, state.commands);
         sseEvents.emitCommands(sessionId, state.commands);
         log.info('Emitted supported commands from SDK', {
           sessionId,
@@ -554,6 +572,7 @@ export async function runClaudeCommand(options: RunClaudeCommandOptions): Promis
         const hasNewCommands = [...newNames].some((n) => !oldNames.has(n));
         if (hasNewCommands) {
           state.commands = merged;
+          persistedCommands.set(sessionId, merged);
           sseEvents.emitCommands(sessionId, merged);
           log.info('Merged slash_commands from system init', {
             sessionId,
@@ -716,10 +735,11 @@ export function answerUserInput(sessionId: string, answers: Record<string, strin
 
 /**
  * Get cached slash commands for a session.
- * Returns commands discovered during the last query, or empty if none.
+ * Reads from the persisted map which survives query completion,
+ * falling back to the active session state during a query.
  */
 export function getSessionCommands(sessionId: string): SlashCommand[] {
-  return sessions.get(sessionId)?.commands ?? [];
+  return persistedCommands.get(sessionId) ?? sessions.get(sessionId)?.commands ?? [];
 }
 
 /**
@@ -874,6 +894,15 @@ export function stopSession(sessionId: string): void {
   state.isRunning = false;
   state.currentQuery = null;
   sessions.delete(sessionId);
+}
+
+/**
+ * Clean up all in-memory state for a session, including persisted commands.
+ * Called when a session is archived/deleted.
+ */
+export function cleanupSession(sessionId: string): void {
+  stopSession(sessionId);
+  persistedCommands.delete(sessionId);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Slash commands (like `/compact`, `/review`, `/cost`, etc.) were always returning `[]` from the `claude.getCommands` endpoint
- **Root cause**: The `sessions` Map entry (including discovered commands) was deleted in the `finally` block after every query completion. When the frontend refetched commands (triggered by the `onClaudeRunning: false` SSE event), it got an empty array back, overwriting whatever the SSE subscription had populated during the query.
- **Fix**: Store commands in a separate `persistedCommands` Map that survives query completion. Only cleaned up when a session is actually archived/deleted (via new `cleanupSession()` function).

## Verified
- Integration test against real SDK: returns 13 commands (3 skills with rich metadata + 10 built-in commands)
- All 383 unit tests pass

## Test plan
- [ ] Start a session and send a prompt
- [ ] After the query completes, verify slash commands appear in the command palette (type `/` in the input)
- [ ] Refresh the page — commands should still be available after refetch
- [ ] Delete a session — verify no memory leak (commands cleaned up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)