### PR TITLE
Hide assistant fragments with no renderable content

### DIFF
--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -11,6 +11,7 @@ import { useNotification } from '@/hooks/useNotification';
 import { useVoicePlaybackContext } from '@/hooks/useVoicePlayback';
 import { isPlanFile } from './messages/plan-utils';
 import { isIgnoredSystemMessage } from '@/lib/claude-messages';
+import { hasRenderableAssistantContent } from './messages/messageHelpers';
 
 interface Message {
   id: string;
@@ -373,7 +374,13 @@ export function MessageList({
           !isCompletedHookStarted(msg, completedHookIds) &&
           // Ignored system events carry no content; filter them here so they
           // don't leave an empty spacer row in the list.
-          !isIgnoredSystemMessage(msg.content)
+          !isIgnoredSystemMessage(msg.content) &&
+          // Empty assistant fragments (e.g. an empty thinking block) would
+          // otherwise leave an empty spacer row too.
+          !(
+            msg.type === 'assistant' &&
+            !hasRenderableAssistantContent(msg.content as MessageContent)
+          )
       ),
     [messages, pairedMessageIds, completedHookIds]
   );

--- a/src/components/messages/MessageBubble.test.tsx
+++ b/src/components/messages/MessageBubble.test.tsx
@@ -230,6 +230,23 @@ describe('MessageBubble', () => {
     });
   });
 
