### PR TITLE
Syntax-highlight Read/Write and drop Read's line-number gutter

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "dompurify": "^3.4.8",
     "event-source-polyfill": "^1.0.31",
     "get-port": "^7.2.0",
+    "highlight.js": "^11.11.1",
     "lucide-react": "^0.562.0",
     "marked": "^17.0.6",
     "next": "^16.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       get-port:
         specifier: ^7.2.0
         version: 7.2.0
+      highlight.js:
+        specifier: ^11.11.1
+        version: 11.11.1
       lucide-react:
         specifier: ^0.562.0
         version: 0.562.0(react@19.2.7)
@@ -2889,6 +2892,10 @@ packages:
 
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
+
+  highlight.js@11.11.1:
+    resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
+    engines: {node: '>=12.0.0'}
 
   hono@4.12.23:
     resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
@@ -6835,6 +6842,8 @@ snapshots:
   hermes-parser@0.25.1:
     dependencies:
       hermes-estree: 0.25.1
+
+  highlight.js@11.11.1: {}
 
   hono@4.12.23: {}
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -265,3 +265,104 @@ body {
   @apply font-mono text-xs whitespace-pre-wrap break-words;
   color: var(--terminal-fg);
 }
+
+/*
+ * highlight.js theme. Token colors are GitHub-flavored and adapt to dark mode.
+ * The base text uses the normal foreground (inherited), so code reads as normal
+ * text with only syntax accents — applied to Read/Write tool displays.
+ */
+.hljs {
+  --hljs-comment: #6a737d;
+  --hljs-keyword: #d73a49;
+  --hljs-string: #032f62;
+  --hljs-number: #005cc5;
+  --hljs-title: #6f42c1;
+  --hljs-built-in: #e36209;
+  --hljs-type: #d73a49;
+  --hljs-tag: #22863a;
+  --hljs-attr: #005cc5;
+  --hljs-meta: #6a737d;
+}
+
+.dark .hljs {
+  --hljs-comment: #8b949e;
+  --hljs-keyword: #ff7b72;
+  --hljs-string: #a5d6ff;
+  --hljs-number: #79c0ff;
+  --hljs-title: #d2a8ff;
+  --hljs-built-in: #ffa657;
+  --hljs-type: #ff7b72;
+  --hljs-tag: #7ee787;
+  --hljs-attr: #79c0ff;
+  --hljs-meta: #8b949e;
+}
+
+.hljs-comment,
+.hljs-quote {
+  color: var(--hljs-comment);
+  font-style: italic;
+}
+
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-literal,
+.hljs-doctag {
+  color: var(--hljs-keyword);
+}
+
+.hljs-string,
+.hljs-regexp,
+.hljs-template-tag,
+.hljs-template-variable,
+.hljs-addition {
+  color: var(--hljs-string);
+}
+
+.hljs-number,
+.hljs-symbol,
+.hljs-bullet {
+  color: var(--hljs-number);
+}
+
+.hljs-title,
+.hljs-title.function_,
+.hljs-section,
+.hljs-name {
+  color: var(--hljs-title);
+}
+
+.hljs-built_in,
+.hljs-class .hljs-title,
+.hljs-params {
+  color: var(--hljs-built-in);
+}
+
+.hljs-type,
+.hljs-title.class_,
+.hljs-variable.language_ {
+  color: var(--hljs-type);
+}
+
+.hljs-tag,
+.hljs-selector-id,
+.hljs-selector-class {
+  color: var(--hljs-tag);
+}
+
+.hljs-attr,
+.hljs-attribute,
+.hljs-property {
+  color: var(--hljs-attr);
+}
+
+.hljs-meta {
+  color: var(--hljs-meta);
+}
+
+.hljs-emphasis {
+  font-style: italic;
+}
+
+.hljs-strong {
+  font-weight: bold;
+}

