### PR TITLE
Add per-repo Claude model override

### DIFF
--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -46,7 +46,7 @@ The database schema is defined in [`prisma/schema.prisma`](../prisma/schema.pris
 - **Message**: Chat messages with sequence numbers for cursor-based pagination
 - **AuthSession**: Login sessions with tokens and audit info
 - **GlobalSettings**: Global application settings (system prompt override and append, Claude model, Claude API key, TTS speed, voice auto-send)
-- **RepoSettings**: Per-repository settings (favorites, custom system prompt)
+- **RepoSettings**: Per-repository settings (favorites, custom system prompt, Claude model override)
 - **EnvVar**: Environment variables for a repository or global (encrypted if secret). When `repoSettingsId` is null, the variable is global and applies to all sessions.
 - **McpServer**: MCP server configurations for a repository or global. When `repoSettingsId` is null, the server is global and applies to all sessions.
 
@@ -337,6 +337,7 @@ Users can configure per-repository settings that are automatically applied when 
 
 - **Favorites**: Mark repositories (or "No Repository") as favorites so they appear at the top of the repo selector
 - **Custom System Prompt**: Additional instructions appended to the default system prompt for all sessions using this repository
+- **Claude Model**: Override the model for all sessions using this repository. Takes precedence over the global model and the `CLAUDE_MODEL` env var. Falls back to those when not set.
 - **Environment Variables**: Custom env vars set for Claude sessions (e.g., API keys, config values)
 - **MCP Servers**: Configure [MCP servers](https://modelcontextprotocol.io/) for Claude to use, supporting three transport types:
   - **Stdio**: Traditional command-based servers (e.g., `npx @anthropic/mcp-server-memory`)
@@ -361,7 +362,7 @@ Users can configure per-repository settings that are automatically applied when 
 
 Users can configure global settings that apply to all sessions:
 
-- **Claude Model**: Override the `CLAUDE_MODEL` environment variable. Free-text field accepting model names like `opus`, `sonnet`, or full IDs like `claude-opus-4-6`. Falls back to the env var default when not set.
+- **Claude Model**: Override the `CLAUDE_MODEL` environment variable. Free-text field accepting model names like `opus`, `sonnet`, or full IDs like `claude-opus-4-6`. A per-repo model override (if set) takes precedence over this; otherwise this is used, falling back to the env var default when neither is set. Resolution order is `repo model → global model → CLAUDE_MODEL env var` (see `resolveClaudeModel` in `settings-merger.ts`).
 - **Claude API Key**: Override the `CLAUDE_CODE_OAUTH_TOKEN` environment variable. Stored encrypted at rest. The actual value is never exposed to the UI — only a "configured" status is shown. Falls back to the env var when not set.
 - **System Prompt Override**: Replace the default system prompt with a custom one. When editing, the field is pre-populated with the current default prompt. The override can be toggled on/off without losing the custom content.
 - **Global System Prompt Append**: Additional content appended to the base prompt (default or override) for all sessions. This is applied before any per-repo custom prompts.
@@ -380,6 +381,7 @@ Users can configure global settings that apply to all sessions:
 
 - **Environment Variables**: Global env vars are included in all sessions. If a per-repo env var has the same name as a global one, the per-repo value takes precedence.
 - **MCP Servers**: Global MCP servers are included in all sessions. If a per-repo MCP server has the same name as a global one, the per-repo configuration takes precedence.
+- **Claude Model**: Resolved in precedence order `per-repo model → global model → CLAUDE_MODEL env var`.
 
 **Configuration**: Go to Settings → System Prompt to manage prompt and model settings. Go to Settings → Audio to manage voice/audio settings (TTS speed, voice auto-send).
 

--- a/prisma/migrations/20260610033926_add_repo_claude_model/migration.sql
+++ b/prisma/migrations/20260610033926_add_repo_claude_model/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "RepoSettings" ADD COLUMN "claudeModel" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -61,6 +61,7 @@ model RepoSettings {
   isFavorite         Boolean  @default(false)
   displayOrder       Int      @default(0) // For custom ordering within favorites
   customSystemPrompt String?  // Optional prompt appended to the default system prompt
+  claudeModel        String?  // If set, overrides the global/env Claude model for this repo's sessions
   createdAt          DateTime @default(now())
   updatedAt          DateTime @updatedAt
 

--- a/src/components/settings/RepoSettingsEditor.tsx
+++ b/src/components/settings/RepoSettingsEditor.tsx
@@ -272,9 +272,9 @@ function ClaudeModelSection({
       <ModelOverrideField
         currentModel={claudeModel}
         defaultModel={fallbackModel}
-        onSave={(model) => {
+        onSave={(model, onSuccess) => {
           setError(null);
-          mutation.mutate({ repoFullName, claudeModel: model });
+          mutation.mutate({ repoFullName, claudeModel: model }, { onSuccess });
         }}
         isPending={mutation.isPending}
         error={error}

--- a/src/components/settings/RepoSettingsEditor.tsx
+++ b/src/components/settings/RepoSettingsEditor.tsx
@@ -15,10 +15,11 @@ import { Spinner } from '@/components/ui/spinner';
 import { Separator } from '@/components/ui/separator';
 import { Textarea } from '@/components/ui/textarea';
 import { trpc } from '@/lib/trpc';
-import { Plus, Star, FileText, FolderOpen } from 'lucide-react';
+import { Plus, Star, FileText, FolderOpen, Cpu } from 'lucide-react';
 import { NO_REPO_SENTINEL } from '@/components/RepoSelector';
 import { EnvVarSection } from './shared/EnvVarSection';
 import { McpServerSection } from './shared/McpServerSection';
+import { ModelOverrideField } from './shared/ModelOverrideField';
 import type { EnvVarMutations } from './shared/EnvVarSection';
 import type { McpServerMutations } from './shared/McpServerSection';
 
@@ -116,6 +117,15 @@ export function RepoSettingsEditor({ repoFullName, onClose }: RepoSettingsEditor
             <CustomSystemPromptSection
               repoFullName={repoFullName}
               customSystemPrompt={data?.customSystemPrompt ?? null}
+              onUpdate={refetch}
+            />
+
+            <Separator />
+
+            {/* Claude Model */}
+            <ClaudeModelSection
+              repoFullName={repoFullName}
+              claudeModel={data?.claudeModel ?? null}
               onUpdate={refetch}
             />
 
@@ -224,6 +234,52 @@ function CustomSystemPromptSection({
           Add Custom Prompt
         </Button>
       )}
+    </div>
+  );
+}
+
+function ClaudeModelSection({
+  repoFullName,
+  claudeModel,
+  onUpdate,
+}: {
+  repoFullName: string;
+  claudeModel: string | null;
+  onUpdate: () => void;
+}) {
+  const [error, setError] = useState<string | null>(null);
+  const { data: globalSettings } = trpc.globalSettings.get.useQuery();
+
+  const mutation = trpc.repoSettings.setClaudeModel.useMutation({
+    onSuccess: () => onUpdate(),
+    onError: (err) => setError(err.message),
+  });
+
+  const fallbackModel =
+    globalSettings?.claudeModel ?? globalSettings?.defaultClaudeModel ?? 'opus[1m]';
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <Cpu className="h-4 w-4 text-muted-foreground" />
+        <h3 className="font-medium">Claude Model</h3>
+      </div>
+
+      <p className="text-sm text-muted-foreground">
+        Overrides the global Claude model for all sessions using this repository.
+      </p>
+
+      <ModelOverrideField
+        currentModel={claudeModel}
+        defaultModel={fallbackModel}
+        onSave={(model) => {
+          setError(null);
+          mutation.mutate({ repoFullName, claudeModel: model });
+        }}
+        isPending={mutation.isPending}
+        error={error}
+        setButtonLabel="Set Model"
+      />
     </div>
   );
 }

--- a/src/components/settings/SystemPromptTab.tsx
+++ b/src/components/settings/SystemPromptTab.tsx
@@ -342,9 +342,9 @@ function ClaudeModelSection({
     <ModelOverrideField
       currentModel={currentModel}
       defaultModel={defaultModel}
-      onSave={(claudeModel) => {
+      onSave={(claudeModel, onSuccess) => {
         setError(null);
-        mutation.mutate({ claudeModel });
+        mutation.mutate({ claudeModel }, { onSuccess });
       }}
       isPending={mutation.isPending}
       error={error}

--- a/src/components/settings/SystemPromptTab.tsx
+++ b/src/components/settings/SystemPromptTab.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useRef, useEffect } from 'react';
+import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -9,18 +9,10 @@ import { Textarea } from '@/components/ui/textarea';
 import { Spinner } from '@/components/ui/spinner';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandItem,
-  CommandList,
-} from '@/components/ui/command';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { trpc } from '@/lib/trpc';
-import { ChevronDown, ChevronRight, RotateCcw, Check, X, ChevronsUpDown } from 'lucide-react';
+import { ChevronDown, ChevronRight, RotateCcw, Check, X } from 'lucide-react';
 import { GlobalEnvVarsCard, GlobalMcpServersCard } from './GlobalSettingsTab';
-import { cn } from '@/lib/utils';
+import { ModelOverrideField } from './shared/ModelOverrideField';
 
 export function SystemPromptTab() {
   const { data: settings, isLoading, refetch } = trpc.globalSettings.get.useQuery();
@@ -339,167 +331,24 @@ function ClaudeModelSection({
   defaultModel: string;
   onUpdate: () => void;
 }) {
-  const [isEditing, setIsEditing] = useState(false);
-  const [editValue, setEditValue] = useState('');
-  const [popoverOpen, setPopoverOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  const { data: suggestionsData } = trpc.globalSettings.getModelSuggestions.useQuery(undefined, {
-    enabled: isEditing,
-    staleTime: 60 * 60 * 1000, // 1 hour
-  });
-  const suggestions = suggestionsData?.models ?? [];
 
   const mutation = trpc.globalSettings.setClaudeModel.useMutation({
-    onSuccess: () => {
-      setIsEditing(false);
-      onUpdate();
-    },
+    onSuccess: () => onUpdate(),
     onError: (err) => setError(err.message),
   });
 
-  const handleSave = () => {
-    setError(null);
-    mutation.mutate({ claudeModel: editValue.trim() || null });
-  };
-
-  const handleClear = () => {
-    setError(null);
-    mutation.mutate({ claudeModel: null });
-  };
-
-  const handleCancel = () => {
-    setIsEditing(false);
-    setPopoverOpen(false);
-    setError(null);
-  };
-
-  const startEditing = () => {
-    setEditValue(currentModel ?? '');
-    setIsEditing(true);
-  };
-
-  // Focus input when editing starts
-  useEffect(() => {
-    if (isEditing) {
-      // Small delay to let the DOM render
-      const timer = setTimeout(() => inputRef.current?.focus(), 50);
-      return () => clearTimeout(timer);
-    }
-  }, [isEditing]);
-
-  const handleSelectSuggestion = (model: string) => {
-    setEditValue(model);
-    setPopoverOpen(false);
-    // Focus back on input after selection
-    setTimeout(() => inputRef.current?.focus(), 50);
-  };
-
-  // Filter suggestions based on current input
-  const filteredSuggestions = editValue.trim()
-    ? suggestions.filter((s) => s.toLowerCase().includes(editValue.trim().toLowerCase()))
-    : suggestions;
-
-  if (isEditing) {
-    return (
-      <div className="space-y-3">
-        <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
-          <PopoverTrigger asChild>
-            <div className="relative">
-              <Input
-                ref={inputRef}
-                value={editValue}
-                onChange={(e) => {
-                  setEditValue(e.target.value);
-                  if (e.target.value && !popoverOpen) {
-                    setPopoverOpen(true);
-                  }
-                }}
-                onFocus={() => setPopoverOpen(true)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') {
-                    e.preventDefault();
-                    handleSave();
-                  } else if (e.key === 'Escape') {
-                    if (popoverOpen) {
-                      setPopoverOpen(false);
-                    } else {
-                      handleCancel();
-                    }
-                  }
-                }}
-                placeholder={defaultModel}
-                className="font-mono text-sm pr-8"
-              />
-              <ChevronsUpDown className="absolute right-2 top-1/2 -translate-y-1/2 h-4 w-4 opacity-50" />
-            </div>
-          </PopoverTrigger>
-          <PopoverContent
-            className="p-0 w-[var(--radix-popover-trigger-width)]"
-            align="start"
-            onOpenAutoFocus={(e) => e.preventDefault()}
-            onCloseAutoFocus={(e) => e.preventDefault()}
-          >
-            <Command shouldFilter={false}>
-              <CommandList>
-                <CommandEmpty className="py-3 text-center text-sm text-muted-foreground">
-                  No matching models
-                </CommandEmpty>
-                <CommandGroup>
-                  {filteredSuggestions.map((model) => (
-                    <CommandItem
-                      key={model}
-                      value={model}
-                      onSelect={() => handleSelectSuggestion(model)}
-                      className="font-mono text-sm cursor-pointer"
-                    >
-                      <Check
-                        className={cn(
-                          'mr-2 h-4 w-4',
-                          editValue === model ? 'opacity-100' : 'opacity-0'
-                        )}
-                      />
-                      {model}
-                    </CommandItem>
-                  ))}
-                </CommandGroup>
-              </CommandList>
-            </Command>
-          </PopoverContent>
-        </Popover>
-        {error && <p className="text-sm text-destructive">{error}</p>}
-        <div className="flex justify-end gap-2">
-          <Button variant="outline" size="sm" onClick={handleCancel}>
-            Cancel
-          </Button>
-          <Button size="sm" onClick={handleSave} disabled={mutation.isPending}>
-            {mutation.isPending ? <Spinner size="sm" /> : 'Save'}
-          </Button>
-        </div>
-      </div>
-    );
-  }
-
   return (
-    <div className="space-y-3">
-      <div className="flex items-center gap-2">
-        <code className="text-sm font-mono bg-muted px-2 py-1 rounded">
-          {currentModel ?? defaultModel}
-        </code>
-        {!currentModel && <span className="text-xs text-muted-foreground">(from environment)</span>}
-      </div>
-      <div className="flex gap-2">
-        <Button variant="outline" size="sm" onClick={startEditing}>
-          {currentModel ? 'Edit' : 'Override'}
-        </Button>
-        {currentModel && (
-          <Button variant="outline" size="sm" onClick={handleClear} disabled={mutation.isPending}>
-            {mutation.isPending ? <Spinner size="sm" /> : 'Reset to Default'}
-          </Button>
-        )}
-      </div>
-    </div>
+    <ModelOverrideField
+      currentModel={currentModel}
+      defaultModel={defaultModel}
+      onSave={(claudeModel) => {
+        setError(null);
+        mutation.mutate({ claudeModel });
+      }}
+      isPending={mutation.isPending}
+      error={error}
+    />
   );
 }
 

--- a/src/components/settings/shared/ModelOverrideField.tsx
+++ b/src/components/settings/shared/ModelOverrideField.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Spinner } from '@/components/ui/spinner';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { trpc } from '@/lib/trpc';
+import { Check, ChevronsUpDown } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface ModelOverrideFieldProps {
+  /** The currently saved override, or null when none is set. */
+  currentModel: string | null;
+  /** The value that applies when no override is set (shown as placeholder). */
+  defaultModel: string;
+  /** Persists the new value. Pass null to clear the override. */
+  onSave: (model: string | null) => void;
+  isPending: boolean;
+  error: string | null;
+  /** Button label shown when no override exists. */
+  setButtonLabel?: string;
+}
+
+export function ModelOverrideField({
+  currentModel,
+  defaultModel,
+  onSave,
+  isPending,
+  error,
+  setButtonLabel = 'Override',
+}: ModelOverrideFieldProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editValue, setEditValue] = useState('');
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const { data: suggestionsData } = trpc.globalSettings.getModelSuggestions.useQuery(undefined, {
+    enabled: isEditing,
+    staleTime: 60 * 60 * 1000, // 1 hour
+  });
+  const suggestions = suggestionsData?.models ?? [];
+
+  const startEditing = () => {
+    setEditValue(currentModel ?? '');
+    setIsEditing(true);
+  };
+
+  useEffect(() => {
+    if (isEditing) {
+      const timer = setTimeout(() => inputRef.current?.focus(), 50);
+      return () => clearTimeout(timer);
+    }
+  }, [isEditing]);
+
+  const handleSave = () => {
+    onSave(editValue.trim() || null);
+    setIsEditing(false);
+  };
+
+  const handleSelectSuggestion = (model: string) => {
+    setEditValue(model);
+    setPopoverOpen(false);
+    setTimeout(() => inputRef.current?.focus(), 50);
+  };
+
+  const filteredSuggestions = editValue.trim()
+    ? suggestions.filter((s) => s.toLowerCase().includes(editValue.trim().toLowerCase()))
+    : suggestions;
+
+  if (isEditing) {
+    return (
+      <div className="space-y-3">
+        <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
+          <PopoverTrigger asChild>
+            <div className="relative">
+              <Input
+                ref={inputRef}
+                value={editValue}
+                onChange={(e) => {
+                  setEditValue(e.target.value);
+                  if (e.target.value && !popoverOpen) {
+                    setPopoverOpen(true);
+                  }
+                }}
+                onFocus={() => setPopoverOpen(true)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    handleSave();
+                  } else if (e.key === 'Escape') {
+                    if (popoverOpen) {
+                      setPopoverOpen(false);
+                    } else {
+                      setIsEditing(false);
+                    }
+                  }
+                }}
+                placeholder={defaultModel}
+                className="font-mono text-sm pr-8"
+              />
+              <ChevronsUpDown className="absolute right-2 top-1/2 -translate-y-1/2 h-4 w-4 opacity-50" />
+            </div>
+          </PopoverTrigger>
+          <PopoverContent
+            className="p-0 w-[var(--radix-popover-trigger-width)]"
+            align="start"
+            onOpenAutoFocus={(e) => e.preventDefault()}
+            onCloseAutoFocus={(e) => e.preventDefault()}
+          >
+            <Command shouldFilter={false}>
+              <CommandList>
+                <CommandEmpty className="py-3 text-center text-sm text-muted-foreground">
+                  No matching models
+                </CommandEmpty>
+                <CommandGroup>
+                  {filteredSuggestions.map((model) => (
+                    <CommandItem
+                      key={model}
+                      value={model}
+                      onSelect={() => handleSelectSuggestion(model)}
+                      className="font-mono text-sm cursor-pointer"
+                    >
+                      <Check
+                        className={cn(
+                          'mr-2 h-4 w-4',
+                          editValue === model ? 'opacity-100' : 'opacity-0'
+                        )}
+                      />
+                      {model}
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
+        {error && <p className="text-sm text-destructive">{error}</p>}
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" size="sm" onClick={() => setIsEditing(false)}>
+            Cancel
+          </Button>
+          <Button size="sm" onClick={handleSave} disabled={isPending}>
+            {isPending ? <Spinner size="sm" /> : 'Save'}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <code className="text-sm font-mono bg-muted px-2 py-1 rounded">
+          {currentModel ?? defaultModel}
+        </code>
+        {!currentModel && <span className="text-xs text-muted-foreground">(default)</span>}
+      </div>
+      <div className="flex gap-2">
+        <Button variant="outline" size="sm" onClick={startEditing}>
+          {currentModel ? 'Edit' : setButtonLabel}
+        </Button>
+        {currentModel && (
+          <Button variant="outline" size="sm" onClick={() => onSave(null)} disabled={isPending}>
+            {isPending ? <Spinner size="sm" /> : 'Reset to Default'}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/shared/ModelOverrideField.tsx
+++ b/src/components/settings/shared/ModelOverrideField.tsx
@@ -21,8 +21,8 @@ interface ModelOverrideFieldProps {
   currentModel: string | null;
   /** The value that applies when no override is set (shown as placeholder). */
   defaultModel: string;
-  /** Persists the new value. Pass null to clear the override. */
-  onSave: (model: string | null) => void;
+  /** Persists the new value. Pass null to clear the override. Call onSuccess once the save succeeds. */
+  onSave: (model: string | null, onSuccess: () => void) => void;
   isPending: boolean;
   error: string | null;
   /** Button label shown when no override exists. */
@@ -61,8 +61,8 @@ export function ModelOverrideField({
   }, [isEditing]);
 
   const handleSave = () => {
-    onSave(editValue.trim() || null);
-    setIsEditing(false);
+    if (isPending) return;
+    onSave(editValue.trim() || null, () => setIsEditing(false));
   };
 
   const handleSelectSuggestion = (model: string) => {
@@ -104,6 +104,7 @@ export function ModelOverrideField({
                   }
                 }}
                 placeholder={defaultModel}
+                disabled={isPending}
                 className="font-mono text-sm pr-8"
               />
               <ChevronsUpDown className="absolute right-2 top-1/2 -translate-y-1/2 h-4 w-4 opacity-50" />
@@ -168,7 +169,12 @@ export function ModelOverrideField({
           {currentModel ? 'Edit' : setButtonLabel}
         </Button>
         {currentModel && (
-          <Button variant="outline" size="sm" onClick={() => onSave(null)} disabled={isPending}>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onSave(null, () => {})}
+            disabled={isPending}
+          >
             {isPending ? <Spinner size="sm" /> : 'Reset to Default'}
           </Button>
         )}

--- a/src/server/routers/repoSettings.ts
+++ b/src/server/routers/repoSettings.ts
@@ -48,6 +48,7 @@ export const repoSettingsRouter = router({
         isFavorite: settings.isFavorite,
         displayOrder: settings.displayOrder,
         customSystemPrompt: settings.customSystemPrompt,
+        claudeModel: settings.claudeModel,
         createdAt: settings.createdAt,
         updatedAt: settings.updatedAt,
         envVars: formatEnvVarsForDisplay(settings.envVars),
@@ -115,6 +116,37 @@ export const repoSettingsRouter = router({
     }),
 
   /**
+   * Set the Claude model override for a repository.
+   * Pass null or empty string to clear (reverts to global/env model).
+   */
+  setClaudeModel: protectedProcedure
+    .input(
+      z.object({
+        repoFullName: repoFullNameSchema,
+        claudeModel: z.string().max(200).nullable(),
+      })
+    )
+    .mutation(async ({ input }) => {
+      const model = input.claudeModel?.trim() || null;
+
+      await prisma.repoSettings.upsert({
+        where: { repoFullName: input.repoFullName },
+        create: {
+          repoFullName: input.repoFullName,
+          claudeModel: model,
+        },
+        update: { claudeModel: model },
+      });
+
+      log.info('Set repo Claude model', {
+        repoFullName: input.repoFullName,
+        hasModel: model !== null,
+      });
+
+      return { success: true };
+    }),
+
+  /**
    * List all favorite repository names
    */
   listFavorites: protectedProcedure.query(async () => {
@@ -145,6 +177,7 @@ export const repoSettingsRouter = router({
         repoFullName: s.repoFullName,
         isFavorite: s.isFavorite,
         customSystemPrompt: s.customSystemPrompt,
+        claudeModel: s.claudeModel,
         envVarCount: s.envVars.length,
         mcpServerCount: s.mcpServers.length,
         envVars: s.envVars,
@@ -439,6 +472,7 @@ export const repoSettingsRouter = router({
 
       return {
         customSystemPrompt: settings.customSystemPrompt,
+        claudeModel: settings.claudeModel,
         envVars: decryptEnvVarsForContainer(settings.envVars),
         mcpServers: decryptMcpServersForContainer(settings.mcpServers),
       };

--- a/src/server/services/repo-settings.ts
+++ b/src/server/services/repo-settings.ts
@@ -58,6 +58,7 @@ export type ContainerMcpServer =
  */
 export interface ContainerRepoSettings {
   customSystemPrompt: string | null;
+  claudeModel: string | null;
   envVars: ContainerEnvVar[];
   mcpServers: ContainerMcpServer[];
 }
@@ -80,6 +81,7 @@ export async function getRepoSettingsForContainer(
 
   return {
     customSystemPrompt: settings.customSystemPrompt,
+    claudeModel: settings.claudeModel,
     envVars: decryptEnvVarsForContainer(settings.envVars),
     mcpServers: decryptMcpServersForContainer(settings.mcpServers),
   };

--- a/src/server/services/settings-merger.test.ts
+++ b/src/server/services/settings-merger.test.ts
@@ -1,6 +1,25 @@
 import { describe, it, expect } from 'vitest';
-import { mergeEnvVars, mergeMcpServers } from './settings-merger';
+import { mergeEnvVars, mergeMcpServers, resolveClaudeModel } from './settings-merger';
 import type { ContainerEnvVar, ContainerMcpServer } from './repo-settings';
+
+describe('resolveClaudeModel', () => {
+  it('prefers the per-repo model over global and env', () => {
+    expect(resolveClaudeModel('repo-model', 'global-model', 'env-model')).toBe('repo-model');
+  });
+
+  it('falls back to the global model when no repo override', () => {
+    expect(resolveClaudeModel(null, 'global-model', 'env-model')).toBe('global-model');
+    expect(resolveClaudeModel(undefined, 'global-model', 'env-model')).toBe('global-model');
+  });
+
+  it('falls back to the env model when neither repo nor global is set', () => {
+    expect(resolveClaudeModel(null, null, 'env-model')).toBe('env-model');
+  });
+
+  it('returns undefined when nothing is set', () => {
+    expect(resolveClaudeModel(null, null, undefined)).toBeUndefined();
+  });
+});
 
 describe('mergeEnvVars', () => {
   it('should return empty array when both inputs are empty', () => {

--- a/src/server/services/settings-merger.ts
+++ b/src/server/services/settings-merger.ts
@@ -42,11 +42,27 @@ export async function loadMergedSessionSettings(
     systemPrompt,
     envVars,
     mcpServers,
-    claudeModel: globalSettings.claudeModel ?? env.CLAUDE_MODEL,
+    claudeModel: resolveClaudeModel(
+      repoSettings?.claudeModel,
+      globalSettings.claudeModel,
+      env.CLAUDE_MODEL
+    ),
     claudeApiKey: globalSettings.claudeApiKey ?? undefined,
     customSystemPrompt: repoSettings?.customSystemPrompt,
     globalSettings,
   };
+}
+
+/**
+ * Resolve the effective Claude model, in precedence order:
+ * per-repo override → global override → CLAUDE_MODEL env var.
+ */
+export function resolveClaudeModel(
+  repoModel: string | null | undefined,
+  globalModel: string | null | undefined,
+  envModel: string | undefined
+): string | undefined {
+  return repoModel ?? globalModel ?? envModel;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds a `claudeModel` field to `RepoSettings` so a repository can pin its own model independent of the global setting — useful when one repo (e.g. ML experiments) needs a different model than everything else.
- Model resolution now follows precedence `per-repo override → global override → CLAUDE_MODEL env var`, via a new pure `resolveClaudeModel` helper in `settings-merger.ts`.
- Extracts the model picker (input + suggestions popover + save/clear) into a shared `ModelOverrideField` component, reused by both global System Prompt settings and the per-repo settings editor.

## Notes
- New Prisma migration `add_repo_claude_model` (additive, nullable column).
- Per-repo override is configured in Settings → Repositories → (repo) → Claude Model. It also works for the "No Repository" sentinel.

## Test plan
- [x] `pnpm test:run` — 387 passing, incl. new `resolveClaudeModel` precedence tests
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm lint` (no new warnings)
- [ ] Manually set a per-repo model, start a session on that repo, and confirm the session uses the override while other repos still use the global model

🤖 Generated with [Claude Code](https://claude.com/claude-code)