### PR TITLE
Add fable and fable[1m] to model suggestions

### DIFF
--- a/src/server/services/anthropic-models.ts
+++ b/src/server/services/anthropic-models.ts
@@ -7,7 +7,15 @@ import { createLogger, toError } from '@/lib/logger';
 const log = createLogger('anthropic-models');
 
 /** Well-known short aliases that always appear as suggestions */
-const WELL_KNOWN_ALIASES = ['opus[1m]', 'sonnet[1m]', 'opus', 'sonnet', 'haiku'];
+const WELL_KNOWN_ALIASES = [
+  'opus[1m]',
+  'sonnet[1m]',
+  'fable[1m]',
+  'opus',
+  'sonnet',
+  'haiku',
+  'fable',
+];
 
 /** Cache for model suggestions */
 let cachedModels: string[] | null = null;


### PR DESCRIPTION
## Summary
- Add `fable` and `fable[1m]` to the well-known model aliases list in `anthropic-models.ts`, which surfaces them in the autocomplete on both the global and per-repo Claude model override fields (shared via `getModelSuggestions`).

## Test plan
- [ ] Open Settings → System Prompt and confirm `fable` and `fable[1m]` appear in the model autocomplete
- [ ] Open Settings → Repositories → any repo override and confirm the same suggestions appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)