--- a/src/components/messages/CodeBlock.tsx
+++ b/src/components/messages/CodeBlock.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useMemo } from 'react';
+import { cn } from '@/lib/utils';
+import { highlightCode } from '@/lib/syntax-highlight';
+
+/**
+ * Renders a block of code with syntax highlighting (via highlight.js) in the
+ * normal foreground color. `fileType` is a {@link getFileType} result; unknown
+ * types render as escaped plain text. Used by Read/Write tool displays.
+ */
+export function CodeBlock({
+  code,
+  fileType,
+  className,
+}: {
+  code: string;
+  fileType: string;
+  className?: string;
+}) {
+  const html = useMemo(() => highlightCode(code, fileType), [code, fileType]);
+
+  return (
+    <pre
+      className={cn(
+        'hljs bg-muted rounded p-2 overflow-auto max-h-96 text-xs leading-relaxed',
+        className
+      )}
+    >
+      <code
+        className="whitespace-pre-wrap break-words"
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    </pre>
+  );
+}

--- a/src/components/messages/ReadDisplay.tsx
+++ b/src/components/messages/ReadDisplay.tsx
@@ -5,6 +5,8 @@ import { Badge } from '@/components/ui/badge';
 import { getFileType } from '@/lib/file-types';
 import { FileIcon } from './FileIcon';
 import { ToolDisplayWrapper } from './ToolDisplayWrapper';
