### PR TITLE
Handle or ignore all SDK system message subtypes

### DIFF
--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -277,11 +277,21 @@ The SDK emits `stream_event` messages which are accumulated by `StreamAccumulato
 
 When extended thinking is active, assistant messages include `thinking` (and, when the API encrypts reasoning, `redacted_thinking`) content blocks alongside `text` and `tool_use`. These are accumulated during streaming (`thinking_delta` events) and rendered as a single collapsed "Thinking" section per message (`ThinkingDisplay`), coalescing multiple thinking blocks into one. Thinking text is excluded from copy/voice output.
 
-During redacted thinking the SDK also emits frequent `{ type: 'system', subtype: 'thinking_tokens' }` progress messages carrying only live token-count estimates. These are transient and are dropped (not persisted or shown) via `isTransientProgressMessage` in [`src/lib/claude-messages.ts`](../src/lib/claude-messages.ts) so they don't render as a stream of empty "System" bubbles.
+During redacted thinking the SDK also emits frequent `{ type: 'system', subtype: 'thinking_tokens' }` progress messages carrying only live token-count estimates. These are dropped (not persisted or shown) via `isIgnoredSystemMessage` in [`src/lib/claude-messages.ts`](../src/lib/claude-messages.ts) — one of several ignored system subtypes (see [System Message Subtypes](#system-message-subtypes)) — so they don't render as a stream of empty "System" bubbles.
 
 ### Message Classification
 
-Every message yielded by the SDK is routed through `classifyMessage(message)` in [`src/lib/claude-messages.ts`](../src/lib/claude-messages.ts), which returns one of `{ kind: 'stream_event' | 'skip' | 'persist' }` (with the DB column type for `persist`). It `switch`es over the SDK's `SDKMessage` discriminated union and ends in `assertNeverFallback`, a compile-time exhaustiveness guard: if a future SDK release adds a top-level message `type`, the build fails until it is handled here. At runtime an unrecognized type degrades to generic system persistence rather than throwing, so an unexpected frame never crashes the query loop. (New `system` _subtypes_ are intentionally not exhaustive — unknown ones persist as a generic system message.)
+Every message yielded by the SDK is routed through `classifyMessage(message)` in [`src/lib/claude-messages.ts`](../src/lib/claude-messages.ts), which returns one of `{ kind: 'stream_event' | 'skip' | 'persist' }` (with the DB column type for `persist`). It `switch`es over the SDK's `SDKMessage` discriminated union and ends in `assertNeverFallback`, a compile-time exhaustiveness guard: if a future SDK release adds a top-level message `type`, the build fails until it is handled here. At runtime an unrecognized type degrades to generic system persistence rather than throwing, so an unexpected frame never crashes the query loop.
+
+### System Message Subtypes
+
+The SDK emits many `type: 'system'` subtypes. A single `type`-level switch can't distinguish them, so subtype handling is split into three buckets (none of which is compile-time exhaustive — unknown subtypes fall through to a safe default):
+
+1. **Ignored** (`IGNORED_SYSTEM_SUBTYPES` + any message flagged `skip_transcript`): pure progress ticks and internal state — `thinking_tokens`, `task_progress`, `task_updated`, `hook_progress`, `status`, `session_state_changed`, `files_persisted`, `elicitation_complete`, `commands_changed`. `classifyMessage` returns `skip`, so they are never persisted; `isIgnoredSystemMessage` also filters any persisted before a subtype was added (both at the list level in `MessageList` so they leave no empty spacer row, and as a guard in `MessageBubble`).
+2. **Dedicated displays**: `init`, `compact_boundary`, `hook_started`, `hook_response`, and the app's synthetic `error` each have their own component.
+3. **Generic summary**: everything else (e.g. `notification`, `api_retry`, `permission_denied`, `model_refusal_fallback`, `plugin_install`, `memory_recall`, `mirror_error`, `task_started`, `task_notification`) renders through `SystemMessageDisplay`, which calls `summarizeSystemMessage` to produce a never-blank `{ label, body, level }`. Unknown/future subtypes degrade to a humanized label plus any string `content`, so a system message is never an empty bubble. `level: 'warn'` (retries, denials, errors) gets an amber treatment.
+
+Subagent (`Task` tool) lifecycle: `task_started` and `task_notification` are the meaningful bookends and are summarized; the high-frequency `task_progress` ticks and intermediate `task_updated` patches are ignored (their terminal outcome arrives via `task_notification`).
 
 ## Message Storage & Pagination
 

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -10,7 +10,7 @@ import type { TokenUsageStats } from '@/lib/token-estimation';
 import { useNotification } from '@/hooks/useNotification';
 import { useVoicePlaybackContext } from '@/hooks/useVoicePlayback';
 import { isPlanFile } from './messages/plan-utils';
-import { isTransientProgressMessage } from '@/lib/claude-messages';
+import { isIgnoredSystemMessage } from '@/lib/claude-messages';
 
 interface Message {
   id: string;
@@ -371,9 +371,9 @@ export function MessageList({
         (msg) =>
           !pairedMessageIds.has(msg.id) &&
           !isCompletedHookStarted(msg, completedHookIds) &&
-          // Transient progress events (e.g. thinking_tokens) carry no content;
-          // filter them here so they don't leave an empty spacer row in the list.
-          !isTransientProgressMessage(msg.content)
+          // Ignored system events carry no content; filter them here so they
+          // don't leave an empty spacer row in the list.
+          !isIgnoredSystemMessage(msg.content)
       ),
     [messages, pairedMessageIds, completedHookIds]
   );

--- a/src/components/messages/MainMessageBubble.tsx
+++ b/src/components/messages/MainMessageBubble.tsx
@@ -39,7 +39,6 @@ export function MainMessageBubble({
 }: MainMessageBubbleProps) {
   const isUser = category === 'user';
   const isAssistant = category === 'assistant';
-  const isSystem = category === 'system';
   const isError = category === 'systemError';
   const isInterrupted = content.interrupted === true;
 
@@ -71,7 +70,6 @@ export function MainMessageBubble({
           'bg-card border border-blue-300 dark:border-blue-700': isAssistant && isPartial,
           'bg-card border border-amber-300 dark:border-amber-700':
             isAssistant && isInterrupted && !isPartial,
-          'bg-muted text-muted-foreground text-sm': isSystem && !isError,
           'bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 text-red-800 dark:text-red-200 text-sm':
             isError,
         })}
@@ -81,11 +79,6 @@ export function MainMessageBubble({
             <Loader2 className="h-3 w-3 animate-spin" />
             <span>Streaming...</span>
           </div>
-        )}
-        {isSystem && !isError && (
-          <Badge variant="secondary" className="mb-2">
-            System
-          </Badge>
         )}
         {isError && (
           <Badge variant="destructive" className="mb-2">

--- a/src/components/messages/MessageBubble.test.tsx
+++ b/src/components/messages/MessageBubble.test.tsx
@@ -199,20 +199,82 @@ describe('MessageBubble', () => {
     });
   });
 
-  describe('transient progress messages', () => {
-    it('renders nothing for thinking_tokens system messages', () => {
+  describe('ignored system messages', () => {
+    it.each(['thinking_tokens', 'task_progress', 'commands_changed'])(
+      'renders nothing for %s system messages',
+      (subtype) => {
+        const message = {
+          type: 'system',
+          content: { type: 'system', subtype } as MessageContent,
+        };
+
+        const { container } = render(<MessageBubble message={message} />);
+
+        expect(container).toBeEmptyDOMElement();
+      }
+    );
+
+    it('renders nothing for skip_transcript system messages', () => {
       const message = {
         type: 'system',
         content: {
           type: 'system',
-          subtype: 'thinking_tokens',
-          estimated_tokens: 100,
+          subtype: 'task_started',
+          skip_transcript: true,
         } as MessageContent,
       };
 
       const { container } = render(<MessageBubble message={message} />);
 
       expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  describe('generic system messages', () => {
+    it('summarizes a notification instead of an empty bubble', () => {
+      const message = {
+        type: 'system',
+        content: {
+          type: 'system',
+          subtype: 'notification',
+          text: 'Your token will expire soon',
+          priority: 'high',
+        } as MessageContent,
+      };
+
+      render(<MessageBubble message={message} />);
+
+      expect(screen.getByText('Notification')).toBeInTheDocument();
+      expect(screen.getByText('Your token will expire soon')).toBeInTheDocument();
+    });
+
+    it('summarizes an api_retry with attempt count', () => {
+      const message = {
+        type: 'system',
+        content: {
+          type: 'system',
+          subtype: 'api_retry',
+          attempt: 2,
+          max_retries: 5,
+          error: { message: 'overloaded' },
+        } as MessageContent,
+      };
+
+      render(<MessageBubble message={message} />);
+
+      expect(screen.getByText('Retrying request')).toBeInTheDocument();
+      expect(screen.getByText('Attempt 2/5 — overloaded')).toBeInTheDocument();
+    });
+
+    it('falls back to a humanized label for unknown subtypes', () => {
+      const message = {
+        type: 'system',
+        content: { type: 'system', subtype: 'some_future_thing' } as MessageContent,
+      };
+
+      render(<MessageBubble message={message} />);
+
+      expect(screen.getByText('Some Future Thing')).toBeInTheDocument();
     });
   });
 

--- a/src/components/messages/MessageBubble.tsx
+++ b/src/components/messages/MessageBubble.tsx
@@ -11,8 +11,9 @@ import { HookResponseDisplay } from './HookResponseDisplay';
 import { HookStartedDisplay } from './HookStartedDisplay';
 import { CompactBoundaryDisplay } from './CompactBoundaryDisplay';
 import { MainMessageBubble } from './MainMessageBubble';
+import { SystemMessageDisplay } from './SystemMessageDisplay';
 import { isRecognizedMessage, getToolResults } from './messageHelpers';
-import { isTransientProgressMessage } from '@/lib/claude-messages';
+import { isIgnoredSystemMessage } from '@/lib/claude-messages';
 import type { ToolResultMap, MessageContent } from './types';
 
 export function MessageBubble({
@@ -32,9 +33,9 @@ export function MessageBubble({
   const recognition = useMemo(() => isRecognizedMessage(type, content), [type, content]);
   const category = recognition.recognized ? recognition.category : null;
 
-  // Transient progress events (e.g. thinking_tokens) carry no durable content.
-  // New ones are never persisted; this also hides any stored before that change.
-  if (isTransientProgressMessage(content)) {
+  // Ignored system events (transient progress / internal state) carry no durable
+  // content. New ones are never persisted; this also hides any stored earlier.
+  if (isIgnoredSystemMessage(content)) {
     return null;
   }
 
@@ -102,6 +103,14 @@ export function MessageBubble({
           <OctagonX className="h-4 w-4" />
           <span>Interrupted</span>
         </div>
+      </div>
+    );
+  }
+
+  if (category === 'system') {
+    return (
+      <div className="w-full max-w-[85%]">
+        <SystemMessageDisplay content={content} />
       </div>
     );
   }

--- a/src/components/messages/SystemMessageDisplay.tsx
+++ b/src/components/messages/SystemMessageDisplay.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useCallback } from 'react';
+import { cn } from '@/lib/utils';
+import { Badge } from '@/components/ui/badge';
+import { MarkdownContent } from '@/components/MarkdownContent';
+import { CopyButton } from './CopyButton';
+import { summarizeSystemMessage } from './messageHelpers';
+import { formatAsJson } from './types';
+import type { MessageContent } from './types';
+
+/**
+ * Display for generic `system` messages (any subtype without a dedicated
+ * renderer). Shows a concise, never-blank summary via {@link summarizeSystemMessage};
+ * warn-level messages (retries, denials, errors) get an amber treatment.
+ */
+export function SystemMessageDisplay({ content }: { content: MessageContent }) {
+  const { label, body, level } = summarizeSystemMessage(content);
+  const warn = level === 'warn';
+  const getJsonText = useCallback(() => formatAsJson(content), [content]);
+
+  return (
+    <div className="group">
+      <div
+        className={cn('rounded-lg p-3 text-sm', {
+          'bg-muted text-muted-foreground': !warn,
+          'border border-amber-200 bg-amber-50 text-amber-800 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200':
+            warn,
+        })}
+      >
+        <Badge variant={warn ? 'outline' : 'secondary'} className="mb-1">
+          {label}
+        </Badge>
+        {body && <MarkdownContent content={body} />}
+      </div>
+      <div className="mt-1">
+        <CopyButton getText={getJsonText} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/messages/messageHelpers.test.ts
+++ b/src/components/messages/messageHelpers.test.ts
@@ -424,10 +424,13 @@ describe('summarizeSystemMessage', () => {
     });
   });
 
-  it('summarizes api_retry with attempt count and error message', () => {
-    expect(
-      sys({ subtype: 'api_retry', attempt: 3, max_retries: 5, error: { message: 'overloaded' } })
-    ).toEqual({ label: 'Retrying request', body: 'Attempt 3/5 — overloaded', level: 'warn' });
+  it('summarizes api_retry with attempt count and error code', () => {
+    // SDKAssistantMessageError is a string union (e.g. 'overloaded').
+    expect(sys({ subtype: 'api_retry', attempt: 3, max_retries: 5, error: 'overloaded' })).toEqual({
+      label: 'Retrying request',
+      body: 'Attempt 3/5 — overloaded',
+      level: 'warn',
+    });
   });
 
   it('summarizes permission_denied with tool and message', () => {
@@ -447,9 +450,31 @@ describe('summarizeSystemMessage', () => {
     });
   });
 
+  it('summarizes a failed plugin install, extracting an object error', () => {
+    expect(
+      sys({ subtype: 'plugin_install', name: 'foo', status: 'failed', error: { message: 'nope' } })
+    ).toEqual({ label: 'Plugin: foo', body: 'failed — nope', level: 'warn' });
+  });
+
+  it('summarizes a mirror error from a string', () => {
+    expect(sys({ subtype: 'mirror_error', error: 'disk full' })).toEqual({
+      label: 'Mirror error',
+      body: 'disk full',
+      level: 'warn',
+    });
+  });
+
   it('falls back to a humanized label for unknown subtypes', () => {
     expect(sys({ subtype: 'some_future_thing' })).toEqual({
       label: 'Some Future Thing',
+      body: undefined,
+      level: 'info',
+    });
+  });
+
+  it('labels top-level types (no subtype) from the message type', () => {
+    expect(sys({ type: 'prompt_suggestion', suggestion: 'try this' })).toEqual({
+      label: 'Prompt Suggestion',
       body: undefined,
       level: 'info',
     });

--- a/src/components/messages/messageHelpers.test.ts
+++ b/src/components/messages/messageHelpers.test.ts
@@ -8,6 +8,7 @@ import {
   buildToolCalls,
   getCopyText,
   getDisplayContent,
+  summarizeSystemMessage,
 } from './messageHelpers';
 
 describe('extractTextContent', () => {
@@ -401,5 +402,64 @@ describe('getDisplayContent', () => {
   it('returns content.content for system messages', () => {
     const content: MessageContent = { content: 'system text' };
     expect(getDisplayContent(content, 'system')).toBe('system text');
+  });
+});
+
+describe('summarizeSystemMessage', () => {
+  // SDK system messages use loose fields (some, like `message`, collide with the
+  // typed MessageContent wrapper), so build them as plain objects.
+  const sys = (c: Record<string, unknown>) =>
+    summarizeSystemMessage(c as unknown as MessageContent);
+
+  it('summarizes a notification, escalating priority to warn', () => {
+    expect(sys({ subtype: 'notification', text: 'Heads up', priority: 'high' })).toEqual({
+      label: 'Notification',
+      body: 'Heads up',
+      level: 'warn',
+    });
+    expect(sys({ subtype: 'notification', text: 'fyi', priority: 'low' })).toEqual({
+      label: 'Notification',
+      body: 'fyi',
+      level: 'info',
+    });
+  });
+
+  it('summarizes api_retry with attempt count and error message', () => {
+    expect(
+      sys({ subtype: 'api_retry', attempt: 3, max_retries: 5, error: { message: 'overloaded' } })
+    ).toEqual({ label: 'Retrying request', body: 'Attempt 3/5 — overloaded', level: 'warn' });
+  });
+
+  it('summarizes permission_denied with tool and message', () => {
+    expect(
+      sys({ subtype: 'permission_denied', tool_name: 'Bash', message: 'not allowed' })
+    ).toEqual({ label: 'Permission denied', body: 'Bash: not allowed', level: 'warn' });
+  });
+
+  it('summarizes subagent start and completion', () => {
+    expect(
+      sys({ subtype: 'task_started', subagent_type: 'Explore', description: 'find usages' })
+    ).toEqual({ label: 'Subagent started', body: 'Explore: find usages', level: 'info' });
+    expect(sys({ subtype: 'task_notification', status: 'failed', summary: 'boom' })).toEqual({
+      label: 'Subagent failed',
+      body: 'boom',
+      level: 'warn',
+    });
+  });
+
+  it('falls back to a humanized label for unknown subtypes', () => {
+    expect(sys({ subtype: 'some_future_thing' })).toEqual({
+      label: 'Some Future Thing',
+      body: undefined,
+      level: 'info',
+    });
+  });
+
+  it('uses string content as the body for unknown subtypes', () => {
+    expect(sys({ subtype: 'mystery', content: 'raw text' })).toEqual({
+      label: 'Mystery',
+      body: 'raw text',
+      level: 'info',
+    });
   });
 });

--- a/src/components/messages/messageHelpers.ts
+++ b/src/components/messages/messageHelpers.ts
@@ -165,6 +165,134 @@ export function isRecognizedMessage(type: string, content: MessageContent): Reco
 }
 
 /**
+ * A concise, human-readable summary of a generic system message, used so these
+ * messages render meaningful content instead of an empty "System" bubble.
+ */
+export interface SystemMessageSummary {
+  /** Short label shown as a badge (e.g. "Retrying request"). */
+  label: string;
+  /** Optional detail line. Absent when the subtype carries no extra text. */
+  body?: string;
+  /** Drives styling — `warn` for retries/denials/errors. */
+  level: 'info' | 'warn';
+}
+
+/** Turn a snake_case subtype into a Title Case label (fallback for unknowns). */
+function humanizeSubtype(subtype: string | undefined): string {
+  if (!subtype) return 'System';
+  return subtype
+    .split('_')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+/** Pull a readable message out of an SDK error value (string or {message}). */
+function extractErrorMessage(error: unknown): string | undefined {
+  if (typeof error === 'string') return error;
+  if (error && typeof error === 'object') {
+    const message = (error as Record<string, unknown>).message;
+    if (typeof message === 'string') return message;
+  }
+  return undefined;
+}
+
+const asString = (value: unknown): string | undefined =>
+  typeof value === 'string' ? value : undefined;
+
+/**
+ * Summarize a generic `system` message (any subtype not handled by a dedicated
+ * display). Known subtypes get a tailored summary; unknown/future ones fall back
+ * to a humanized label plus any string `content`, so a system message is never
+ * rendered blank.
+ */
+export function summarizeSystemMessage(content: MessageContent): SystemMessageSummary {
+  switch (content.subtype) {
+    case 'notification': {
+      const priority = content.priority;
+      return {
+        label: 'Notification',
+        body: asString(content.text),
+        level: priority === 'high' || priority === 'immediate' ? 'warn' : 'info',
+      };
+    }
+    case 'api_retry': {
+      const attempt = typeof content.attempt === 'number' ? content.attempt : undefined;
+      const max = typeof content.max_retries === 'number' ? content.max_retries : undefined;
+      const parts: string[] = [];
+      if (attempt !== undefined && max !== undefined) parts.push(`Attempt ${attempt}/${max}`);
+      const errMsg = extractErrorMessage(content.error);
+      if (errMsg) parts.push(errMsg);
+      return { label: 'Retrying request', body: parts.join(' — ') || undefined, level: 'warn' };
+    }
+    case 'permission_denied': {
+      const tool = asString(content.tool_name) ?? 'tool';
+      const message = asString(content.message);
+      return {
+        label: 'Permission denied',
+        body: message ? `${tool}: ${message}` : tool,
+        level: 'warn',
+      };
+    }
+    case 'model_refusal_fallback': {
+      const from = asString(content.original_model) ?? '?';
+      const to = asString(content.fallback_model) ?? '?';
+      const why = asString(content.api_refusal_explanation);
+      return {
+        label: 'Model switched after refusal',
+        body: `${from} → ${to}${why ? ` — ${why}` : ''}`,
+        level: 'warn',
+      };
+    }
+    case 'plugin_install': {
+      const name = asString(content.name);
+      const status = asString(content.status) ?? 'unknown';
+      const error = asString(content.error);
+      return {
+        label: name ? `Plugin: ${name}` : 'Plugin install',
+        body: error ? `${status} — ${error}` : status,
+        level: status === 'failed' ? 'warn' : 'info',
+      };
+    }
+    case 'memory_recall': {
+      const count = Array.isArray(content.memories) ? content.memories.length : 0;
+      const mode = asString(content.mode) ?? 'select';
+      return { label: 'Recalled memories', body: `${count} (${mode})`, level: 'info' };
+    }
+    case 'mirror_error':
+      return { label: 'Mirror error', body: asString(content.error), level: 'warn' };
+    case 'task_started': {
+      const description = asString(content.description);
+      const agent = asString(content.subagent_type);
+      return {
+        label: 'Subagent started',
+        body: [agent, description].filter(Boolean).join(': ') || undefined,
+        level: 'info',
+      };
+    }
+    case 'task_notification': {
+      const status = asString(content.status) ?? 'completed';
+      return {
+        label: `Subagent ${status}`,
+        body: asString(content.summary),
+        level: status === 'failed' ? 'warn' : 'info',
+      };
+    }
+    case 'local_command_output':
+      return {
+        label: 'Command output',
+        body: typeof content.content === 'string' ? stripXmlTags(content.content) : undefined,
+        level: 'info',
+      };
+    default:
+      return {
+        label: humanizeSubtype(content.subtype),
+        body: asString(content.content),
+        level: 'info',
+      };
+  }
+}
+
+/**
  * Build tool call objects with results for assistant messages.
  */
 export function buildToolCalls(content: MessageContent, toolResults?: ToolResultMap): ToolCall[] {

--- a/src/components/messages/messageHelpers.ts
+++ b/src/components/messages/messageHelpers.ts
@@ -246,7 +246,7 @@ export function summarizeSystemMessage(content: MessageContent): SystemMessageSu
     case 'plugin_install': {
       const name = asString(content.name);
       const status = asString(content.status) ?? 'unknown';
-      const error = asString(content.error);
+      const error = extractErrorMessage(content.error);
       return {
         label: name ? `Plugin: ${name}` : 'Plugin install',
         body: error ? `${status} — ${error}` : status,
@@ -259,7 +259,7 @@ export function summarizeSystemMessage(content: MessageContent): SystemMessageSu
       return { label: 'Recalled memories', body: `${count} (${mode})`, level: 'info' };
     }
     case 'mirror_error':
-      return { label: 'Mirror error', body: asString(content.error), level: 'warn' };
+      return { label: 'Mirror error', body: extractErrorMessage(content.error), level: 'warn' };
     case 'task_started': {
       const description = asString(content.description);
       const agent = asString(content.subagent_type);
@@ -285,7 +285,9 @@ export function summarizeSystemMessage(content: MessageContent): SystemMessageSu
       };
     default:
       return {
-        label: humanizeSubtype(content.subtype),
+        // Fall back to the message `type` when there is no subtype, so top-level
+        // types persisted as system (e.g. prompt_suggestion) get a real label.
+        label: humanizeSubtype(content.subtype ?? asString(content.type)),
         body: asString(content.content),
         level: 'info',
       };

--- a/src/lib/claude-messages.test.ts
+++ b/src/lib/claude-messages.test.ts
@@ -15,7 +15,7 @@ import {
   parseStoredMessage,
   parseClaudeStreamLine,
   classifyMessage,
-  isTransientProgressMessage,
+  isIgnoredSystemMessage,
   buildToolResultMap,
   AssistantMessage,
   UserMessage,
@@ -668,8 +668,37 @@ describe('claude-messages', () => {
       expect(msg({ type: 'system' })).toEqual({ kind: 'persist', dbType: 'system' });
     });
 
-    it('skips transient system progress events', () => {
-      expect(msg({ type: 'system', subtype: 'thinking_tokens' })).toEqual({ kind: 'skip' });
+    it('skips ignored system progress/state events', () => {
+      for (const subtype of [
+        'thinking_tokens',
+        'task_progress',
+        'task_updated',
+        'hook_progress',
+        'status',
+        'session_state_changed',
+        'files_persisted',
+        'elicitation_complete',
+        'commands_changed',
+      ]) {
+        expect(msg({ type: 'system', subtype })).toEqual({ kind: 'skip' });
+      }
+    });
+
+    it('skips system messages flagged skip_transcript', () => {
+      expect(msg({ type: 'system', subtype: 'task_started', skip_transcript: true })).toEqual({
+        kind: 'skip',
+      });
+    });
+
+    it('persists summarized system subtypes', () => {
+      for (const subtype of [
+        'notification',
+        'api_retry',
+        'permission_denied',
+        'task_notification',
+      ]) {
+        expect(msg({ type: 'system', subtype })).toEqual({ kind: 'persist', dbType: 'system' });
+      }
     });
 
     it('marks stream events for separate accumulation', () => {
@@ -681,30 +710,31 @@ describe('claude-messages', () => {
     });
   });
 
-  describe('isTransientProgressMessage', () => {
-    it('returns true for thinking_tokens system messages', () => {
+  describe('isIgnoredSystemMessage', () => {
+    it('returns true for every ignored subtype', () => {
+      expect(isIgnoredSystemMessage({ type: 'system', subtype: 'thinking_tokens' })).toBe(true);
+      expect(isIgnoredSystemMessage({ type: 'system', subtype: 'task_progress' })).toBe(true);
+      expect(isIgnoredSystemMessage({ type: 'system', subtype: 'commands_changed' })).toBe(true);
+    });
+
+    it('returns true for any system message flagged skip_transcript', () => {
       expect(
-        isTransientProgressMessage({
-          type: 'system',
-          subtype: 'thinking_tokens',
-          estimated_tokens: 100,
-          estimated_tokens_delta: 10,
-        })
+        isIgnoredSystemMessage({ type: 'system', subtype: 'task_started', skip_transcript: true })
       ).toBe(true);
     });
 
-    it('returns false for other system messages', () => {
-      expect(isTransientProgressMessage({ type: 'system', subtype: 'init' })).toBe(false);
-      expect(isTransientProgressMessage({ type: 'system', subtype: 'error' })).toBe(false);
-      expect(isTransientProgressMessage({ type: 'system' })).toBe(false);
+    it('returns false for system messages we render', () => {
+      expect(isIgnoredSystemMessage({ type: 'system', subtype: 'init' })).toBe(false);
+      expect(isIgnoredSystemMessage({ type: 'system', subtype: 'notification' })).toBe(false);
+      expect(isIgnoredSystemMessage({ type: 'system' })).toBe(false);
     });
 
     it('returns false for non-system messages and non-objects', () => {
-      expect(isTransientProgressMessage({ type: 'assistant' })).toBe(false);
-      expect(isTransientProgressMessage({ subtype: 'thinking_tokens' })).toBe(false);
-      expect(isTransientProgressMessage(null)).toBe(false);
-      expect(isTransientProgressMessage(undefined)).toBe(false);
-      expect(isTransientProgressMessage('thinking_tokens')).toBe(false);
+      expect(isIgnoredSystemMessage({ type: 'assistant' })).toBe(false);
+      expect(isIgnoredSystemMessage({ subtype: 'thinking_tokens' })).toBe(false);
+      expect(isIgnoredSystemMessage(null)).toBe(false);
+      expect(isIgnoredSystemMessage(undefined)).toBe(false);
+      expect(isIgnoredSystemMessage('thinking_tokens')).toBe(false);
     });
   });
 

--- a/src/lib/claude-messages.ts
+++ b/src/lib/claude-messages.ts
@@ -825,29 +825,49 @@ export type MessageHandling =
   | { kind: 'persist'; dbType: DbMessageType };
 
 /**
- * System message subtypes that are transient progress events: they arrive
- * frequently during a turn and carry no durable content, so they are never
- * persisted or shown.
+ * System message subtypes that carry no durable value — pure progress ticks or
+ * internal state transitions. They are never persisted or shown.
  *
- * - `thinking_tokens`: live token-count estimates emitted (often many times) while
- *   Claude is thinking. The actual thinking text arrives in the assistant message's
- *   thinking content blocks, so these estimates would otherwise render as a stream
- *   of empty "System" bubbles.
+ * - `thinking_tokens`: live token-count estimates while Claude is thinking; the
+ *   actual reasoning arrives in the assistant message's thinking content blocks.
+ * - `task_progress`: cumulative progress ticks for a running subagent.
+ * - `task_updated`: subagent state-merge patches; the meaningful terminal outcome
+ *   arrives via `task_notification` instead.
+ * - `hook_progress`: streaming hook output between `hook_started`/`hook_response`.
+ * - `status`, `session_state_changed`: transient session/run state.
+ * - `files_persisted`, `elicitation_complete`: internal bookkeeping events.
+ * - `commands_changed`: slash-command list updates (not chat content).
+ *
+ * Without this filter each would render as an empty "System" bubble.
  */
-export const TRANSIENT_SYSTEM_SUBTYPES = ['thinking_tokens'] as const;
+export const IGNORED_SYSTEM_SUBTYPES = [
+  'thinking_tokens',
+  'task_progress',
+  'task_updated',
+  'hook_progress',
+  'status',
+  'session_state_changed',
+  'files_persisted',
+  'elicitation_complete',
+  'commands_changed',
+] as const;
 
 /**
- * Whether a message is a transient progress event that should not be persisted
- * or shown. Operates on loosely-typed content so it can also filter already-stored
- * rows on the client (see {@link classifyMessage} for the typed SDK path).
+ * Whether a system message should be dropped entirely (never persisted or shown).
+ * Operates on loosely-typed content so it can also filter rows stored before a
+ * subtype was added to the ignore list (see {@link classifyMessage} for the typed
+ * SDK path).
  */
-export function isTransientProgressMessage(content: unknown): boolean {
+export function isIgnoredSystemMessage(content: unknown): boolean {
   if (!content || typeof content !== 'object') return false;
   const obj = content as Record<string, unknown>;
+  if (obj.type !== 'system') return false;
+  // The SDK flags ambient/housekeeping tasks with skip_transcript so consumers
+  // hide them from the inline transcript.
+  if (obj.skip_transcript === true) return true;
   return (
-    obj.type === 'system' &&
     typeof obj.subtype === 'string' &&
-    (TRANSIENT_SYSTEM_SUBTYPES as readonly string[]).includes(obj.subtype)
+    (IGNORED_SYSTEM_SUBTYPES as readonly string[]).includes(obj.subtype)
   );
 }
 
@@ -883,7 +903,7 @@ export function classifyMessage(message: SDKMessage): MessageHandling {
     case 'stream_event':
       return { kind: 'stream_event' };
     case 'system':
-      return isTransientProgressMessage(message)
+      return isIgnoredSystemMessage(message)
         ? { kind: 'skip' }
         : { kind: 'persist', dbType: 'system' };
     case 'tool_progress':


### PR DESCRIPTION
## Background

Follow-up to the thinking-blocks work (#349) and the blank-gap fix (#350). The SDK emits **23 `system` subtypes**; we only special-cased 5. Everything else hit the generic bubble, which renders only `content.content` — so ~16 subtypes (`api_retry`, `permission_denied`, `notification`, `task_*`, `memory_recall`, …) showed as **empty grey "System" badges**, and several pure-progress ones were just noise.

## Changes

Three buckets, none requiring compile-time exhaustiveness on subtypes (unknown ones degrade safely):

1. **Ignored** — `IGNORED_SYSTEM_SUBTYPES` + any message flagged `skip_transcript`: `thinking_tokens`, `task_progress`, `task_updated`, `hook_progress`, `status`, `session_state_changed`, `files_persisted`, `elicitation_complete`, `commands_changed`. `classifyMessage` returns `skip` (never persisted); `isIgnoredSystemMessage` filters any stored earlier (in `MessageList`, so no empty spacer row, plus a `MessageBubble` guard).
2. **Dedicated displays** (unchanged): `init`, `compact_boundary`, `hook_started`, `hook_response`, synthetic `error`.
3. **Generic summary** — everything else routes to a new **`SystemMessageDisplay`** backed by a pure `summarizeSystemMessage()` returning `{ label, body, level }`. Tailored summaries for `notification`, `api_retry`, `permission_denied`, `model_refusal_fallback`, `plugin_install`, `memory_recall`, `mirror_error`, `task_started`, `task_notification`, `local_command_output`; **unknown/future subtypes fall back to a humanized label + any string `content`**, so a system message is never blank. Warn-level (retries/denials/errors) gets an amber treatment.

### Subagent (`Task`) lifecycle — answering "are task_progress/task_updated useless?"
- `task_progress`: high-frequency cumulative ticks → **ignored** (only useful as a live indicator we don't have).
- `task_updated`: intermediate state-merge patches whose terminal outcome arrives via `task_notification` → **ignored**.
- `task_started` + `task_notification`: the meaningful bookends → **summarized** ("Subagent started/completed: …").

Also removed the now-dead `system` branch from `MainMessageBubble`.

## Tests
`classifyMessage` skip/persist per subtype + `skip_transcript`; `isIgnoredSystemMessage`; `summarizeSystemMessage` (known subtypes, warn escalation, humanized fallback); `MessageBubble` rendering (ignored → nothing; notification/api_retry/unknown → non-blank summary). All unit + component tests pass; lint/typecheck clean. DESIGN.md updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)