### PR TITLE
Render thinking blocks as Thinking, drop thinking_tokens system spam

### DIFF
--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -279,6 +279,10 @@ When extended thinking is active, assistant messages include `thinking` (and, wh
 
 During redacted thinking the SDK also emits frequent `{ type: 'system', subtype: 'thinking_tokens' }` progress messages carrying only live token-count estimates. These are transient and are dropped (not persisted or shown) via `isTransientProgressMessage` in [`src/lib/claude-messages.ts`](../src/lib/claude-messages.ts) so they don't render as a stream of empty "System" bubbles.
 
+### Message Classification
+
+Every message yielded by the SDK is routed through `classifyMessage(message)` in [`src/lib/claude-messages.ts`](../src/lib/claude-messages.ts), which returns one of `{ kind: 'stream_event' | 'skip' | 'persist' }` (with the DB column type for `persist`). It `switch`es over the SDK's `SDKMessage` discriminated union and ends in `assertNeverFallback`, a compile-time exhaustiveness guard: if a future SDK release adds a top-level message `type`, the build fails until it is handled here. At runtime an unrecognized type degrades to generic system persistence rather than throwing, so an unexpected frame never crashes the query loop. (New `system` _subtypes_ are intentionally not exhaustive — unknown ones persist as a generic system message.)
+
 ## Message Storage & Pagination
 
 Messages are stored with a monotonically increasing sequence number per session (see `Message` model in [`prisma/schema.prisma`](../prisma/schema.prisma)). This enables efficient cursor-based pagination.

--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -273,6 +273,12 @@ The SDK emits `stream_event` messages which are accumulated by `StreamAccumulato
 
 **Implementation:** [`src/server/services/claude-runner.ts`](../src/server/services/claude-runner.ts)
 
+### Thinking Blocks
+
+When extended thinking is active, assistant messages include `thinking` (and, when the API encrypts reasoning, `redacted_thinking`) content blocks alongside `text` and `tool_use`. These are accumulated during streaming (`thinking_delta` events) and rendered as a single collapsed "Thinking" section per message (`ThinkingDisplay`), coalescing multiple thinking blocks into one. Thinking text is excluded from copy/voice output.
+
+During redacted thinking the SDK also emits frequent `{ type: 'system', subtype: 'thinking_tokens' }` progress messages carrying only live token-count estimates. These are transient and are dropped (not persisted or shown) via `isTransientProgressMessage` in [`src/lib/claude-messages.ts`](../src/lib/claude-messages.ts) so they don't render as a stream of empty "System" bubbles.
+
 ## Message Storage & Pagination
 
 Messages are stored with a monotonically increasing sequence number per session (see `Message` model in [`prisma/schema.prisma`](../prisma/schema.prisma)). This enables efficient cursor-based pagination.

--- a/src/components/messages/ContentRenderer.tsx
+++ b/src/components/messages/ContentRenderer.tsx
@@ -19,6 +19,7 @@ import { EnterPlanModeDisplay } from './EnterPlanModeDisplay';
 import { ExitPlanModeDisplay } from './ExitPlanModeDisplay';
 import { TodoWriteDisplay } from './TodoWriteDisplay';
 import { AskUserQuestionDisplay } from './AskUserQuestionDisplay';
+import { ThinkingDisplay } from './ThinkingDisplay';
 
 /**
  * Map of tool names to their specialized display components.
@@ -43,19 +44,31 @@ const TOOL_DISPLAY_MAP: Record<string, React.ComponentType<{ tool: ToolCall }>> 
 };
 
 function renderContentBlocks(blocks: ContentBlock[], toolResults?: ToolResultMap): React.ReactNode {
+  const thinkingParts: string[] = [];
   const textBlocks: string[] = [];
   const toolUseBlocks: ContentBlock[] = [];
+  let hasRedactedThinking = false;
 
   for (const block of blocks) {
     if (block.type === 'text' && block.text) {
       textBlocks.push(block.text);
+    } else if (block.type === 'thinking' && block.thinking) {
+      thinkingParts.push(block.thinking);
+    } else if (block.type === 'redacted_thinking') {
+      hasRedactedThinking = true;
     } else if (block.type === 'tool_use') {
       toolUseBlocks.push(block);
     }
   }
 
+  // Coalesce all thinking in this message into a single block.
+  const thinking = thinkingParts.join('\n\n');
+
   return (
     <>
+      {(thinking.length > 0 || hasRedactedThinking) && (
+        <ThinkingDisplay thinking={thinking} redacted={thinking.length === 0} />
+      )}
       {textBlocks.length > 0 && <MarkdownContent content={textBlocks.join('\n')} />}
       {toolUseBlocks.length > 0 && (
         <div className="mt-2 space-y-2">

--- a/src/components/messages/ContentRenderer.tsx
+++ b/src/components/messages/ContentRenderer.tsx
@@ -61,14 +61,15 @@ function renderContentBlocks(blocks: ContentBlock[], toolResults?: ToolResultMap
     }
   }
 
-  // Coalesce all thinking in this message into a single block.
+  // Coalesce all visible thinking in this message into a single block. Redacted
+  // thinking carries no text, so it is shown as its own separate indicator (a
+  // message can contain both visible and redacted thinking blocks).
   const thinking = thinkingParts.join('\n\n');
 
   return (
     <>
-      {(thinking.length > 0 || hasRedactedThinking) && (
-        <ThinkingDisplay thinking={thinking} redacted={thinking.length === 0} />
-      )}
+      {thinking.length > 0 && <ThinkingDisplay thinking={thinking} />}
+      {hasRedactedThinking && <ThinkingDisplay thinking="" redacted />}
       {textBlocks.length > 0 && <MarkdownContent content={textBlocks.join('\n')} />}
       {toolUseBlocks.length > 0 && (
         <div className="mt-2 space-y-2">

--- a/src/components/messages/MessageBubble.test.tsx
+++ b/src/components/messages/MessageBubble.test.tsx
@@ -120,6 +120,63 @@ describe('MessageBubble', () => {
 
       expect(screen.getByText('May be incomplete')).toBeInTheDocument();
     });
+
+    it('renders thinking blocks as a Thinking section, not a System block', () => {
+      const message = {
+        type: 'assistant',
+        content: {
+          message: {
+            content: [
+              { type: 'thinking', thinking: 'Let me reason about this.' },
+              { type: 'text', text: 'Here is my answer.' },
+            ],
+          },
+        } as MessageContent,
+      };
+
+      render(<MessageBubble message={message} />);
+
+      expect(screen.getByText('Thinking')).toBeInTheDocument();
+      expect(screen.getByText('Here is my answer.')).toBeInTheDocument();
+      expect(screen.queryByText('System')).not.toBeInTheDocument();
+    });
+
+    it('coalesces multiple thinking blocks into a single Thinking section', () => {
+      const message = {
+        type: 'assistant',
+        content: {
+          message: {
+            content: [
+              { type: 'thinking', thinking: 'First thought.' },
+              { type: 'thinking', thinking: 'Second thought.' },
+              { type: 'text', text: 'Done.' },
+            ],
+          },
+        } as MessageContent,
+      };
+
+      render(<MessageBubble message={message} />);
+
+      expect(screen.getAllByText('Thinking')).toHaveLength(1);
+    });
+
+    it('labels redacted thinking as redacted', () => {
+      const message = {
+        type: 'assistant',
+        content: {
+          message: {
+            content: [
+              { type: 'redacted_thinking', data: 'opaque' },
+              { type: 'text', text: 'Answer.' },
+            ],
+          },
+        } as MessageContent,
+      };
+
+      render(<MessageBubble message={message} />);
+
+      expect(screen.getByText('Thinking (redacted)')).toBeInTheDocument();
+    });
   });
 
   describe('user messages', () => {

--- a/src/components/messages/MessageBubble.test.tsx
+++ b/src/components/messages/MessageBubble.test.tsx
@@ -177,6 +177,43 @@ describe('MessageBubble', () => {
 
       expect(screen.getByText('Thinking (redacted)')).toBeInTheDocument();
     });
+
+    it('shows both visible and redacted thinking when both are present', () => {
+      const message = {
+        type: 'assistant',
+        content: {
+          message: {
+            content: [
+              { type: 'thinking', thinking: 'Visible reasoning.' },
+              { type: 'redacted_thinking', data: 'opaque' },
+              { type: 'text', text: 'Answer.' },
+            ],
+          },
+        } as MessageContent,
+      };
+
+      render(<MessageBubble message={message} />);
+
+      expect(screen.getByText('Thinking')).toBeInTheDocument();
+      expect(screen.getByText('Thinking (redacted)')).toBeInTheDocument();
+    });
+  });
+
+  describe('transient progress messages', () => {
+    it('renders nothing for thinking_tokens system messages', () => {
+      const message = {
+        type: 'system',
+        content: {
+          type: 'system',
+          subtype: 'thinking_tokens',
+          estimated_tokens: 100,
+        } as MessageContent,
+      };
+
+      const { container } = render(<MessageBubble message={message} />);
+
+      expect(container).toBeEmptyDOMElement();
+    });
   });
 
   describe('user messages', () => {

--- a/src/components/messages/MessageBubble.tsx
+++ b/src/components/messages/MessageBubble.tsx
@@ -12,6 +12,7 @@ import { HookStartedDisplay } from './HookStartedDisplay';
 import { CompactBoundaryDisplay } from './CompactBoundaryDisplay';
 import { MainMessageBubble } from './MainMessageBubble';
 import { isRecognizedMessage, getToolResults } from './messageHelpers';
+import { isTransientProgressMessage } from '@/lib/claude-messages';
 import type { ToolResultMap, MessageContent } from './types';
 
 export function MessageBubble({
@@ -30,6 +31,12 @@ export function MessageBubble({
 
   const recognition = useMemo(() => isRecognizedMessage(type, content), [type, content]);
   const category = recognition.recognized ? recognition.category : null;
+
+  // Transient progress events (e.g. thinking_tokens) carry no durable content.
+  // New ones are never persisted; this also hides any stored before that change.
+  if (isTransientProgressMessage(content)) {
+    return null;
+  }
 
   if (!recognition.recognized) {
     return (

--- a/src/components/messages/ThinkingDisplay.tsx
+++ b/src/components/messages/ThinkingDisplay.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useState } from 'react';
+import { Brain } from 'lucide-react';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import { MarkdownContent } from '@/components/MarkdownContent';
+
+/**
+ * Collapsible display for Claude's extended-thinking content.
+ *
+ * Multiple thinking blocks within a single message are coalesced by the caller
+ * and rendered here as one section so the UI shows a single "Thinking" block
+ * rather than a stream of separate bubbles.
+ */
+export function ThinkingDisplay({
+  thinking,
+  redacted = false,
+  defaultExpanded = false,
+}: {
+  thinking: string;
+  redacted?: boolean;
+  defaultExpanded?: boolean;
+}) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+
+  return (
+    <Collapsible open={expanded} onOpenChange={setExpanded} className="mt-2">
+      <CollapsibleTrigger className="flex w-full items-center gap-1.5 text-left text-xs text-muted-foreground hover:text-foreground transition-colors">
+        <Brain className="h-3.5 w-3.5 flex-shrink-0" />
+        <span className="italic">Thinking{redacted ? ' (redacted)' : ''}</span>
+        <span className="ml-auto">{expanded ? '−' : '+'}</span>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <div className="mt-1 border-l-2 border-muted pl-3 text-sm text-muted-foreground italic">
+          {redacted ? (
+            <span>Claude&apos;s thinking for this step was encrypted and is not shown.</span>
+          ) : (
+            <MarkdownContent content={thinking} />
+          )}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/src/components/messages/types.ts
+++ b/src/components/messages/types.ts
@@ -12,8 +12,10 @@ export interface ToolCall {
 }
 
 export interface ContentBlock {
-  type: 'text' | 'tool_use' | 'tool_result';
+  type: 'text' | 'thinking' | 'redacted_thinking' | 'tool_use' | 'tool_result';
   text?: string;
+  /** For thinking blocks */
+  thinking?: string;
   id?: string;
   name?: string;
   input?: unknown;

--- a/src/lib/claude-messages.test.ts
+++ b/src/lib/claude-messages.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
 import {
   TextBlockSchema,
   ToolUseBlockSchema,
@@ -13,7 +14,7 @@ import {
   StoredMessageSchema,
   parseStoredMessage,
   parseClaudeStreamLine,
-  getMessageType,
+  classifyMessage,
   isTransientProgressMessage,
   buildToolResultMap,
   AssistantMessage,
@@ -641,27 +642,42 @@ describe('claude-messages', () => {
     });
   });
 
-  describe('getMessageType', () => {
-    it('should return correct type for known types', () => {
-      expect(getMessageType({ type: 'assistant' })).toBe('assistant');
-      expect(getMessageType({ type: 'user' })).toBe('user');
-      expect(getMessageType({ type: 'result' })).toBe('result');
-      expect(getMessageType({ type: 'system' })).toBe('system');
+  describe('classifyMessage', () => {
+    // Synthetic messages; classifyMessage only inspects type/subtype.
+    const msg = (m: Record<string, unknown>) => classifyMessage(m as unknown as SDKMessage);
+
+    it('persists user/assistant/result under their own db type', () => {
+      expect(msg({ type: 'assistant' })).toEqual({ kind: 'persist', dbType: 'assistant' });
+      expect(msg({ type: 'user' })).toEqual({ kind: 'persist', dbType: 'user' });
+      expect(msg({ type: 'result' })).toEqual({ kind: 'persist', dbType: 'result' });
     });
 
-    it('should return system for SDK types that map to system', () => {
-      // These SDK message types all map to 'system' in the DB
-      expect(getMessageType({ type: 'tool_progress' })).toBe('system');
-      expect(getMessageType({ type: 'tool_use_summary' })).toBe('system');
-      expect(getMessageType({ type: 'auth_status' })).toBe('system');
-      expect(getMessageType({ type: 'stream_event' })).toBe('system');
+    it('persists non-system progress-ish types as system', () => {
+      expect(msg({ type: 'tool_progress' })).toEqual({ kind: 'persist', dbType: 'system' });
+      expect(msg({ type: 'tool_use_summary' })).toEqual({ kind: 'persist', dbType: 'system' });
+      expect(msg({ type: 'auth_status' })).toEqual({ kind: 'persist', dbType: 'system' });
+      expect(msg({ type: 'rate_limit_event' })).toEqual({ kind: 'persist', dbType: 'system' });
+      expect(msg({ type: 'prompt_suggestion' })).toEqual({ kind: 'persist', dbType: 'system' });
     });
 
-    it('should return system for unknown types', () => {
-      expect(getMessageType({ type: 'unknown' })).toBe('system');
-      expect(getMessageType(null)).toBe('system');
-      expect(getMessageType(undefined)).toBe('system');
-      expect(getMessageType('string')).toBe('system');
+    it('persists ordinary system messages as system', () => {
+      expect(msg({ type: 'system', subtype: 'init' })).toEqual({
+        kind: 'persist',
+        dbType: 'system',
+      });
+      expect(msg({ type: 'system' })).toEqual({ kind: 'persist', dbType: 'system' });
+    });
+
+    it('skips transient system progress events', () => {
+      expect(msg({ type: 'system', subtype: 'thinking_tokens' })).toEqual({ kind: 'skip' });
+    });
+
+    it('marks stream events for separate accumulation', () => {
+      expect(msg({ type: 'stream_event' })).toEqual({ kind: 'stream_event' });
+    });
+
+    it('degrades unknown future types to system persistence at runtime', () => {
+      expect(msg({ type: 'some_future_type' })).toEqual({ kind: 'persist', dbType: 'system' });
     });
   });
 

--- a/src/lib/claude-messages.test.ts
+++ b/src/lib/claude-messages.test.ts
@@ -14,6 +14,7 @@ import {
   parseStoredMessage,
   parseClaudeStreamLine,
   getMessageType,
+  isTransientProgressMessage,
   buildToolResultMap,
   AssistantMessage,
   UserMessage,
@@ -92,6 +93,25 @@ describe('claude-messages', () => {
           name: 'Bash',
           input: {},
         });
+        expect(result.success).toBe(true);
+      });
+
+      it('should parse thinking block', () => {
+        const result = ContentBlockSchema.safeParse({
+          type: 'thinking',
+          thinking: 'let me reason',
+          signature: 'sig',
+        });
+        expect(result.success).toBe(true);
+      });
+
+      it('should parse thinking block without signature (mid-stream)', () => {
+        const result = ContentBlockSchema.safeParse({ type: 'thinking', thinking: 'partial' });
+        expect(result.success).toBe(true);
+      });
+
+      it('should parse redacted_thinking block', () => {
+        const result = ContentBlockSchema.safeParse({ type: 'redacted_thinking', data: 'abc' });
         expect(result.success).toBe(true);
       });
 
@@ -642,6 +662,33 @@ describe('claude-messages', () => {
       expect(getMessageType(null)).toBe('system');
       expect(getMessageType(undefined)).toBe('system');
       expect(getMessageType('string')).toBe('system');
+    });
+  });
+
+  describe('isTransientProgressMessage', () => {
+    it('returns true for thinking_tokens system messages', () => {
+      expect(
+        isTransientProgressMessage({
+          type: 'system',
+          subtype: 'thinking_tokens',
+          estimated_tokens: 100,
+          estimated_tokens_delta: 10,
+        })
+      ).toBe(true);
+    });
+
+    it('returns false for other system messages', () => {
+      expect(isTransientProgressMessage({ type: 'system', subtype: 'init' })).toBe(false);
+      expect(isTransientProgressMessage({ type: 'system', subtype: 'error' })).toBe(false);
+      expect(isTransientProgressMessage({ type: 'system' })).toBe(false);
+    });
+
+    it('returns false for non-system messages and non-objects', () => {
+      expect(isTransientProgressMessage({ type: 'assistant' })).toBe(false);
+      expect(isTransientProgressMessage({ subtype: 'thinking_tokens' })).toBe(false);
+      expect(isTransientProgressMessage(null)).toBe(false);
+      expect(isTransientProgressMessage(undefined)).toBe(false);
+      expect(isTransientProgressMessage('thinking_tokens')).toBe(false);
     });
   });
 

--- a/src/lib/claude-messages.ts
+++ b/src/lib/claude-messages.ts
@@ -21,6 +21,27 @@ export const TextBlockSchema = z.object({
 export type TextBlock = z.infer<typeof TextBlockSchema>;
 
 /**
+ * Thinking content block - represents Claude's extended-thinking reasoning.
+ * `signature` is present on summarized thinking and absent while streaming.
+ */
+export const ThinkingBlockSchema = z.object({
+  type: z.literal('thinking'),
+  thinking: z.string(),
+  signature: z.string().optional(),
+});
+export type ThinkingBlock = z.infer<typeof ThinkingBlockSchema>;
+
+/**
+ * Redacted thinking block - thinking that the API encrypted rather than returning.
+ * Carries no human-readable text, only opaque `data`.
+ */
+export const RedactedThinkingBlockSchema = z.object({
+  type: z.literal('redacted_thinking'),
+  data: z.string(),
+});
+export type RedactedThinkingBlock = z.infer<typeof RedactedThinkingBlockSchema>;
+
+/**
  * Tool use content block - represents a tool call by the assistant
  */
 export const ToolUseBlockSchema = z.object({
@@ -47,6 +68,8 @@ export type ToolResultBlock = z.infer<typeof ToolResultBlockSchema>;
  */
 export const ContentBlockSchema = z.discriminatedUnion('type', [
   TextBlockSchema,
+  ThinkingBlockSchema,
+  RedactedThinkingBlockSchema,
   ToolUseBlockSchema,
   ToolResultBlockSchema,
 ]);
@@ -794,6 +817,22 @@ export function parseClaudeStreamLine(json: unknown): StreamLineParseResult {
  * - 'system': system messages (init, error, compact_boundary, status, hooks, etc.),
  *             plus other SDK types (tool_progress, tool_use_summary, auth_status, etc.)
  */
+/**
+ * Whether a message is a transient progress event that should not be persisted
+ * or shown in the chat. These arrive frequently during a turn and carry no
+ * durable content.
+ *
+ * - `thinking_tokens`: live token-count estimates emitted (often many times) while
+ *   Claude is thinking. The actual thinking text arrives in the assistant message's
+ *   thinking content blocks, so these estimates would otherwise render as a stream
+ *   of empty "System" bubbles.
+ */
+export function isTransientProgressMessage(content: unknown): boolean {
+  if (!content || typeof content !== 'object') return false;
+  const obj = content as Record<string, unknown>;
+  return obj.type === 'system' && obj.subtype === 'thinking_tokens';
+}
+
 export function getMessageType(content: unknown): 'system' | 'user' | 'assistant' | 'result' {
   if (!content || typeof content !== 'object') return 'system';
   const obj = content as Record<string, unknown>;

--- a/src/lib/claude-messages.ts
+++ b/src/lib/claude-messages.ts
@@ -6,6 +6,7 @@
  */
 
 import { z } from 'zod';
+import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
 
 // =============================================================================
 // Content Block Schemas
@@ -808,43 +809,92 @@ export function parseClaudeStreamLine(json: unknown): StreamLineParseResult {
 }
 
 /**
- * Extract the database-compatible message type from raw content.
- *
- * Maps SDK message types to one of the four DB column types:
- * - 'user': user messages and user message replays
- * - 'assistant': assistant messages
- * - 'result': result/completion messages
- * - 'system': system messages (init, error, compact_boundary, status, hooks, etc.),
- *             plus other SDK types (tool_progress, tool_use_summary, auth_status, etc.)
+ * The four message types stored in the `Message.type` DB column.
  */
+export type DbMessageType = 'system' | 'user' | 'assistant' | 'result';
+
 /**
- * Whether a message is a transient progress event that should not be persisted
- * or shown in the chat. These arrive frequently during a turn and carry no
- * durable content.
+ * How a streamed SDK message should be handled by the runner.
+ * - `stream_event`: a partial-message delta, accumulated separately (not persisted)
+ * - `skip`: a transient progress event with no durable content (dropped)
+ * - `persist`: a complete message stored under `dbType`
+ */
+export type MessageHandling =
+  | { kind: 'stream_event' }
+  | { kind: 'skip' }
+  | { kind: 'persist'; dbType: DbMessageType };
+
+/**
+ * System message subtypes that are transient progress events: they arrive
+ * frequently during a turn and carry no durable content, so they are never
+ * persisted or shown.
  *
  * - `thinking_tokens`: live token-count estimates emitted (often many times) while
  *   Claude is thinking. The actual thinking text arrives in the assistant message's
  *   thinking content blocks, so these estimates would otherwise render as a stream
  *   of empty "System" bubbles.
  */
+export const TRANSIENT_SYSTEM_SUBTYPES = ['thinking_tokens'] as const;
+
+/**
+ * Whether a message is a transient progress event that should not be persisted
+ * or shown. Operates on loosely-typed content so it can also filter already-stored
+ * rows on the client (see {@link classifyMessage} for the typed SDK path).
+ */
 export function isTransientProgressMessage(content: unknown): boolean {
   if (!content || typeof content !== 'object') return false;
   const obj = content as Record<string, unknown>;
-  return obj.type === 'system' && obj.subtype === 'thinking_tokens';
+  return (
+    obj.type === 'system' &&
+    typeof obj.subtype === 'string' &&
+    (TRANSIENT_SYSTEM_SUBTYPES as readonly string[]).includes(obj.subtype)
+  );
 }
 
-export function getMessageType(content: unknown): 'system' | 'user' | 'assistant' | 'result' {
-  if (!content || typeof content !== 'object') return 'system';
-  const obj = content as Record<string, unknown>;
-  const type = obj.type;
-  if (type === 'user') return 'user';
-  if (type === 'assistant') return 'assistant';
-  if (type === 'result') return 'result';
-  // All other SDK types map to 'system' for DB storage:
-  // 'system' (init, error, compact_boundary, status, hook_started, hook_response,
-  //           hook_progress, files_persisted, task_notification)
-  // 'tool_progress', 'tool_use_summary', 'auth_status', 'stream_event'
-  return 'system';
+/**
+ * Compile-time exhaustiveness guard that stays safe at runtime.
+ *
+ * Passing a non-`never` value is a type error, so this fails to compile if a
+ * `switch` misses a case (e.g. a newer SDK adds a `SDKMessage` variant). At
+ * runtime it returns `fallback` rather than throwing, so an unexpected message
+ * degrades gracefully instead of crashing the query loop.
+ */
+export function assertNeverFallback<T>(_unhandled: never, fallback: T): T {
+  return fallback;
+}
+
+/**
+ * Decide how to handle a message yielded by the Claude Agent SDK.
+ *
+ * Driven by the SDK's `SDKMessage` discriminated union: the `switch` is
+ * exhaustive over the top-level `type`, so a message type added by a future SDK
+ * release fails to compile here (via {@link assertNeverFallback}) until it is
+ * explicitly handled. New `system` *subtypes* are intentionally not exhaustive —
+ * unknown ones default to being persisted as a generic system message.
+ */
+export function classifyMessage(message: SDKMessage): MessageHandling {
+  switch (message.type) {
+    case 'assistant':
+      return { kind: 'persist', dbType: 'assistant' };
+    case 'user':
+      return { kind: 'persist', dbType: 'user' };
+    case 'result':
+      return { kind: 'persist', dbType: 'result' };
+    case 'stream_event':
+      return { kind: 'stream_event' };
+    case 'system':
+      return isTransientProgressMessage(message)
+        ? { kind: 'skip' }
+        : { kind: 'persist', dbType: 'system' };
+    case 'tool_progress':
+    case 'tool_use_summary':
+    case 'auth_status':
+    case 'rate_limit_event':
+    case 'prompt_suggestion':
+      return { kind: 'persist', dbType: 'system' };
+    default:
+      return assertNeverFallback(message, { kind: 'persist', dbType: 'system' });
+  }
 }
 
 // =============================================================================

--- a/src/server/services/claude-runner.ts
+++ b/src/server/services/claude-runner.ts
@@ -14,11 +14,7 @@ import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { query, type McpServerConfig, type SlashCommand } from '@anthropic-ai/claude-agent-sdk';
 import { prisma } from '@/lib/prisma';
-import {
-  getMessageType,
-  isTransientProgressMessage,
-  SystemInitContentSchema,
-} from '@/lib/claude-messages';
+import { classifyMessage, SystemInitContentSchema } from '@/lib/claude-messages';
 import { extractRepoFullName } from '@/lib/utils';
 import { v4 as uuid, v5 as uuidv5 } from 'uuid';
 import { sseEvents } from './events';
@@ -615,16 +611,17 @@ export async function runClaudeCommand(options: RunClaudeCommandOptions): Promis
         accumulator.reset();
       }
 
-      // Skip transient progress events (e.g. thinking_tokens) — they arrive many
-      // times per turn and carry no durable content. The thinking text itself is
-      // rendered from the assistant message's thinking content blocks.
-      if (isTransientProgressMessage(message)) {
+      // Decide how to handle this message based on the SDK's typed union. Only
+      // 'persist' messages are stored; 'skip' covers transient progress events
+      // (e.g. thinking_tokens), and 'stream_event' was already handled above.
+      const handling = classifyMessage(message);
+      if (handling.kind !== 'persist') {
         continue;
       }
 
       // Persist complete messages
       const messageContent = JSON.stringify(message);
-      const messageType = getMessageType(message);
+      const messageType = handling.dbType;
       const msgId = (message as { uuid?: string }).uuid || uuid();
 
       try {

--- a/src/server/services/claude-runner.ts
+++ b/src/server/services/claude-runner.ts
@@ -14,7 +14,11 @@ import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { query, type McpServerConfig, type SlashCommand } from '@anthropic-ai/claude-agent-sdk';
 import { prisma } from '@/lib/prisma';
-import { getMessageType, SystemInitContentSchema } from '@/lib/claude-messages';
+import {
+  getMessageType,
+  isTransientProgressMessage,
+  SystemInitContentSchema,
+} from '@/lib/claude-messages';
 import { extractRepoFullName } from '@/lib/utils';
 import { v4 as uuid, v5 as uuidv5 } from 'uuid';
 import { sseEvents } from './events';
@@ -609,6 +613,13 @@ export async function runClaudeCommand(options: RunClaudeCommandOptions): Promis
       // Reset accumulator when full assistant message arrives
       if (message.type === 'assistant') {
         accumulator.reset();
+      }
+
+      // Skip transient progress events (e.g. thinking_tokens) — they arrive many
+      // times per turn and carry no durable content. The thinking text itself is
+      // rendered from the assistant message's thinking content blocks.
+      if (isTransientProgressMessage(message)) {
+        continue;
       }
 
       // Persist complete messages

--- a/src/server/services/stream-accumulator.test.ts
+++ b/src/server/services/stream-accumulator.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import { StreamAccumulator } from './stream-accumulator';
+
+/**
+ * Helper to wrap a raw stream event in the message envelope the accumulator expects.
+ */
+function event(e: Record<string, unknown>) {
+  return {
+    type: 'stream_event' as const,
+    event: e as { type: string; [key: string]: unknown },
+    parent_tool_use_id: null,
+    uuid: 'uuid-1',
+    session_id: 'session-1',
+  };
+}
+
+describe('StreamAccumulator', () => {
+  it('accumulates text deltas into a text block', () => {
+    const acc = new StreamAccumulator();
+    acc.accumulate(event({ type: 'message_start', message: { model: 'opus' } }));
+    acc.accumulate(
+      event({ type: 'content_block_start', index: 0, content_block: { type: 'text' } })
+    );
+    acc.accumulate(
+      event({
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'text_delta', text: 'Hello ' },
+      })
+    );
+    const partial = acc.accumulate(
+      event({ type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'world' } })
+    );
+
+    expect(partial?.message.content).toEqual([{ type: 'text', text: 'Hello world' }]);
+  });
+
+  it('accumulates thinking deltas into a thinking block', () => {
+    const acc = new StreamAccumulator();
+    acc.accumulate(event({ type: 'message_start', message: {} }));
+    acc.accumulate(
+      event({ type: 'content_block_start', index: 0, content_block: { type: 'thinking' } })
+    );
+    acc.accumulate(
+      event({
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'thinking_delta', thinking: 'I should ' },
+      })
+    );
+    const partial = acc.accumulate(
+      event({
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'thinking_delta', thinking: 'check this' },
+      })
+    );
+
+    expect(partial?.message.content).toEqual([
+      { type: 'thinking', thinking: 'I should check this' },
+    ]);
+  });
+
+  it('keeps thinking and following text blocks aligned by index', () => {
+    const acc = new StreamAccumulator();
+    acc.accumulate(event({ type: 'message_start', message: {} }));
+    // Thinking block at index 0
+    acc.accumulate(
+      event({ type: 'content_block_start', index: 0, content_block: { type: 'thinking' } })
+    );
+    acc.accumulate(
+      event({
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'thinking_delta', thinking: 'reasoning' },
+      })
+    );
+    // Text block at index 1
+    acc.accumulate(
+      event({ type: 'content_block_start', index: 1, content_block: { type: 'text' } })
+    );
+    const partial = acc.accumulate(
+      event({
+        type: 'content_block_delta',
+        index: 1,
+        delta: { type: 'text_delta', text: 'answer' },
+      })
+    );
+
+    expect(partial?.message.content).toEqual([
+      { type: 'thinking', thinking: 'reasoning' },
+      { type: 'text', text: 'answer' },
+    ]);
+  });
+
+  it('drops unrenderable blocks (redacted_thinking) but keeps indices aligned', () => {
+    const acc = new StreamAccumulator();
+    acc.accumulate(event({ type: 'message_start', message: {} }));
+    // Unknown/redacted block at index 0 (placeholder, not emitted)
+    acc.accumulate(
+      event({ type: 'content_block_start', index: 0, content_block: { type: 'redacted_thinking' } })
+    );
+    // Text block at index 1 must still receive its deltas
+    acc.accumulate(
+      event({ type: 'content_block_start', index: 1, content_block: { type: 'text' } })
+    );
+    const partial = acc.accumulate(
+      event({ type: 'content_block_delta', index: 1, delta: { type: 'text_delta', text: 'hi' } })
+    );
+
+    expect(partial?.message.content).toEqual([{ type: 'text', text: 'hi' }]);
+  });
+
+  it('returns null when only placeholder blocks exist', () => {
+    const acc = new StreamAccumulator();
+    acc.accumulate(event({ type: 'message_start', message: {} }));
+    const partial = acc.accumulate(
+      event({ type: 'content_block_start', index: 0, content_block: { type: 'redacted_thinking' } })
+    );
+    expect(partial).toBeNull();
+  });
+});

--- a/src/server/services/stream-accumulator.ts
+++ b/src/server/services/stream-accumulator.ts
@@ -23,6 +23,7 @@ export interface PartialAssistantMessage {
     role: 'assistant';
     content: Array<
       | { type: 'text'; text: string }
+      | { type: 'thinking'; thinking: string }
       | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> }
     >;
     model?: string;
@@ -35,10 +36,13 @@ export interface PartialAssistantMessage {
 
 /**
  * Represents a content block being accumulated from stream deltas.
+ *
+ * Every content_block_start pushes one entry (including blocks we don't render,
+ * as `other`) so that `event.index` stays aligned with this array.
  */
 interface AccumulatingContentBlock {
-  type: 'text' | 'tool_use';
-  /** For text blocks */
+  type: 'text' | 'thinking' | 'tool_use' | 'other';
+  /** For text and thinking blocks */
   text?: string;
   /** For tool_use blocks */
   id?: string;
@@ -63,11 +67,13 @@ interface StreamEvent {
     id?: string;
     name?: string;
     text?: string;
+    thinking?: string;
     [key: string]: unknown;
   };
   delta?: {
     type: string;
     text?: string;
+    thinking?: string;
     partial_json?: string;
     stop_reason?: string;
     [key: string]: unknown;
@@ -129,8 +135,12 @@ export class StreamAccumulator {
         const block = event.content_block;
         if (!block) return null;
 
+        // Push one entry per block (even unrendered ones) so event.index stays
+        // aligned with this.contentBlocks for subsequent deltas.
         if (block.type === 'text') {
           this.contentBlocks.push({ type: 'text', text: block.text ?? '' });
+        } else if (block.type === 'thinking') {
+          this.contentBlocks.push({ type: 'thinking', text: block.thinking ?? '' });
         } else if (block.type === 'tool_use') {
           this.contentBlocks.push({
             type: 'tool_use',
@@ -138,8 +148,12 @@ export class StreamAccumulator {
             name: block.name ?? '',
             input: '',
           });
+        } else {
+          // Unknown/unrendered block (e.g. redacted_thinking) — keep a placeholder
+          // so indices line up, but it is dropped at emission time.
+          this.contentBlocks.push({ type: 'other' });
         }
-        // Emit after adding a new block (shows tool_use starting)
+        // Emit after adding a new block (shows tool_use / thinking starting)
         return this.buildPartial();
       }
 
@@ -154,6 +168,11 @@ export class StreamAccumulator {
 
         if (delta.type === 'text_delta' && currentBlock.type === 'text') {
           currentBlock.text = (currentBlock.text ?? '') + (delta.text ?? '');
+          return this.buildPartial();
+        }
+
+        if (delta.type === 'thinking_delta' && currentBlock.type === 'thinking') {
+          currentBlock.text = (currentBlock.text ?? '') + (delta.thinking ?? '');
           return this.buildPartial();
         }
 
@@ -198,12 +217,13 @@ export class StreamAccumulator {
   private buildPartial(): PartialAssistantMessage | null {
     if (!this.active || this.contentBlocks.length === 0) return null;
 
-    const content: PartialAssistantMessage['message']['content'] = this.contentBlocks.map(
-      (block) => {
-        if (block.type === 'text') {
-          return { type: 'text' as const, text: block.text ?? '' };
-        }
-        // tool_use block
+    const content: PartialAssistantMessage['message']['content'] = [];
+    for (const block of this.contentBlocks) {
+      if (block.type === 'text') {
+        content.push({ type: 'text', text: block.text ?? '' });
+      } else if (block.type === 'thinking') {
+        content.push({ type: 'thinking', thinking: block.text ?? '' });
+      } else if (block.type === 'tool_use') {
         let parsedInput: Record<string, unknown> = {};
         if (block.input) {
           try {
@@ -214,14 +234,18 @@ export class StreamAccumulator {
             parsedInput = { _partial_json: block.input };
           }
         }
-        return {
-          type: 'tool_use' as const,
+        content.push({
+          type: 'tool_use',
           id: block.id ?? '',
           name: block.name ?? '',
           input: parsedInput,
-        };
+        });
       }
-    );
+      // 'other' placeholder blocks are intentionally dropped
+    }
+
+    // Nothing renderable yet (e.g. only placeholder blocks) — don't emit.
+    if (content.length === 0) return null;
 
     return {
       type: 'assistant',


### PR DESCRIPTION
## Problem

Two related issues with extended-thinking output in the chat UI:

1. **Thinking text was silently dropped.** Assistant messages carry `thinking` / `redacted_thinking` content blocks, but both `StreamAccumulator` and `ContentRenderer` only handled `text` / `tool_use`, so thinking was never shown.
2. **`thinking_tokens` spammed the chat as "System" blocks.** During redacted thinking the SDK emits frequent `{ type: 'system', subtype: 'thinking_tokens' }` progress events (live token-count estimates only). These were persisted and rendered as a stream of empty grey **"System"** bubbles.

## Changes

- Add `thinking` / `redacted_thinking` to the content-block schema (`claude-messages.ts`) and the client `ContentBlock` type.
- `StreamAccumulator`: accumulate `thinking_delta` into partial messages, and push a placeholder for every `content_block_start` (including unrendered ones) so `event.index` stays aligned with following text/tool_use blocks — fixing a latent index-misalignment bug.
- New `ThinkingDisplay` component: renders all thinking in a message as a **single collapsible "Thinking" section** (coalesced/deduplicated), labelled "(redacted)" when only encrypted thinking is present. Thinking text is excluded from copy/voice output.
- Skip persisting/emitting transient `thinking_tokens` messages via a new pure `isTransientProgressMessage` predicate.
- Updated `doc/DESIGN.md`.

## Tests

- `stream-accumulator.test.ts` (new): text/thinking accumulation, index alignment with skipped blocks, placeholder-only → null.
- `claude-messages.test.ts`: thinking/redacted_thinking schema parsing + `isTransientProgressMessage`.
- `MessageBubble.test.tsx`: renders Thinking (not System), coalesces multiple thinking blocks, labels redacted.

All unit + component tests pass; lint/typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)