+import { CodeBlock } from './CodeBlock';
+import { parseReadOutput } from './read-output';
 import type { ToolCall } from './types';
 
 interface ReadInput {
@@ -13,61 +15,9 @@ interface ReadInput {
   limit?: number;
 }
 
-interface ParsedLine {
-  lineNumber: number;
-  content: string;
-}
-
-/**
- * Parse Read tool output which has format like "     1→content" where:
- * - Line numbers are right-aligned with spaces
- * - Arrow separator (→) between line number and content
- * - Content may have leading whitespace that should be preserved
- */
-function parseReadOutput(output: string): ParsedLine[] {
-  if (!output || typeof output !== 'string') {
-    return [];
-  }
-
-  const lines = output.split('\n');
-  const result: ParsedLine[] = [];
-
-  // Regex to match Claude's Read output format: spaces + number + → + content
-  // The arrow character is → (U+2192)
-  const linePattern = /^\s*(\d+)→(.*)$/;
-
-  for (const line of lines) {
-    // Skip system-reminder tags that may be injected
-    if (line.includes('<system-reminder>') || line.includes('</system-reminder>')) {
-      continue;
-    }
-
-    const match = line.match(linePattern);
-    if (match) {
-      result.push({
-        lineNumber: parseInt(match[1], 10),
-        content: match[2],
-      });
-    } else if (line.trim() && result.length === 0) {
-      // If we haven't matched the pattern yet and there's content,
-      // this might be raw file content without line numbers
-      // In this case, just add lines with sequential numbers
-      const rawLines = output
-        .split('\n')
-        .filter((l) => !l.includes('<system-reminder>') && !l.includes('</system-reminder>'));
-      return rawLines.map((content, index) => ({
-        lineNumber: index + 1,
-        content,
-      }));
-    }
-  }
-
-  return result;
-}
-
 /**
  * Specialized display for Read tool calls.
- * Shows file path and nicely formatted file content with line numbers.
+ * Shows file path and syntax-highlighted file content (no line-number gutter).
  */
 export function ReadDisplay({ tool }: { tool: ToolCall }) {
   const hasOutput = tool.output !== undefined;
@@ -81,19 +31,7 @@ export function ReadDisplay({ tool }: { tool: ToolCall }) {
   const fileName = filePath.split('/').pop() ?? filePath;
   const fileType = useMemo(() => getFileType(filePath), [filePath]);
 
-  const parsedLines = useMemo(() => {
-    if (typeof tool.output !== 'string') {
-      return [];
-    }
-    return parseReadOutput(tool.output);
-  }, [tool.output]);
-
-  // Calculate the width needed for line numbers based on the highest line number
-  const lineNumberWidth = useMemo(() => {
-    if (parsedLines.length === 0) return 3;
-    const maxLineNum = parsedLines[parsedLines.length - 1]?.lineNumber ?? 1;
-    return Math.max(3, String(maxLineNum).length);
-  }, [parsedLines]);
+  const { code, lineCount } = useMemo(() => parseReadOutput(tool.output), [tool.output]);
 
   return (
     <ToolDisplayWrapper
@@ -110,7 +48,7 @@ export function ReadDisplay({ tool }: { tool: ToolCall }) {
           variant="outline"
           className="text-xs border-blue-500 text-blue-700 dark:text-blue-400"
         >
-          {parsedLines.length} {parsedLines.length === 1 ? 'line' : 'lines'}
+          {lineCount} {lineCount === 1 ? 'line' : 'lines'}
         </Badge>
       }
     >
@@ -146,28 +84,10 @@ export function ReadDisplay({ tool }: { tool: ToolCall }) {
             <pre className="bg-red-50 dark:bg-red-950 text-red-800 dark:text-red-200 p-2 rounded overflow-x-auto max-h-96 overflow-y-auto whitespace-pre-wrap break-words">
               {typeof tool.output === 'string' ? tool.output : JSON.stringify(tool.output, null, 2)}
             </pre>
-          ) : parsedLines.length === 0 ? (
+          ) : code === '' ? (
             <div className="text-muted-foreground italic py-2">(empty file)</div>
           ) : (
-            <div className="bg-muted rounded overflow-hidden">
-              <pre className="max-h-96 overflow-y-auto overflow-x-auto text-sm">
-                <code className="block">
-                  {parsedLines.map(({ lineNumber, content }) => (
-                    <div key={lineNumber} className="flex hover:bg-background/50 leading-relaxed">
-                      {/* Line number */}
-                      <span
-                        className="text-muted-foreground select-none pr-3 pl-2 text-right flex-shrink-0 border-r border-border/50"
-                        style={{ minWidth: `${lineNumberWidth + 2}ch` }}
-                      >
-                        {lineNumber}
-                      </span>
-                      {/* Line content */}
-                      <span className="pl-3 pr-2 whitespace-pre">{content}</span>
-                    </div>
-                  ))}
-                </code>
-              </pre>
-            </div>
+            <CodeBlock code={code} fileType={fileType} />
           )}
         </div>
       )}

--- a/src/components/messages/WriteDisplay.tsx
+++ b/src/components/messages/WriteDisplay.tsx
@@ -7,6 +7,7 @@ import { getFileType } from '@/lib/file-types';
 import { MarkdownContent } from '@/components/MarkdownContent';
 import { FileIcon } from './FileIcon';
 import { ToolDisplayWrapper } from './ToolDisplayWrapper';
+import { CodeBlock } from './CodeBlock';
 import { isPlanFile } from './plan-utils';
 import type { ToolCall } from './types';
 
@@ -106,11 +107,7 @@ export function WriteDisplay({ tool }: { tool: ToolCall }) {
             </span>
           </div>
           {content ? (
-            <pre className="bg-green-50 dark:bg-green-950/50 border border-green-200 dark:border-green-800 p-2 rounded overflow-x-auto max-h-96 overflow-y-auto">
-              <code className="text-green-800 dark:text-green-200 whitespace-pre-wrap break-words">
-                {content}
-              </code>
-            </pre>
+            <CodeBlock code={content} fileType={fileType} />
           ) : (
             <div className="text-muted-foreground italic py-2">(empty file)</div>
           )}

--- a/src/components/messages/read-output.test.ts
+++ b/src/components/messages/read-output.test.ts
@@ -38,6 +38,16 @@ describe('parseReadOutput', () => {
     });
   });
 
