### PR TITLE
Fix model select input losing focus after first keystroke

### DIFF
--- a/src/components/settings/SystemPromptTab.tsx
+++ b/src/components/settings/SystemPromptTab.tsx
@@ -435,8 +435,13 @@ function ClaudeModelSection({
               <ChevronsUpDown className="absolute right-2 top-1/2 -translate-y-1/2 h-4 w-4 opacity-50" />
             </div>
           </PopoverTrigger>
-          <PopoverContent className="p-0 w-[var(--radix-popover-trigger-width)]" align="start">
-            <Command>
+          <PopoverContent
+            className="p-0 w-[var(--radix-popover-trigger-width)]"
+            align="start"
+            onOpenAutoFocus={(e) => e.preventDefault()}
+            onCloseAutoFocus={(e) => e.preventDefault()}
+          >
+            <Command shouldFilter={false}>
               <CommandList>
                 <CommandEmpty className="py-3 text-center text-sm text-muted-foreground">
                   No matching models


### PR DESCRIPTION
## Summary
- Fixed the model select in Settings losing focus after typing one character
- The `PopoverContent` was auto-focusing into itself when it opened, stealing focus from the `Input`
- The `Command` (cmdk) component was also capturing keyboard events for its own internal filtering, conflicting with the external input
- Added `onOpenAutoFocus`/`onCloseAutoFocus` with `preventDefault` to keep focus on the `Input`, and `shouldFilter={false}` since we already filter suggestions ourselves

## Test plan
- [x] All 383 existing tests pass
- [ ] Open Settings → Claude Model → click Override/Edit
- [ ] Type a full model name (e.g. "claude-opus-4-6") — input should accept all characters without losing focus
- [ ] Verify the dropdown suggestions filter as you type
- [ ] Verify clicking a suggestion fills the input
- [ ] Verify Enter saves, Escape closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)