+  describe('empty assistant fragments', () => {
+    it('renders nothing for an assistant message with only an empty thinking block', () => {
+      const message = {
+        type: 'assistant',
+        content: {
+          message: {
+            content: [{ type: 'thinking', thinking: '', signature: 'sig' }],
+          },
+        } as MessageContent,
+      };
+
+      const { container } = render(<MessageBubble message={message} />);
+
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
   describe('generic system messages', () => {
     it('summarizes a notification instead of an empty bubble', () => {
       const message = {

--- a/src/components/messages/MessageBubble.tsx
+++ b/src/components/messages/MessageBubble.tsx
@@ -12,7 +12,11 @@ import { HookStartedDisplay } from './HookStartedDisplay';
 import { CompactBoundaryDisplay } from './CompactBoundaryDisplay';
 import { MainMessageBubble } from './MainMessageBubble';
 import { SystemMessageDisplay } from './SystemMessageDisplay';
-import { isRecognizedMessage, getToolResults } from './messageHelpers';
+import {
+  isRecognizedMessage,
+  getToolResults,
+  hasRenderableAssistantContent,
+} from './messageHelpers';
 import { isIgnoredSystemMessage } from '@/lib/claude-messages';
 import type { ToolResultMap, MessageContent } from './types';
 
@@ -36,6 +40,12 @@ export function MessageBubble({
   // Ignored system events (transient progress / internal state) carry no durable
   // content. New ones are never persisted; this also hides any stored earlier.
   if (isIgnoredSystemMessage(content)) {
+    return null;
+  }
+
+  // Assistant fragments with nothing renderable (e.g. an empty thinking block
+  // with only a continuity signature) would otherwise show as an empty bubble.
+  if (category === 'assistant' && !hasRenderableAssistantContent(content)) {
     return null;
   }
 

--- a/src/components/messages/messageHelpers.test.ts
+++ b/src/components/messages/messageHelpers.test.ts
@@ -447,6 +447,15 @@ describe('hasRenderableAssistantContent', () => {
   it('returns true for non-array content (handled elsewhere)', () => {
     expect(hasRenderableAssistantContent({ content: 'plain' })).toBe(true);
   });
+
+  it('does not throw on null content or null blocks', () => {
+    expect(hasRenderableAssistantContent(null as unknown as MessageContent)).toBe(true);
+    expect(
+      hasRenderableAssistantContent({
+        message: { content: [null, { type: 'text', text: 'hi' }] as never },
+      })
+    ).toBe(true);
+  });
 });
 
 describe('summarizeSystemMessage', () => {

--- a/src/components/messages/messageHelpers.test.ts
+++ b/src/components/messages/messageHelpers.test.ts
@@ -9,6 +9,7 @@ import {
   getCopyText,
   getDisplayContent,
   summarizeSystemMessage,
+  hasRenderableAssistantContent,
 } from './messageHelpers';
 
 describe('extractTextContent', () => {
@@ -402,6 +403,49 @@ describe('getDisplayContent', () => {
   it('returns content.content for system messages', () => {
     const content: MessageContent = { content: 'system text' };
     expect(getDisplayContent(content, 'system')).toBe('system text');
+  });
+});
+
+describe('hasRenderableAssistantContent', () => {
+  it('returns false when the only block is empty thinking', () => {
+    const content: MessageContent = {
+      message: { content: [{ type: 'thinking', thinking: '', signature: 'sig' }] },
+    };
+    expect(hasRenderableAssistantContent(content)).toBe(false);
+  });
+
+  it('returns false for whitespace-only text and an empty block array', () => {
+    expect(
+      hasRenderableAssistantContent({ message: { content: [{ type: 'text', text: '   ' }] } })
+    ).toBe(false);
+    expect(hasRenderableAssistantContent({ message: { content: [] } })).toBe(false);
+  });
+
+  it('returns true when any block has real content', () => {
+    expect(
+      hasRenderableAssistantContent({
+        message: {
+          content: [
+            { type: 'thinking', thinking: '' },
+            { type: 'text', text: 'hi' },
+          ],
+        },
+      })
+    ).toBe(true);
+    expect(
+      hasRenderableAssistantContent({
+        message: { content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: {} }] },
+      })
+    ).toBe(true);
+    expect(
+      hasRenderableAssistantContent({
+        message: { content: [{ type: 'redacted_thinking' }] },
+      })
+    ).toBe(true);
+  });
+
+  it('returns true for non-array content (handled elsewhere)', () => {
+    expect(hasRenderableAssistantContent({ content: 'plain' })).toBe(true);
   });
 });
 

--- a/src/components/messages/messageHelpers.ts
+++ b/src/components/messages/messageHelpers.ts
@@ -77,6 +77,33 @@ export function getToolResults(content: MessageContent): ContentBlock[] {
 }
 
 /**
+ * Whether an assistant message has any content worth rendering. Filters out
+ * fragments whose blocks would all render to nothing — e.g. a `thinking` block
+ * with empty `thinking` text (just a continuity signature) and nothing else,
+ * which would otherwise show as an empty assistant bubble.
+ *
+ * Keep the renderable cases in sync with `ContentRenderer.renderContentBlocks`.
+ */
+export function hasRenderableAssistantContent(content: MessageContent): boolean {
+  const blocks = content.message?.content;
+  // Non-array content (e.g. a string) is handled by other display paths.
+  if (!Array.isArray(blocks)) return true;
+  return blocks.some((block) => {
+    switch (block.type) {
+      case 'text':
+        return typeof block.text === 'string' && block.text.trim().length > 0;
+      case 'thinking':
+        return typeof block.thinking === 'string' && block.thinking.trim().length > 0;
+      case 'tool_use':
+      case 'redacted_thinking':
+        return true;
+      default:
+        return false;
+    }
+  });
+}
+
+/**
  * Check if a message can be recognized and displayed with our typed components.
  * Returns the message category if recognized, or { recognized: false } for unknown types.
  */

--- a/src/components/messages/messageHelpers.ts
+++ b/src/components/messages/messageHelpers.ts
@@ -85,11 +85,11 @@ export function getToolResults(content: MessageContent): ContentBlock[] {
  * Keep the renderable cases in sync with `ContentRenderer.renderContentBlocks`.
  */
 export function hasRenderableAssistantContent(content: MessageContent): boolean {
-  const blocks = content.message?.content;
+  const blocks = content?.message?.content;
   // Non-array content (e.g. a string) is handled by other display paths.
   if (!Array.isArray(blocks)) return true;
   return blocks.some((block) => {
-    switch (block.type) {
+    switch (block?.type) {
       case 'text':
         return typeof block.text === 'string' && block.text.trim().length > 0;
       case 'thinking':

--- a/src/components/messages/types.ts
+++ b/src/components/messages/types.ts
@@ -16,6 +16,8 @@ export interface ContentBlock {
   text?: string;
   /** For thinking blocks */
   thinking?: string;
+  /** Continuity signature on thinking blocks */
+  signature?: string;
   id?: string;
   name?: string;
   input?: unknown;


### PR DESCRIPTION
## Problem

Empty bubbles still appeared occasionally. The culprit (from a copied message) is an **assistant** message whose only content block is a `thinking` block with empty `thinking` text and just a continuity `signature`:

```json
{ "type": "assistant", "message": { "content": [
  { "type": "thinking", "thinking": "", "signature": "Eso…" }
] }, … }
```

`ContentRenderer` correctly drops the empty thinking block — which leaves the assistant card with nothing inside, and `MessageList` still wraps it in a spacer row → an empty bubble/gap. Prior filters only covered `system` messages.

## Fix

- Add `hasRenderableAssistantContent()` (kept in sync with `ContentRenderer`'s handled block types): true only if some block is non-empty text, non-empty thinking, `tool_use`, or `redacted_thinking`.
- Filter such fragments out of `MessageList` (no spacer row) and guard in `MessageBubble` (renders `null`). Covers already-persisted rows too, and the equivalent empty partial during streaming.
- Add `signature` to the client `ContentBlock` type (a real field on thinking blocks).

## Tests
`hasRenderableAssistantContent` (empty/whitespace/empty-array → false; real content/tool_use/redacted → true) and a `MessageBubble` test asserting an empty-thinking-only assistant message renders nothing. All unit + component tests pass; lint/typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)