### PR TITLE
Filter transient messages out of the list to avoid blank gaps

### DIFF
--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -10,6 +10,7 @@ import type { TokenUsageStats } from '@/lib/token-estimation';
 import { useNotification } from '@/hooks/useNotification';
 import { useVoicePlaybackContext } from '@/hooks/useVoicePlayback';
 import { isPlanFile } from './messages/plan-utils';
+import { isTransientProgressMessage } from '@/lib/claude-messages';
 
 interface Message {
   id: string;
@@ -367,7 +368,12 @@ export function MessageList({
   const visibleMessages = useMemo(
     () =>
       messages.filter(
-        (msg) => !pairedMessageIds.has(msg.id) && !isCompletedHookStarted(msg, completedHookIds)
+        (msg) =>
+          !pairedMessageIds.has(msg.id) &&
+          !isCompletedHookStarted(msg, completedHookIds) &&
+          // Transient progress events (e.g. thinking_tokens) carry no content;
+          // filter them here so they don't leave an empty spacer row in the list.
+          !isTransientProgressMessage(msg.content)
       ),
     [messages, pairedMessageIds, completedHookIds]
   );


### PR DESCRIPTION
## Problem

Follow-up to #349. After we stopped persisting/showing transient `thinking_tokens` progress messages, sessions with such rows persisted *before* that change showed up as **blank gaps** in the chat instead of System bubbles.

Cause: `MessageBubble` returns `null` for transient messages, but `MessageList` wraps every message in a `<div className="flex …">` inside a `space-y-4` container. A hidden (`null`) bubble still left its empty wrapper row, and `space-y-4` spaced around it → a visible blank gap.

## Fix

Filter transient progress messages out of `visibleMessages` so no wrapper `<div>` is ever created for them. The `MessageBubble` `null` guard stays as cheap defense-in-depth; both call the shared `isTransientProgressMessage` predicate.

All unit + component tests pass; lint/typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)