### PR TITLE
Add production update script

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,14 @@ systemctl --user enable --now clawed-abode.service
 journalctl --user -u clawed-abode.service -f
 ```
 
+### Updating
+
+```bash
+./scripts/update.sh
+```
+
+This pulls the latest code, installs dependencies, applies database migrations, rebuilds, and restarts the service. A plain `git pull` + restart is **not** enough — `next start` serves the prebuilt `.next` bundle, so without a rebuild you keep running the old code. If your service isn't named `clawed-abode.service`, set `CLAWED_ABODE_SERVICE`.
+
 ## Remote Access with Tailscale
 
 ### Tailscale Serve (within your Tailnet)

--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -464,7 +464,8 @@ clawed-abode/
 ├── shared/
 │   └── agent-types.ts          # Shared types (PartialAssistantMessage)
 ├── scripts/
-│   └── hash-password.ts        # Password hashing utility
+│   ├── hash-password.ts        # Password hashing utility
+│   └── update.sh               # Production update: pull, install, migrate, build, restart
 ├── src/
 │   ├── server/
 │   │   ├── routers/

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Update a production deployment: pull, install, migrate, build, restart.
+# Run from anywhere; operates on the repo this script lives in.
+#
+# The whole body is wrapped in braces so bash parses it fully before
+# executing — otherwise `git pull` rewriting this file mid-run could
+# make bash execute garbage from the new version.
+{
+  set -euo pipefail
+
+  cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+  SERVICE_NAME="${CLAWED_ABODE_SERVICE:-clawed-abode.service}"
+
+  echo "==> Pulling latest code"
+  git pull --ff-only
+
+  echo "==> Installing dependencies"
+  pnpm install --frozen-lockfile
+
+  echo "==> Applying database migrations"
+  pnpm prisma migrate deploy
+
+  echo "==> Building"
+  pnpm build
+
+  echo "==> Restarting ${SERVICE_NAME}"
+  if systemctl --user is-active --quiet "$SERVICE_NAME" 2>/dev/null; then
+    systemctl --user restart "$SERVICE_NAME"
+    echo "Restarted user service ${SERVICE_NAME}"
+  elif systemctl is-active --quiet "$SERVICE_NAME" 2>/dev/null; then
+    sudo systemctl restart "$SERVICE_NAME"
+    echo "Restarted system service ${SERVICE_NAME}"
+  else
+    echo "No running ${SERVICE_NAME} found — restart your server manually."
+  fi
+
+  echo "==> Done"
+  exit 0
+}


### PR DESCRIPTION
## Summary
- Adds `scripts/update.sh`: one command to update a production deployment — `git pull --ff-only`, `pnpm install --frozen-lockfile`, `prisma migrate deploy`, `pnpm build`, then restart the systemd service.
- Motivated by the stale-build issue after #344: a plain `git pull` + restart silently keeps serving the old `.next` bundle since `next start` serves the prebuilt output.
- Restart handles both user-level (`systemctl --user`, as documented in the README) and system-level services, and the service name is overridable via `CLAWED_ABODE_SERVICE`. Falls back to a manual-restart message if neither is running.
- The script body is wrapped in braces so bash parses it fully before executing — protects against `git pull` rewriting the script mid-run.
- Documents an "Updating" section in the README and lists the script in DESIGN.md's file structure.

## Test plan
- [x] `bash -n` syntax check
- [x] Verified the user/system service detection logic against the live `clawed-abode.service` (user-level, active)
- [ ] Run `./scripts/update.sh` in `~/clawed-abode` after merging (will restart the service, so kicking this off from a session you don't mind dropping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)