+  it('does not strip numeric-tab lines in raw (unnumbered) content', () => {
+    // First line has no prefix, so this is not Read's numbered output; a later
+    // "42\tvalue" line must be preserved verbatim rather than stripped.
+    const output = 'header\n42\tvalue\n';
+    expect(parseReadOutput(output)).toEqual({
+      code: 'header\n42\tvalue',
+      lineCount: 2,
+    });
+  });
+
   it('handles empty and non-string input', () => {
     expect(parseReadOutput('')).toEqual({ code: '', lineCount: 0 });
     expect(parseReadOutput(undefined)).toEqual({ code: '', lineCount: 0 });

--- a/src/components/messages/read-output.test.ts
+++ b/src/components/messages/read-output.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { parseReadOutput } from './read-output';
+
+describe('parseReadOutput', () => {
+  it('strips arrow-style line-number prefixes', () => {
+    const output = '     1→const x = 1;\n     2→const y = 2;\n';
+    expect(parseReadOutput(output)).toEqual({
+      code: 'const x = 1;\nconst y = 2;',
+      lineCount: 2,
+    });
+  });
+
+  it('strips cat -n tab-style line-number prefixes', () => {
+    const output = '     1\tfoo\n     2\tbar\n';
+    expect(parseReadOutput(output)).toEqual({ code: 'foo\nbar', lineCount: 2 });
+  });
+
+  it('preserves content indentation after the prefix', () => {
+    const output = '     1→function f() {\n     2→  return 1;\n     3→}\n';
+    expect(parseReadOutput(output).code).toBe('function f() {\n  return 1;\n}');
+  });
+
+  it('only consumes the first separator, keeping arrows/tabs in content', () => {
+    const output = '     1→a → b\n';
+    expect(parseReadOutput(output).code).toBe('a → b');
+  });
+
+  it('drops injected system-reminder lines', () => {
+    const output = '     1→code\n<system-reminder>note</system-reminder>\n     2→more\n';
+    expect(parseReadOutput(output)).toEqual({ code: 'code\nmore', lineCount: 2 });
+  });
+
+  it('leaves raw content without prefixes untouched', () => {
+    const output = 'plain line one\nplain line two\n';
+    expect(parseReadOutput(output)).toEqual({
+      code: 'plain line one\nplain line two',
+      lineCount: 2,
+    });
+  });
+
+  it('handles empty and non-string input', () => {
+    expect(parseReadOutput('')).toEqual({ code: '', lineCount: 0 });
+    expect(parseReadOutput(undefined)).toEqual({ code: '', lineCount: 0 });
+    expect(parseReadOutput(42)).toEqual({ code: '', lineCount: 0 });
+  });
+});

--- a/src/components/messages/read-output.ts
+++ b/src/components/messages/read-output.ts
@@ -1,0 +1,36 @@
+/** Result of parsing Read tool output into plain code. */
+export interface ParsedReadOutput {
+  /** File content with line-number prefixes removed, ready for highlighting. */
+  code: string;
+  /** Number of content lines (for a summary badge). */
+  lineCount: number;
+}
+
+// Leading line-number prefix in Read output: optional spaces, digits, then a
+// separator. Handles both the arrow style ("   12→code") and cat -n tabs
+// ("   12\tcode"). Only the first separator is consumed, so tab/arrow
+// characters within the content itself are preserved.
+const LINE_PREFIX = /^\s*\d+[→\t]/;
+const SYSTEM_REMINDER = /<\/?system-reminder>/;
+
+/**
+ * Parse Read tool output into plain file content, stripping the line-number
+ * gutter that Read prepends to each line and dropping any injected
+ * system-reminder lines. Returns the de-numbered code and a line count.
+ * Pure function: same input → same output.
+ */
+export function parseReadOutput(output: unknown): ParsedReadOutput {
+  if (typeof output !== 'string' || output === '') {
+    return { code: '', lineCount: 0 };
+  }
+
+  let lines = output.split('\n').filter((line) => !SYSTEM_REMINDER.test(line));
+
+  // Drop a single trailing empty line produced by a terminating newline.
+  if (lines.length > 0 && lines[lines.length - 1] === '') {
+    lines = lines.slice(0, -1);
+  }
+
+  const stripped = lines.map((line) => line.replace(LINE_PREFIX, ''));
+  return { code: stripped.join('\n'), lineCount: stripped.length };
+}

--- a/src/components/messages/read-output.ts
+++ b/src/components/messages/read-output.ts
@@ -31,6 +31,12 @@ export function parseReadOutput(output: unknown): ParsedReadOutput {
     lines = lines.slice(0, -1);
   }
 
-  const stripped = lines.map((line) => line.replace(LINE_PREFIX, ''));
+  // Only strip prefixes if this actually looks like numbered Read output —
+  // detected from the first non-empty line. Otherwise raw content that happens
+  // to start a line with "<number><tab>" would be corrupted.
+  const firstNonEmpty = lines.find((line) => line.trim() !== '');
+  const hasPrefix = firstNonEmpty !== undefined && LINE_PREFIX.test(firstNonEmpty);
+  const stripped = hasPrefix ? lines.map((line) => line.replace(LINE_PREFIX, '')) : lines;
+
   return { code: stripped.join('\n'), lineCount: stripped.length };
 }

--- a/src/lib/syntax-highlight.test.ts
+++ b/src/lib/syntax-highlight.test.ts
@@ -39,4 +39,13 @@ describe('highlightCode', () => {
   it('returns empty string for empty input', () => {
     expect(highlightCode('', 'typescript')).toBe('');
   });
+
+  it('skips highlighting (escaped plain text) for very large input', () => {
+    const huge = `const x = "<b>";\n`.repeat(10000); // > 100k chars
+    expect(huge.length).toBeGreaterThan(100_000);
+    const html = highlightCode(huge, 'typescript');
+    expect(html).not.toContain('hljs-');
+    expect(html).toContain('&lt;b&gt;');
+    expect(html).not.toContain('<b>');
+  });
 });

--- a/src/lib/syntax-highlight.test.ts
+++ b/src/lib/syntax-highlight.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { highlightCode, highlightCodeForFile } from './syntax-highlight';
+
+describe('highlightCode', () => {
+  it('wraps tokens in hljs spans for a known language', () => {
+    const html = highlightCode('const x = 1;', 'typescript');
+    expect(html).toContain('hljs-keyword');
+    expect(html).toContain('const');
+  });
+
+  it('escapes HTML for unknown/unsupported file types', () => {
+    const html = highlightCode('<script>alert(1)</script>', 'text');
+    expect(html).toBe('&lt;script&gt;alert(1)&lt;/script&gt;');
+    expect(html).not.toContain('<script>');
+  });
+
+  it('falls back to escaped plain text for a grammar-less type (prisma)', () => {
+    const html = highlightCode('model User { id Int }', 'prisma');
+    expect(html).toContain('model User');
+    expect(html).not.toContain('hljs-');
+  });
+
+  it('escapes HTML metacharacters even within highlighted output', () => {
+    const html = highlightCode('const html = "<div>" & true;', 'typescript');
+    expect(html).not.toContain('<div>');
+    expect(html).toContain('&lt;div&gt;');
+  });
+
+  it('maps shell file type to the bash grammar', () => {
+    const html = highlightCode('echo "hi"', 'shell');
+    expect(html).toContain('hljs-');
+  });
+
+  it('highlightCodeForFile resolves the language from the path', () => {
+    const html = highlightCodeForFile('def f(): pass', '/tmp/foo.py');
+    expect(html).toContain('hljs-keyword');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(highlightCode('', 'typescript')).toBe('');
+  });
+});

--- a/src/lib/syntax-highlight.ts
+++ b/src/lib/syntax-highlight.ts
@@ -1,0 +1,110 @@
+import hljs from 'highlight.js/lib/core';
+import typescript from 'highlight.js/lib/languages/typescript';
+import javascript from 'highlight.js/lib/languages/javascript';
+import python from 'highlight.js/lib/languages/python';
+import ruby from 'highlight.js/lib/languages/ruby';
+import rust from 'highlight.js/lib/languages/rust';
+import go from 'highlight.js/lib/languages/go';
+import java from 'highlight.js/lib/languages/java';
+import kotlin from 'highlight.js/lib/languages/kotlin';
+import swift from 'highlight.js/lib/languages/swift';
+import c from 'highlight.js/lib/languages/c';
+import cpp from 'highlight.js/lib/languages/cpp';
+import css from 'highlight.js/lib/languages/css';
+import scss from 'highlight.js/lib/languages/scss';
+import less from 'highlight.js/lib/languages/less';
+import xml from 'highlight.js/lib/languages/xml';
+import json from 'highlight.js/lib/languages/json';
+import yaml from 'highlight.js/lib/languages/yaml';
+import markdown from 'highlight.js/lib/languages/markdown';
+import sql from 'highlight.js/lib/languages/sql';
+import bash from 'highlight.js/lib/languages/bash';
+import dockerfile from 'highlight.js/lib/languages/dockerfile';
+import { getFileType } from './file-types';
+
+/**
+ * Map a {@link getFileType} result to a registered highlight.js language id.
+ * File types with no corresponding grammar (e.g. `prisma`, `text`) are absent
+ * and fall back to plain, escaped rendering.
+ */
+const FILE_TYPE_TO_HLJS: Record<string, string> = {
+  typescript: 'typescript',
+  javascript: 'javascript',
+  python: 'python',
+  ruby: 'ruby',
+  rust: 'rust',
+  go: 'go',
+  java: 'java',
+  kotlin: 'kotlin',
+  swift: 'swift',
+  c: 'c',
+  cpp: 'cpp',
+  css: 'css',
+  scss: 'scss',
+  less: 'less',
+  html: 'xml',
+  xml: 'xml',
+  json: 'json',
+  yaml: 'yaml',
+  markdown: 'markdown',
+  sql: 'sql',
+  shell: 'bash',
+  docker: 'dockerfile',
+};
+
+let registered = false;
+
+/** Register the curated language set once (highlight.js is a singleton). */
+function ensureRegistered(): void {
+  if (registered) return;
+  hljs.registerLanguage('typescript', typescript);
+  hljs.registerLanguage('javascript', javascript);
+  hljs.registerLanguage('python', python);
+  hljs.registerLanguage('ruby', ruby);
+  hljs.registerLanguage('rust', rust);
+  hljs.registerLanguage('go', go);
+  hljs.registerLanguage('java', java);
+  hljs.registerLanguage('kotlin', kotlin);
+  hljs.registerLanguage('swift', swift);
+  hljs.registerLanguage('c', c);
+  hljs.registerLanguage('cpp', cpp);
+  hljs.registerLanguage('css', css);
+  hljs.registerLanguage('scss', scss);
+  hljs.registerLanguage('less', less);
+  hljs.registerLanguage('xml', xml);
+  hljs.registerLanguage('json', json);
+  hljs.registerLanguage('yaml', yaml);
+  hljs.registerLanguage('markdown', markdown);
+  hljs.registerLanguage('sql', sql);
+  hljs.registerLanguage('bash', bash);
+  hljs.registerLanguage('dockerfile', dockerfile);
+  registered = true;
+}
+
+/** Escape HTML so plain (un-highlighted) code is rendered safely as text. */
+function escapeHtml(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+/**
+ * Highlight `code` for the given {@link getFileType} result, returning an HTML
+ * string of `<span class="hljs-...">` tokens (themed via CSS). Languages without
+ * a grammar — or any highlighting error — fall back to escaped plain text, so
+ * the output is always safe to inject. Pure function: same inputs → same output.
+ */
+export function highlightCode(code: string, fileType: string): string {
+  const language = FILE_TYPE_TO_HLJS[fileType];
+  if (!language) return escapeHtml(code);
+
+  ensureRegistered();
+  try {
+    return hljs.highlight(code, { language, ignoreIllegals: true }).value;
+  } catch {
+    return escapeHtml(code);
+  }
+}
+
+/** Convenience: highlight by file path rather than a pre-computed file type. */
+export function highlightCodeForFile(code: string, filePath: string): string {
+  return highlightCode(code, getFileType(filePath));
+}

--- a/src/lib/syntax-highlight.ts
+++ b/src/lib/syntax-highlight.ts
@@ -87,14 +87,21 @@ function escapeHtml(value: string): string {
 }
 
 /**
+ * Above this length, skip highlighting and render escaped plain text. hljs runs
+ * synchronously on the render thread, so a huge file would freeze the tab.
+ */
+const MAX_HIGHLIGHT_CHARS = 100_000;
+
+/**
  * Highlight `code` for the given {@link getFileType} result, returning an HTML
  * string of `<span class="hljs-...">` tokens (themed via CSS). Languages without
- * a grammar — or any highlighting error — fall back to escaped plain text, so
- * the output is always safe to inject. Pure function: same inputs → same output.
+ * a grammar, inputs over {@link MAX_HIGHLIGHT_CHARS}, or any highlighting error
+ * fall back to escaped plain text, so the output is always safe to inject. Pure
+ * function: same inputs → same output.
  */
 export function highlightCode(code: string, fileType: string): string {
   const language = FILE_TYPE_TO_HLJS[fileType];
-  if (!language) return escapeHtml(code);
+  if (!language || code.length > MAX_HIGHLIGHT_CHARS) return escapeHtml(code);
 
   ensureRegistered();
   try {


### PR DESCRIPTION
Follow-up to #353 (inline diff). Makes the Read/Write/Edit displays consistent and more readable.

## Changes

**Read line numbers → gone.** Read previously rendered its own line-number gutter *and*, when the output format didn't match its regex, fell back to showing raw lines that still contained the embedded `N→` prefix — so line numbers appeared twice. Per discussion, dropped the gutter entirely. A new pure `parseReadOutput()` strips line-number prefixes (both arrow `N→` and `cat -n` tab styles) and injected `<system-reminder>` lines.

**Syntax highlighting for Read & Write.** Code now renders in the normal foreground color with syntax accents instead of an all-green block.
- Added `highlight.js` (core + a curated language set, registered once) behind a pure `highlightCode(code, fileType)` helper that maps our existing `getFileType()` results to grammars. Unknown/grammar-less types (e.g. `prisma`, `text`) fall back to escaped plain text, so output is always safe to inject.
- New shared `CodeBlock` component used by both Read and Write.
- GitHub-style hljs theme in `globals.css` using CSS variables that adapt to dark mode.

**Edit** is unchanged — its red/green diff already reads well, and layering token highlighting onto the word-level diff spans wasn't worth the complexity.

### Not done: collapsing sequential Edits
Considered grouping consecutive Edits into one whole-file diff, but we don't receive full file contents and overlapping edits could conflict — agreed it's not worth it.

## Library note
Syntax highlighting needs a real grammar engine. Chose `highlight.js` core (synchronous, lean via selective language registration, themed with our own CSS) over `react-syntax-highlighter` (perf issues with many instances in a chat list) and Shiki (async init + heavy bundle).

## Testing
- `syntax-highlight.test.ts` (7) — token spans, HTML escaping/XSS safety, grammar-less fallback, path resolution
- `read-output.test.ts` (8) — arrow & tab prefixes, indentation preserved, separator-in-content, system-reminder stripping, raw/empty input
- Full suite: 443 passing; `tsc`, eslint, and `next build` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)