### PR TITLE
Fix interactive question/plan answering with server-side routing

### DIFF
--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -166,9 +166,25 @@ claude.send({ sessionId: string, prompt: string })
   // Starts a query() call in-process using the Claude Agent SDK
   // Messages stream to the client via SSE
 
-claude.answerQuestion({ sessionId: string, answers: Record<string, string> })
-  → { success: true }
-  // Resolves a pending AskUserQuestion canUseTool callback
+claude.answerQuestion({
+  sessionId: string,
+  toolUseId: string,                    // the AskUserQuestion tool_use block id
+  answers: Record<string, string>
+})
+  → { success: true, routed: 'live' | 'fallback' | 'already' }
+  // Delivers answers to an AskUserQuestion tool call. The server decides how
+  // (see "Answering Interactive Tools" below): resolve the live canUseTool
+  // promise, or — if the query has ended — resume with a new turn.
+
+claude.respondToPlan({
+  sessionId: string,
+  toolUseId: string,                    // the ExitPlanMode tool_use block id
+  approve: boolean,
+  feedback?: string                     // revision notes (used when approve=false)
+})
+  → { success: true, routed: 'live' | 'fallback' | 'already' }
+  // Approve or request changes to an ExitPlanMode plan, routed the same way
+  // as answerQuestion.
 
 claude.interrupt({ sessionId: string })
   → { success: true }
@@ -201,8 +217,7 @@ claude.getHistory({
 1. User sends prompt via `claude.send()`
 2. Next.js server calls `query()` from the Claude Agent SDK directly in-process, with `resume: sessionId` for follow-up messages
 3. The `canUseTool` callback handles:
-   - **AskUserQuestion**: Parks a promise, sends the question to the browser via SSE (as a normal assistant message with tool_use). User answers via `claude.answerQuestion()` mutation, which resolves the promise.
-   - **ExitPlanMode**: Similar flow — user approves/rejects the plan.
+   - **AskUserQuestion** / **ExitPlanMode**: Parks a promise keyed by the SDK's `toolUseID`, sends the question/plan to the browser via SSE (as a normal assistant message with a `tool_use` block). The user responds via `claude.answerQuestion()` / `claude.respondToPlan()` (see [Answering Interactive Tools](#answering-interactive-tools)).
    - **All other tools**: Auto-approved (bypass permissions mode).
 4. Messages stream from the SDK:
    - **Partial messages**: `stream_event` messages are accumulated by `StreamAccumulator` and emitted via SSE for real-time UI updates (not persisted).
@@ -263,9 +278,19 @@ Each user prompt is a separate `query()` call with `resume: sessionId` for multi
 
 The SDK's `canUseTool` callback handles interactive tools:
 
-- **AskUserQuestion**: The callback parks a `Promise` that resolves when the user answers via the `claude.answerQuestion` tRPC mutation. The question appears as a normal assistant message (tool_use block) in the UI.
-- **ExitPlanMode**: Similar flow — user approves/rejects the plan.
+- **AskUserQuestion** / **ExitPlanMode**: The callback parks a `Promise` (keyed by the SDK's `toolUseID`) in the in-memory session state. It is resolved when the user responds — see [Answering Interactive Tools](#answering-interactive-tools). The request appears as a normal assistant message (`tool_use` block) in the UI.
 - **All other tools**: Auto-approved (`bypassPermissions` mode).
+
+### Answering Interactive Tools
+
+The hard part is that the parked `Promise` lives only in the in-memory session map. It is destroyed when the query ends — completion, stop, interrupt, or a **server restart** — but the `tool_use` block survives in the database forever. If the UI decided interactivity from its own state, the two could disagree (controls shown for a question that can no longer be answered), or a transient running-state signal could wrongly disable the controls. To avoid this, **the server is authoritative** and the UI stays dumb:
+
+- **UI rule**: answer controls are shown whenever a `tool_use` block has no matching `tool_result` (purely DB-derived in `MessageList`/`AskUserQuestionDisplay`/`ExitPlanModeDisplay`). The UI never consults running-state to decide interactivity. On submit it calls `claude.answerQuestion` / `claude.respondToPlan` with the block's `toolUseId`.
+- **Server routing** (`submitToolResponse` in [`src/server/routers/claude.ts`](../src/server/routers/claude.ts)):
+  1. **Live** — if a query is still parked on that `toolUseId`, resolve the in-memory promise so the current turn continues (cheap, no new query). A short wait covers the rare race where the answer beats the SDK's `canUseTool` call.
+  2. **Fallback** — if no live promise exists (the query ended), the original tool call can never be resolved, so the answer is delivered as a **new turn**: the server persists a synthetic `tool_result` for the block (pairing it in the UI so the controls disappear) and resumes the session with a prompt built from the answer. This is the automatic "fall back to the normal chat interface" path.
+- **Idempotency**: the synthetic `tool_result`'s message id is derived from the `toolUseId`, so a duplicate submit hits the unique constraint and is a no-op (`routed: 'already'`) — a double answer never starts two turns.
+- **Mapping responses**: an `AskUserQuestion` answer resolves `allow` with the selected answers; an `ExitPlanMode` approval resolves `allow`, while "request changes" resolves `deny` with the feedback message so Claude revises in place. On the fallback path these become natural-language prompts (see `formatToolResponsePrompt` in [`src/lib/tool-response.ts`](../src/lib/tool-response.ts)).
 
 ### Streaming
 

--- a/src/app/session/[id]/page.tsx
+++ b/src/app/session/[id]/page.tsx
@@ -52,6 +52,7 @@ function SessionView({ sessionId }: { sessionId: string }) {
     interrupt,
     isInterrupting,
     answerQuestion,
+    respondToPlan,
     commands,
   } = useClaudeState(sessionId);
 
@@ -203,8 +204,6 @@ function SessionView({ sessionId }: { sessionId: string }) {
               hasMore={hasMore}
               onLoadMore={fetchMore}
               tokenUsage={tokenUsage}
-              onSendResponse={() => {}}
-              isClaudeRunning={false}
             />
             <div className="border-t bg-muted/50 px-4 py-3 text-center text-sm text-muted-foreground">
               This session has been archived. You can view the message history but cannot send new
@@ -260,7 +259,7 @@ function SessionView({ sessionId }: { sessionId: string }) {
           tokenUsage={tokenUsage}
           onSendResponse={handleSendPromptWithVoice}
           onAnswerQuestion={answerQuestion}
-          isClaudeRunning={isClaudeRunning}
+          onRespondToPlan={respondToPlan}
         />
 
         {voiceOverlayOpen && voiceConfig.enabled ? (

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -250,8 +250,8 @@ interface MessageListProps {
   onLoadMore: () => void;
   tokenUsage?: TokenUsageStats | null;
   onSendResponse?: (response: string) => void;
-  onAnswerQuestion?: (answers: Record<string, string>) => void;
-  isClaudeRunning?: boolean;
+  onAnswerQuestion?: (toolUseId: string, answers: Record<string, string>) => void;
+  onRespondToPlan?: (toolUseId: string, approve: boolean, feedback?: string) => void;
 }
 
 export function MessageList({
@@ -262,7 +262,7 @@ export function MessageList({
   tokenUsage,
   onSendResponse,
   onAnswerQuestion,
-  isClaudeRunning,
+  onRespondToPlan,
 }: MessageListProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const topSentinelRef = useRef<HTMLDivElement>(null);
@@ -553,7 +553,7 @@ export function MessageList({
       onTodoManualToggle: handleTodoManualToggle,
       onSendResponse,
       onAnswerQuestion,
-      isClaudeRunning,
+      onRespondToPlan,
       latestPlanContent,
     }),
     [
@@ -562,7 +562,7 @@ export function MessageList({
       handleTodoManualToggle,
       onSendResponse,
       onAnswerQuestion,
-      isClaudeRunning,
+      onRespondToPlan,
       latestPlanContent,
     ]
   );

--- a/src/components/messages/AskUserQuestionDisplay.test.tsx
+++ b/src/components/messages/AskUserQuestionDisplay.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AskUserQuestionDisplay } from './AskUserQuestionDisplay';
+import { MessageListProvider } from './MessageListContext';
+import type { ToolCall } from './types';
+
+const QUESTION_TOOL: ToolCall = {
+  name: 'AskUserQuestion',
+  id: 'toolu_q1',
+  input: {
+    questions: [
+      {
+        question: 'Which approach?',
+        header: 'Approach',
+        multiSelect: false,
+        options: [
+          { label: 'Option A', description: 'first' },
+          { label: 'Option B', description: 'second' },
+        ],
+      },
+    ],
+  },
+};
+
+function renderWithContext(
+  tool: ToolCall,
+  ctx: Partial<React.ComponentProps<typeof MessageListProvider>['value']> = {}
+) {
+  return render(
+    <MessageListProvider
+      value={{
+        latestTodoWriteId: null,
+        manuallyToggledTodoIds: new Set(),
+        onTodoManualToggle: vi.fn(),
+        latestPlanContent: null,
+        ...ctx,
+      }}
+    >
+      <AskUserQuestionDisplay tool={tool} />
+    </MessageListProvider>
+  );
+}
+
+describe('AskUserQuestionDisplay', () => {
+  it('answers with the tool_use id when an option is clicked', async () => {
+    const onAnswerQuestion = vi.fn();
+    renderWithContext(QUESTION_TOOL, { onAnswerQuestion });
+
+    await userEvent.click(screen.getByText('Option A'));
+
+    expect(onAnswerQuestion).toHaveBeenCalledWith('toolu_q1', { 'Which approach?': 'Option A' });
+  });
+
+  it('stays interactive regardless of any running state (no isClaudeRunning gate)', () => {
+    // The fix removed the running-state gate: a pending question is always
+    // answerable, and the server decides how to route the answer.
+    const onAnswerQuestion = vi.fn();
+    renderWithContext(QUESTION_TOOL, { onAnswerQuestion });
+
+    const option = screen.getByText('Option A').closest('button');
+    expect(option).not.toBeDisabled();
+  });
+
+  it('is read-only once the tool call has a result', () => {
+    const onAnswerQuestion = vi.fn();
+    renderWithContext({ ...QUESTION_TOOL, output: 'Option A' }, { onAnswerQuestion });
+
+    expect(screen.getByRole('button', { name: /Option A/ })).toBeDisabled();
+  });
+
+  it('falls back to text response when no tool_use id is available', async () => {
+    const onSendResponse = vi.fn();
+    renderWithContext({ ...QUESTION_TOOL, id: undefined }, { onSendResponse });
+
+    await userEvent.click(screen.getByText('Option B'));
+
+    expect(onSendResponse).toHaveBeenCalledWith('Option B');
+  });
+});

--- a/src/components/messages/AskUserQuestionDisplay.tsx
+++ b/src/components/messages/AskUserQuestionDisplay.tsx
@@ -98,7 +98,7 @@ export function AskUserQuestionDisplay({ tool }: { tool: ToolCall }) {
   const ctx = useMessageListContext();
   const onSendResponse = ctx?.onSendResponse;
   const onAnswerQuestion = ctx?.onAnswerQuestion;
-  const isClaudeRunning = ctx?.isClaudeRunning;
+  const toolUseId = tool.id;
 
   // Track selected options per question. For single-select: Set with 0 or 1 item.
   const [selectedOptions, setSelectedOptions] = useState<Map<number, Set<number>>>(new Map());
@@ -137,15 +137,19 @@ export function AskUserQuestionDisplay({ tool }: { tool: ToolCall }) {
       answers[question.question] = selectedLabels.join(', ');
     }
 
-    if (onAnswerQuestion) {
-      onAnswerQuestion(answers);
+    if (onAnswerQuestion && toolUseId) {
+      onAnswerQuestion(toolUseId, answers);
     } else if (onSendResponse) {
-      // Fallback: send as text
+      // Fallback: send as text (e.g. tool id missing)
       onSendResponse(Object.values(answers).join('; '));
     }
-  }, [questions, selectedOptions, onAnswerQuestion, onSendResponse]);
+  }, [questions, selectedOptions, onAnswerQuestion, onSendResponse, toolUseId]);
 
-  const canInteract = isPending && !isClaudeRunning && (!!onAnswerQuestion || !!onSendResponse);
+  // Interactivity is driven purely by whether this tool call still needs an
+  // answer (no paired result yet). The server decides how to deliver it —
+  // resolving the live tool call or resuming as a new turn — so the UI never
+  // needs to track whether Claude is "running".
+  const canInteract = isPending && ((!!onAnswerQuestion && !!toolUseId) || !!onSendResponse);
 
   // Check if all questions have at least one selection
   const allQuestionsAnswered =
@@ -187,8 +191,8 @@ export function AskUserQuestionDisplay({ tool }: { tool: ToolCall }) {
       // Single question, single select: submit immediately
       const option = question.options[optionIndex];
       if (option) {
-        if (onAnswerQuestion) {
-          onAnswerQuestion({ [question.question]: option.label });
+        if (onAnswerQuestion && toolUseId) {
+          onAnswerQuestion(toolUseId, { [question.question]: option.label });
         } else if (onSendResponse) {
           onSendResponse(option.label);
         }

--- a/src/components/messages/ExitPlanModeDisplay.tsx
+++ b/src/components/messages/ExitPlanModeDisplay.tsx
@@ -2,6 +2,8 @@
 
 import { useCallback, useState } from 'react';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
 import { MarkdownContent } from '@/components/MarkdownContent';
 import { ToolDisplayWrapper } from './ToolDisplayWrapper';
 import { useMessageListContext } from './MessageListContext';
@@ -78,12 +80,30 @@ function CheckIcon() {
 export function ExitPlanModeDisplay({ tool }: { tool: ToolCall }) {
   const ctx = useMessageListContext();
   const planContent = ctx?.latestPlanContent;
+  const onRespondToPlan = ctx?.onRespondToPlan;
   const hasOutput = tool.output !== undefined;
   const isPending = !hasOutput;
+  const toolUseId = tool.id;
   const [copied, setCopied] = useState(false);
+  const [showFeedback, setShowFeedback] = useState(false);
+  const [feedback, setFeedback] = useState('');
+
+  // Interactivity is driven purely by whether this plan still needs a response.
+  // The server decides how to deliver it (resolve the live tool call or resume
+  // as a new turn), so the UI doesn't track whether Claude is "running".
+  const canRespond = isPending && !!onRespondToPlan && !!toolUseId;
 
   const inputObj = tool.input as ExitPlanModeInput | undefined;
   const allowedPrompts = inputObj?.allowedPrompts ?? [];
+
+  const handleApprove = useCallback(() => {
+    if (onRespondToPlan && toolUseId) onRespondToPlan(toolUseId, true);
+  }, [onRespondToPlan, toolUseId]);
+
+  const handleRequestChanges = useCallback(() => {
+    if (onRespondToPlan && toolUseId)
+      onRespondToPlan(toolUseId, false, feedback.trim() || undefined);
+  }, [onRespondToPlan, toolUseId, feedback]);
 
   const handleCopyPlan = useCallback(async () => {
     if (!planContent) return;
@@ -174,6 +194,42 @@ export function ExitPlanModeDisplay({ tool }: { tool: ToolCall }) {
       {/* Show status message if no plan content available */}
       {!planContent && isPending && (
         <div className="text-muted-foreground italic py-2">Waiting for plan approval...</div>
+      )}
+
+      {/* Approve / request-changes controls */}
+      {canRespond && (
+        <div className="pt-3 mt-1 border-t space-y-2">
+          {showFeedback && (
+            <Textarea
+              value={feedback}
+              onChange={(e) => setFeedback(e.target.value)}
+              placeholder="What should change about the plan? (optional)"
+              className="min-h-[72px] text-sm"
+              autoFocus
+            />
+          )}
+          <div className="flex gap-2">
+            {showFeedback ? (
+              <>
+                <Button size="sm" onClick={handleRequestChanges}>
+                  Send changes
+                </Button>
+                <Button size="sm" variant="ghost" onClick={() => setShowFeedback(false)}>
+                  Cancel
+                </Button>
+              </>
+            ) : (
+              <>
+                <Button size="sm" onClick={handleApprove}>
+                  Approve &amp; proceed
+                </Button>
+                <Button size="sm" variant="outline" onClick={() => setShowFeedback(true)}>
+                  Request changes
+                </Button>
+              </>
+            )}
+          </div>
+        </div>
       )}
     </ToolDisplayWrapper>
   );

--- a/src/components/messages/ExitPlanModeDisplay.tsx
+++ b/src/components/messages/ExitPlanModeDisplay.tsx
@@ -96,14 +96,14 @@ export function ExitPlanModeDisplay({ tool }: { tool: ToolCall }) {
   const inputObj = tool.input as ExitPlanModeInput | undefined;
   const allowedPrompts = inputObj?.allowedPrompts ?? [];
 
-  const handleApprove = useCallback(() => {
+  const handleApprove = () => {
     if (onRespondToPlan && toolUseId) onRespondToPlan(toolUseId, true);
-  }, [onRespondToPlan, toolUseId]);
+  };
 
-  const handleRequestChanges = useCallback(() => {
+  const handleRequestChanges = () => {
     if (onRespondToPlan && toolUseId)
       onRespondToPlan(toolUseId, false, feedback.trim() || undefined);
-  }, [onRespondToPlan, toolUseId, feedback]);
+  };
 
   const handleCopyPlan = useCallback(async () => {
     if (!planContent) return;

--- a/src/components/messages/MessageListContext.tsx
+++ b/src/components/messages/MessageListContext.tsx
@@ -11,10 +11,10 @@ interface MessageListContextValue {
   onTodoManualToggle: (toolId: string) => void;
   /** Callback to send a response to Claude (for AskUserQuestion) */
   onSendResponse?: (response: string) => void;
-  /** Callback to answer an AskUserQuestion via canUseTool (preferred over onSendResponse) */
-  onAnswerQuestion?: (answers: Record<string, string>) => void;
-  /** Whether Claude is currently running (disables AskUserQuestion interactions) */
-  isClaudeRunning?: boolean;
+  /** Answer an AskUserQuestion tool call (preferred over onSendResponse) */
+  onAnswerQuestion?: (toolUseId: string, answers: Record<string, string>) => void;
+  /** Respond to an ExitPlanMode tool call (approve or request changes) */
+  onRespondToPlan?: (toolUseId: string, approve: boolean, feedback?: string) => void;
   /** The latest plan content from Write/Edit of plan files, or null */
   latestPlanContent: string | null;
 }

--- a/src/hooks/useClaudeState.ts
+++ b/src/hooks/useClaudeState.ts
@@ -29,13 +29,7 @@ export function useClaudeState(sessionId: string) {
     { sessionId },
     {
       onData: (trackedData) => {
-        utils.claude.isRunning.setData(
-          { sessionId },
-          {
-            running: trackedData.data.running,
-            hasPendingInput: false,
-          }
-        );
+        utils.claude.isRunning.setData({ sessionId }, { running: trackedData.data.running });
         // When Claude finishes running, refetch commands in case new ones were discovered
         if (!trackedData.data.running) {
           refetchCommands();
@@ -63,6 +57,7 @@ export function useClaudeState(sessionId: string) {
   const sendMutation = trpc.claude.send.useMutation();
   const interruptMutation = trpc.claude.interrupt.useMutation();
   const answerMutation = trpc.claude.answerQuestion.useMutation();
+  const respondToPlanMutation = trpc.claude.respondToPlan.useMutation();
 
   const send = useCallback(
     (prompt: string) => {
@@ -76,10 +71,17 @@ export function useClaudeState(sessionId: string) {
   }, [sessionId, interruptMutation]);
 
   const answerQuestion = useCallback(
-    (answers: Record<string, string>) => {
-      answerMutation.mutate({ sessionId, answers });
+    (toolUseId: string, answers: Record<string, string>) => {
+      answerMutation.mutate({ sessionId, toolUseId, answers });
     },
     [sessionId, answerMutation]
+  );
+
+  const respondToPlan = useCallback(
+    (toolUseId: string, approve: boolean, feedback?: string) => {
+      respondToPlanMutation.mutate({ sessionId, toolUseId, approve, feedback });
+    },
+    [sessionId, respondToPlanMutation]
   );
 
   const isRunning = runningData?.running ?? false;
@@ -91,6 +93,7 @@ export function useClaudeState(sessionId: string) {
     interrupt,
     isInterrupting: interruptMutation.isPending,
     answerQuestion,
+    respondToPlan,
     commands,
   };
 }

--- a/src/lib/tool-response.test.ts
+++ b/src/lib/tool-response.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import {
+  summarizeToolResponse,
+  formatToolResponsePrompt,
+  buildSyntheticToolResultContent,
+  type ToolResponse,
+} from './tool-response';
+import { UserContentSchema } from './claude-messages';
+
+describe('summarizeToolResponse', () => {
+  it('joins question answer values', () => {
+    const response: ToolResponse = {
+      kind: 'questions',
+      answers: { 'Which approach?': 'Option A', 'Use TypeScript?': 'Yes' },
+    };
+    expect(summarizeToolResponse(response)).toBe('Option A, Yes');
+  });
+
+  it('handles empty question answers', () => {
+    expect(summarizeToolResponse({ kind: 'questions', answers: {} })).toBe('No selection');
+    expect(summarizeToolResponse({ kind: 'questions', answers: { q: '  ' } })).toBe('No selection');
+  });
+
+  it('summarizes plan approval', () => {
+    expect(summarizeToolResponse({ kind: 'plan', approve: true })).toBe('Plan approved');
+  });
+
+  it('summarizes plan rejection with and without feedback', () => {
+    expect(summarizeToolResponse({ kind: 'plan', approve: false })).toBe('Changes requested');
+    expect(summarizeToolResponse({ kind: 'plan', approve: false, feedback: 'use a queue' })).toBe(
+      'Changes requested: use a queue'
+    );
+  });
+});
+
+describe('formatToolResponsePrompt', () => {
+  it('formats question answers as labeled blocks', () => {
+    const prompt = formatToolResponsePrompt({
+      kind: 'questions',
+      answers: { 'Which approach?': 'Option A', 'Use TypeScript?': 'Yes' },
+    });
+    expect(prompt).toContain('Here are my answers to your questions:');
+    expect(prompt).toContain('**Which approach?**\nOption A');
+    expect(prompt).toContain('**Use TypeScript?**\nYes');
+  });
+
+  it('skips blank answers and degrades gracefully when none remain', () => {
+    expect(formatToolResponsePrompt({ kind: 'questions', answers: { q: '' } })).toBe(
+      'I have no answer to your questions; please use your best judgment.'
+    );
+  });
+
+  it('formats plan approval, with optional notes', () => {
+    expect(formatToolResponsePrompt({ kind: 'plan', approve: true })).toBe(
+      'I approve this plan. Please go ahead and implement it.'
+    );
+    expect(
+      formatToolResponsePrompt({ kind: 'plan', approve: true, feedback: 'ship it' })
+    ).toContain('Additional notes:\nship it');
+  });
+
+  it('formats plan rejection, with optional feedback', () => {
+    expect(formatToolResponsePrompt({ kind: 'plan', approve: false })).toBe(
+      "I'd like you to revise the plan before implementing it."
+    );
+    expect(formatToolResponsePrompt({ kind: 'plan', approve: false, feedback: 'too risky' })).toBe(
+      'Please revise the plan before implementing it. too risky'
+    );
+  });
+});
+
+describe('buildSyntheticToolResultContent', () => {
+  it('produces a valid UserContent tool_result that pairs by tool_use_id', () => {
+    const content = buildSyntheticToolResultContent({
+      sessionId: 'session-1',
+      toolUseId: 'toolu_abc',
+      uuid: 'uuid-1',
+      text: 'Option A',
+    });
+
+    // Must parse against the same schema the message list uses, so the UI
+    // pairs the dangling tool_use exactly like a real SDK result.
+    const parsed = UserContentSchema.safeParse(content);
+    expect(parsed.success).toBe(true);
+
+    const block = content.message.content[0];
+    expect(block).toMatchObject({
+      type: 'tool_result',
+      tool_use_id: 'toolu_abc',
+      content: 'Option A',
+      is_error: false,
+    });
+  });
+});

--- a/src/lib/tool-response.ts
+++ b/src/lib/tool-response.ts
@@ -1,0 +1,100 @@
+/**
+ * Pure helpers for responding to interactive tool calls (AskUserQuestion /
+ * ExitPlanMode).
+ *
+ * A response can be delivered two ways (decided by the server, see
+ * `submitToolResponse` in the claude router):
+ *
+ * 1. **Live**: a `query()` is still parked in its `canUseTool` callback, so the
+ *    parked promise is resolved and the same turn continues.
+ * 2. **Fallback**: the query has ended (completed, stopped, or the server
+ *    restarted), so the dangling `tool_use` can never be resolved. Instead we
+ *    persist a synthetic `tool_result` (so the UI pairs the block and stops
+ *    showing answer controls) and resume the session with a new turn built from
+ *    {@link formatToolResponsePrompt}.
+ *
+ * These functions are pure so the formatting/serialization is unit-testable
+ * without the SDK or the database.
+ */
+
+import type { UserContent } from './claude-messages';
+
+/** A user's response to a parked interactive tool call. */
+export type ToolResponse =
+  | { kind: 'questions'; answers: Record<string, string> }
+  | { kind: 'plan'; approve: boolean; feedback?: string };
+
+/**
+ * Short human-readable summary stored as the synthetic `tool_result` content on
+ * the fallback path. The AskUserQuestion display matches this against option
+ * labels to highlight what was chosen, so for questions it is the answer values
+ * joined by `, `.
+ */
+export function summarizeToolResponse(response: ToolResponse): string {
+  if (response.kind === 'questions') {
+    const values = Object.values(response.answers).filter((v) => v.trim().length > 0);
+    return values.length > 0 ? values.join(', ') : 'No selection';
+  }
+
+  if (response.approve) {
+    return 'Plan approved';
+  }
+  const feedback = response.feedback?.trim();
+  return feedback ? `Changes requested: ${feedback}` : 'Changes requested';
+}
+
+/**
+ * Build the prompt sent as a new turn when the original tool call is gone.
+ * Phrased as if the user is replying, so the resumed conversation reads
+ * naturally.
+ */
+export function formatToolResponsePrompt(response: ToolResponse): string {
+  if (response.kind === 'questions') {
+    const lines = Object.entries(response.answers)
+      .filter(([, answer]) => answer.trim().length > 0)
+      .map(([question, answer]) => `**${question}**\n${answer.trim()}`);
+
+    if (lines.length === 0) {
+      return 'I have no answer to your questions; please use your best judgment.';
+    }
+    return `Here are my answers to your questions:\n\n${lines.join('\n\n')}`;
+  }
+
+  const feedback = response.feedback?.trim();
+  if (response.approve) {
+    const base = 'I approve this plan. Please go ahead and implement it.';
+    return feedback ? `${base}\n\nAdditional notes:\n${feedback}` : base;
+  }
+  return feedback
+    ? `Please revise the plan before implementing it. ${feedback}`
+    : "I'd like you to revise the plan before implementing it.";
+}
+
+/**
+ * Build a synthetic `user`/`tool_result` message that pairs a dangling
+ * `tool_use` block. Matches {@link UserContent} so it parses and pairs exactly
+ * like a real SDK tool result in the message list.
+ */
+export function buildSyntheticToolResultContent(params: {
+  sessionId: string;
+  toolUseId: string;
+  uuid: string;
+  text: string;
+}): UserContent {
+  return {
+    type: 'user',
+    message: {
+      role: 'user',
+      content: [
+        {
+          type: 'tool_result',
+          tool_use_id: params.toolUseId,
+          content: params.text,
+          is_error: false,
+        },
+      ],
+    },
+    session_id: params.sessionId,
+    uuid: params.uuid,
+  };
+}

--- a/src/server/routers/claude.integration.test.ts
+++ b/src/server/routers/claude.integration.test.ts
@@ -273,6 +273,44 @@ describe('claudeRouter integration', () => {
       expect(mockRunClaudeCommand).toHaveBeenCalledTimes(1);
     });
 
+    it('does not drop a second answer when two tool calls are answered concurrently', async () => {
+      // Two different tool_use ids answered at once race on the read-then-insert
+      // sequence assignment. Both must be written (with retry) — neither should
+      // be silently reported as already-answered.
+      const session = await createRunningSession();
+      mockIsClaudeRunningAsync.mockResolvedValue(false);
+      mockRunClaudeCommand.mockResolvedValue(undefined);
+
+      const caller = createCaller('auth-session-id');
+      const [a, b] = await Promise.all([
+        caller.claude.answerQuestion({
+          sessionId: session.id,
+          toolUseId: 'toolu_a',
+          answers: { q: 'A' },
+        }),
+        caller.claude.answerQuestion({
+          sessionId: session.id,
+          toolUseId: 'toolu_b',
+          answers: { q: 'B' },
+        }),
+      ]);
+
+      expect(a.routed).toBe('fallback');
+      expect(b.routed).toBe('fallback');
+
+      const messages = await testPrisma.message.findMany({ where: { sessionId: session.id } });
+      const toolUseIds = messages
+        .map((m) => JSON.parse(m.content).message?.content?.[0]?.tool_use_id)
+        .filter(Boolean);
+      expect(toolUseIds).toContain('toolu_a');
+      expect(toolUseIds).toContain('toolu_b');
+
+      // Sequences must be unique (no collision survived).
+      const sequences = messages.map((m) => m.sequence);
+      expect(new Set(sequences).size).toBe(sequences.length);
+      expect(mockRunClaudeCommand).toHaveBeenCalledTimes(2);
+    });
+
     it('throws CONFLICT when a query is still processing', async () => {
       const session = await createRunningSession();
       mockIsClaudeRunningAsync.mockResolvedValue(true);

--- a/src/server/routers/claude.integration.test.ts
+++ b/src/server/routers/claude.integration.test.ts
@@ -207,6 +207,143 @@ describe('claudeRouter integration', () => {
     });
   });
 
+  describe('answerQuestion (fallback path)', () => {
+    // With no in-memory query parked, submitLiveToolResponse returns false, so
+    // these exercise the resume fallback that runs when the runner is gone
+    // (e.g. after a server restart).
+    const createRunningSession = () =>
+      testPrisma.session.create({
+        data: {
+          name: 'Q Session',
+          repoUrl: 'https://github.com/owner/repo.git',
+          branch: 'main',
+          workspacePath: '/workspace/test',
+          status: 'running',
+        },
+      });
+
+    it('marks the question answered and resumes with a new turn', async () => {
+      const session = await createRunningSession();
+      mockIsClaudeRunningAsync.mockResolvedValue(false);
+      mockRunClaudeCommand.mockResolvedValue(undefined);
+
+      const caller = createCaller('auth-session-id');
+      const result = await caller.claude.answerQuestion({
+        sessionId: session.id,
+        toolUseId: 'toolu_q1',
+        answers: { 'Which approach?': 'Option A' },
+      });
+
+      expect(result).toEqual({ success: true, routed: 'fallback' });
+
+      // A synthetic tool_result was persisted so the UI pairs the dangling block.
+      const messages = await testPrisma.message.findMany({ where: { sessionId: session.id } });
+      const toolResult = messages.find((m) => {
+        const content = JSON.parse(m.content);
+        return content.message?.content?.[0]?.tool_use_id === 'toolu_q1';
+      });
+      expect(toolResult).toBeDefined();
+
+      // And the answer was resumed as a new prompt.
+      expect(mockRunClaudeCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId: session.id,
+          prompt: expect.stringContaining('Option A'),
+        })
+      );
+    });
+
+    it('is idempotent: a duplicate answer does not start a second turn', async () => {
+      const session = await createRunningSession();
+      mockIsClaudeRunningAsync.mockResolvedValue(false);
+      mockRunClaudeCommand.mockResolvedValue(undefined);
+
+      const caller = createCaller('auth-session-id');
+      const args = {
+        sessionId: session.id,
+        toolUseId: 'toolu_dup',
+        answers: { q: 'A' },
+      };
+
+      const first = await caller.claude.answerQuestion(args);
+      const second = await caller.claude.answerQuestion(args);
+
+      expect(first.routed).toBe('fallback');
+      expect(second.routed).toBe('already');
+      expect(mockRunClaudeCommand).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws CONFLICT when a query is still processing', async () => {
+      const session = await createRunningSession();
+      mockIsClaudeRunningAsync.mockResolvedValue(true);
+
+      const caller = createCaller('auth-session-id');
+
+      await expect(
+        caller.claude.answerQuestion({
+          sessionId: session.id,
+          toolUseId: 'toolu_busy',
+          answers: { q: 'A' },
+        })
+      ).rejects.toMatchObject({ code: 'CONFLICT' });
+      expect(mockRunClaudeCommand).not.toHaveBeenCalled();
+    });
+
+    it('throws PRECONDITION_FAILED when the session is not running', async () => {
+      const session = await testPrisma.session.create({
+        data: {
+          name: 'Stopped Q Session',
+          repoUrl: 'https://github.com/owner/repo.git',
+          branch: 'main',
+          workspacePath: '/workspace/test',
+          status: 'stopped',
+        },
+      });
+
+      const caller = createCaller('auth-session-id');
+
+      await expect(
+        caller.claude.answerQuestion({
+          sessionId: session.id,
+          toolUseId: 'toolu_stopped',
+          answers: { q: 'A' },
+        })
+      ).rejects.toMatchObject({ code: 'PRECONDITION_FAILED' });
+    });
+  });
+
+  describe('respondToPlan (fallback path)', () => {
+    it('resumes with a revise prompt when changes are requested', async () => {
+      const session = await testPrisma.session.create({
+        data: {
+          name: 'Plan Session',
+          repoUrl: 'https://github.com/owner/repo.git',
+          branch: 'main',
+          workspacePath: '/workspace/test',
+          status: 'running',
+        },
+      });
+      mockIsClaudeRunningAsync.mockResolvedValue(false);
+      mockRunClaudeCommand.mockResolvedValue(undefined);
+
+      const caller = createCaller('auth-session-id');
+      const result = await caller.claude.respondToPlan({
+        sessionId: session.id,
+        toolUseId: 'toolu_plan',
+        approve: false,
+        feedback: 'use a queue',
+      });
+
+      expect(result).toEqual({ success: true, routed: 'fallback' });
+      expect(mockRunClaudeCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId: session.id,
+          prompt: expect.stringContaining('use a queue'),
+        })
+      );
+    });
+  });
+
   describe('interrupt', () => {
     it('should interrupt Claude successfully', async () => {
       const session = await testPrisma.session.create({
@@ -421,7 +558,7 @@ describe('claudeRouter integration', () => {
         sessionId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
       });
 
-      expect(result).toEqual({ running: true, hasPendingInput: false });
+      expect(result).toEqual({ running: true });
     });
 
     it('should return not running status', async () => {
@@ -432,7 +569,7 @@ describe('claudeRouter integration', () => {
         sessionId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
       });
 
-      expect(result).toEqual({ running: false, hasPendingInput: false });
+      expect(result).toEqual({ running: false });
     });
 
     it('should require authentication', async () => {

--- a/src/server/routers/claude.ts
+++ b/src/server/routers/claude.ts
@@ -7,9 +7,8 @@ import {
   interruptClaude,
   isClaudeRunningAsync,
   markLastMessageAsInterrupted,
-  answerUserInput,
-  hasPendingInput,
-  getPendingInput,
+  submitLiveToolResponse,
+  persistSyntheticToolResult,
   getSessionCommands,
 } from '../services/claude-runner';
 import { loadMergedSessionSettings } from '../services/settings-merger';
@@ -17,8 +16,105 @@ import { getSessionWorkingDir } from '../services/worktree-manager';
 import { estimateTokenUsage } from '@/lib/token-estimation';
 import { createLogger, toError } from '@/lib/logger';
 import { extractRepoFullName } from '@/lib/utils';
+import {
+  type ToolResponse,
+  summarizeToolResponse,
+  formatToolResponsePrompt,
+} from '@/lib/tool-response';
 
 const log = createLogger('claude');
+
+/** Minimal session fields needed to launch a Claude query. */
+type LaunchableSession = { repoUrl: string | null; repoPath: string };
+
+/**
+ * Load merged settings and start a Claude query in the background.
+ * Shared by `send` and the tool-response fallback path.
+ */
+async function launchClaude(
+  session: LaunchableSession,
+  sessionId: string,
+  prompt: string
+): Promise<void> {
+  const repoFullName = session.repoUrl ? extractRepoFullName(session.repoUrl) : null;
+  const settingsKey = repoFullName ?? '__no_repo__';
+  const settings = await loadMergedSessionSettings(settingsKey);
+  const workingDir = getSessionWorkingDir(sessionId, session.repoPath);
+
+  log.info('Launching Claude command', { sessionId, workingDir });
+
+  // Start Claude in the background - don't await
+  runClaudeCommand({
+    sessionId,
+    prompt,
+    workingDir,
+    customSystemPrompt: settings.customSystemPrompt,
+    globalSettings: settings.globalSettings,
+    claudeModel: settings.claudeModel,
+    envVars: settings.envVars,
+    claudeApiKey: settings.claudeApiKey,
+    mcpServers: settings.mcpServers,
+  }).catch((err) => {
+    log.error('Claude command failed', toError(err), { sessionId });
+  });
+}
+
+/**
+ * Deliver a response to an interactive tool call (AskUserQuestion / ExitPlanMode),
+ * choosing how to route it based on authoritative server state:
+ *
+ * 1. If the query is still parked in `canUseTool`, resolve the live promise and
+ *    continue the same turn.
+ * 2. Otherwise the query has ended (completed, stopped, or the server
+ *    restarted) — the original tool call can't be resolved. Mark it answered
+ *    with a synthetic tool_result (idempotent) and resume with a new turn.
+ *
+ * The caller (UI) never needs to know which path is taken.
+ */
+async function submitToolResponse(
+  sessionId: string,
+  toolUseId: string,
+  response: ToolResponse
+): Promise<{ routed: 'live' | 'fallback' | 'already' }> {
+  if (await submitLiveToolResponse(sessionId, toolUseId, response)) {
+    return { routed: 'live' };
+  }
+
+  const session = await prisma.session.findUnique({
+    where: { id: sessionId },
+    select: { status: true, repoUrl: true, repoPath: true },
+  });
+  if (!session) {
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'Session not found' });
+  }
+  if (session.status !== 'running') {
+    throw new TRPCError({
+      code: 'PRECONDITION_FAILED',
+      message: 'Session is not running. Start it to respond.',
+    });
+  }
+  // A live promise should have been found above; if a query is still running it
+  // hasn't parked yet (or is busy with something else). Don't start a second
+  // turn — let the client retry.
+  if (await isClaudeRunningAsync(sessionId)) {
+    throw new TRPCError({
+      code: 'CONFLICT',
+      message: 'Claude is still processing. Try again in a moment.',
+    });
+  }
+
+  const wrote = await persistSyntheticToolResult(
+    sessionId,
+    toolUseId,
+    summarizeToolResponse(response)
+  );
+  if (!wrote) {
+    return { routed: 'already' };
+  }
+
+  await launchClaude(session, sessionId, formatToolResponsePrompt(response));
+  return { routed: 'fallback' };
+}
 
 export const claudeRouter = router({
   send: protectedProcedure
@@ -31,6 +127,7 @@ export const claudeRouter = router({
     .mutation(async ({ input }) => {
       const session = await prisma.session.findUnique({
         where: { id: input.sessionId },
+        select: { status: true, repoUrl: true, repoPath: true },
       });
 
       if (!session) {
@@ -54,33 +151,7 @@ export const claudeRouter = router({
         });
       }
 
-      // Load and merge global + per-repo settings
-      const repoFullName = session.repoUrl ? extractRepoFullName(session.repoUrl) : null;
-      const settingsKey = repoFullName ?? '__no_repo__';
-      const settings = await loadMergedSessionSettings(settingsKey);
-
-      // Build working directory
-      const workingDir = getSessionWorkingDir(input.sessionId, session.repoPath);
-
-      log.info('Starting Claude command', {
-        sessionId: input.sessionId,
-        workingDir,
-      });
-
-      // Start Claude in the background - don't await
-      runClaudeCommand({
-        sessionId: input.sessionId,
-        prompt: input.prompt,
-        workingDir,
-        customSystemPrompt: settings.customSystemPrompt,
-        globalSettings: settings.globalSettings,
-        claudeModel: settings.claudeModel,
-        envVars: settings.envVars,
-        claudeApiKey: settings.claudeApiKey,
-        mcpServers: settings.mcpServers,
-      }).catch((err) => {
-        log.error('Claude command failed', toError(err), { sessionId: input.sessionId });
-      });
+      await launchClaude(session, input.sessionId, input.prompt);
 
       return { success: true };
     }),
@@ -89,27 +160,34 @@ export const claudeRouter = router({
     .input(
       z.object({
         sessionId: z.string().uuid(),
+        toolUseId: z.string().min(1),
         answers: z.record(z.string(), z.string()),
       })
     )
     .mutation(async ({ input }) => {
-      const answered = answerUserInput(input.sessionId, input.answers);
-
-      if (!answered) {
-        throw new TRPCError({
-          code: 'PRECONDITION_FAILED',
-          message: 'No pending question for this session',
-        });
-      }
-
-      return { success: true };
+      const { routed } = await submitToolResponse(input.sessionId, input.toolUseId, {
+        kind: 'questions',
+        answers: input.answers,
+      });
+      return { success: true, routed };
     }),
 
-  getPendingQuestion: protectedProcedure
-    .input(z.object({ sessionId: z.string().uuid() }))
-    .query(({ input }) => {
-      const pending = getPendingInput(input.sessionId);
-      return { pending };
+  respondToPlan: protectedProcedure
+    .input(
+      z.object({
+        sessionId: z.string().uuid(),
+        toolUseId: z.string().min(1),
+        approve: z.boolean(),
+        feedback: z.string().max(100000).optional(),
+      })
+    )
+    .mutation(async ({ input }) => {
+      const { routed } = await submitToolResponse(input.sessionId, input.toolUseId, {
+        kind: 'plan',
+        approve: input.approve,
+        feedback: input.feedback,
+      });
+      return { success: true, routed };
     }),
 
   interrupt: protectedProcedure
@@ -207,7 +285,6 @@ export const claudeRouter = router({
     .query(async ({ input }) => {
       return {
         running: await isClaudeRunningAsync(input.sessionId),
-        hasPendingInput: hasPendingInput(input.sessionId),
       };
     }),
 

--- a/src/server/services/claude-runner.test.ts
+++ b/src/server/services/claude-runner.test.ts
@@ -48,8 +48,7 @@ import {
   resetBaseEnvCache,
   mergeSlashCommands,
   getSessionCommands,
-  answerUserInput,
-  hasPendingInput,
+  submitLiveToolResponse,
   isClaudeRunning,
   isClaudeRunningAsync,
   markAllSessionsStopped,
@@ -317,16 +316,13 @@ describe('claude-runner', () => {
     });
   });
 
-  describe('answerUserInput', () => {
-    it('should return false when no pending input exists', () => {
-      const result = answerUserInput('nonexistent-session', { q: 'answer' });
+  describe('submitLiveToolResponse', () => {
+    it('returns false immediately when no query is running for the session', async () => {
+      const result = await submitLiveToolResponse('nonexistent-session', 'toolu_1', {
+        kind: 'questions',
+        answers: { q: 'answer' },
+      });
       expect(result).toBe(false);
-    });
-  });
-
-  describe('hasPendingInput', () => {
-    it('should return false for nonexistent sessions', () => {
-      expect(hasPendingInput('nonexistent-session')).toBe(false);
     });
   });
 

--- a/src/server/services/claude-runner.ts
+++ b/src/server/services/claude-runner.ts
@@ -533,9 +533,16 @@ export async function runClaudeCommand(options: RunClaudeCommandOptions): Promis
         // so the frontend enables the answer UI
         sseEvents.emitClaudeRunning(sessionId, false);
 
-        // Park a promise that will be resolved when the user answers
+        // Park a promise that will be resolved when the user answers. Only one
+        // request can be parked at a time; if the SDK asks for a second
+        // interactive tool before the first is answered (e.g. parallel tool
+        // calls), reject the earlier one rather than orphaning its promise and
+        // wedging the turn.
         try {
           return await new Promise<PermissionResult>((resolve, reject) => {
+            if (state.pendingInput) {
+              state.pendingInput.reject(new Error('Superseded by another tool request'));
+            }
             state.pendingInput = { toolName, toolUseId: toolUseID, input, resolve, reject };
           });
         } finally {
@@ -783,15 +790,24 @@ export async function submitLiveToolResponse(
   }
 }
 
+/** Number of times to retry sequence assignment when a concurrent insert wins the race. */
+const SEQUENCE_RETRY_LIMIT = 5;
+
 /**
  * Persist a synthetic `tool_result` for a tool_use whose query has ended, so the
  * UI pairs the dangling block and stops showing answer controls.
  *
- * The message id is derived from the tool_use id, so a duplicate submit is a
- * no-op (insert hits the unique constraint) — this both makes the fallback
- * idempotent and prevents a double answer from starting two turns.
+ * The message id is derived from the tool_use id, so a duplicate answer for the
+ * same tool call is a no-op (it collides on the primary key) — this makes the
+ * fallback idempotent and prevents a double answer from starting two turns.
  *
- * @returns true if a result was written, false if one already existed.
+ * Sequence is assigned read-then-insert (see the broader race in #356); a
+ * concurrent insert can therefore collide on the `(sessionId, sequence)` unique.
+ * We disambiguate that from a duplicate-answer collision by re-checking the id,
+ * and retry the sequence so a different concurrent answer is never silently
+ * dropped.
+ *
+ * @returns true if a result was written, false if this tool call was already answered.
  */
 export async function persistSyntheticToolResult(
   sessionId: string,
@@ -799,37 +815,52 @@ export async function persistSyntheticToolResult(
   text: string
 ): Promise<boolean> {
   const id = uuidv5(`${sessionId}:tool_result:${toolUseId}`, ERROR_LINE_NAMESPACE);
-
-  const lastMessage = await prisma.message.findFirst({
-    where: { sessionId },
-    orderBy: { sequence: 'desc' },
-    select: { sequence: true },
-  });
-  const sequence = (lastMessage?.sequence ?? -1) + 1;
-
   const content = buildSyntheticToolResultContent({ sessionId, toolUseId, uuid: id, text });
 
-  try {
-    const message = await prisma.message.create({
-      data: { id, sessionId, sequence, type: 'user', content: JSON.stringify(content) },
+  for (let attempt = 0; attempt < SEQUENCE_RETRY_LIMIT; attempt++) {
+    const lastMessage = await prisma.message.findFirst({
+      where: { sessionId },
+      orderBy: { sequence: 'desc' },
+      select: { sequence: true },
     });
+    const sequence = (lastMessage?.sequence ?? -1) + 1;
 
-    sseEvents.emitNewMessage(sessionId, {
-      id: message.id,
-      sessionId,
-      sequence,
-      type: 'user',
-      content,
-      createdAt: message.createdAt,
-    });
-    return true;
-  } catch (err) {
-    if (err && typeof err === 'object' && 'code' in err && err.code === 'P2002') {
-      log.debug('persistSyntheticToolResult: tool call already answered', { sessionId, toolUseId });
-      return false;
+    try {
+      const message = await prisma.message.create({
+        data: { id, sessionId, sequence, type: 'user', content: JSON.stringify(content) },
+      });
+
+      sseEvents.emitNewMessage(sessionId, {
+        id: message.id,
+        sessionId,
+        sequence,
+        type: 'user',
+        content,
+        createdAt: message.createdAt,
+      });
+      return true;
+    } catch (err) {
+      if (!(err && typeof err === 'object' && 'code' in err && err.code === 'P2002')) {
+        throw err;
+      }
+      // A row with our deterministic id already exists → this tool call was
+      // already answered (true idempotency). Otherwise the clash was on the
+      // sequence; recompute and retry so a different answer isn't dropped.
+      const existing = await prisma.message.findUnique({ where: { id }, select: { id: true } });
+      if (existing) {
+        log.debug('persistSyntheticToolResult: tool call already answered', {
+          sessionId,
+          toolUseId,
+        });
+        return false;
+      }
+      log.debug('persistSyntheticToolResult: sequence collision, retrying', { sessionId, attempt });
     }
-    throw err;
   }
+
+  throw new Error(
+    `Failed to persist tool result for ${toolUseId} after ${SEQUENCE_RETRY_LIMIT} attempts`
+  );
 }
 
 /**

--- a/src/server/services/claude-runner.ts
+++ b/src/server/services/claude-runner.ts
@@ -12,9 +12,15 @@
 
 import { execFile } from 'child_process';
 import { promisify } from 'util';
-import { query, type McpServerConfig, type SlashCommand } from '@anthropic-ai/claude-agent-sdk';
+import {
+  query,
+  type McpServerConfig,
+  type SlashCommand,
+  type PermissionResult,
+} from '@anthropic-ai/claude-agent-sdk';
 import { prisma } from '@/lib/prisma';
 import { classifyMessage, SystemInitContentSchema } from '@/lib/claude-messages';
+import { type ToolResponse, buildSyntheticToolResultContent } from '@/lib/tool-response';
 import { extractRepoFullName } from '@/lib/utils';
 import { v4 as uuid, v5 as uuidv5 } from 'uuid';
 import { sseEvents } from './events';
@@ -66,10 +72,36 @@ const ERROR_LINE_NAMESPACE = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
  */
 interface PendingUserInput {
   toolName: string;
+  /** The tool_use block id, used to match an incoming answer to this request. */
+  toolUseId: string;
   input: Record<string, unknown>;
-  resolve: (response: { behavior: 'allow'; updatedInput: Record<string, unknown> }) => void;
+  resolve: (result: PermissionResult) => void;
   reject: (error: Error) => void;
 }
+
+/** Translate a user's response into the SDK PermissionResult for the live path. */
+function buildPermissionResult(
+  response: ToolResponse,
+  input: Record<string, unknown>
+): PermissionResult {
+  if (response.kind === 'questions') {
+    return {
+      behavior: 'allow',
+      updatedInput: { questions: input.questions, answers: response.answers },
+    };
+  }
+
+  if (response.approve) {
+    return { behavior: 'allow', updatedInput: input };
+  }
+  return {
+    behavior: 'deny',
+    message:
+      response.feedback?.trim() || 'User rejected the plan. Please revise it before proceeding.',
+  };
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
  * In-memory state for each active session.
@@ -483,7 +515,11 @@ export async function runClaudeCommand(options: RunClaudeCommandOptions): Promis
       append: systemPrompt,
     },
     tools: { type: 'preset' as const, preset: 'claude_code' as const },
-    canUseTool: async (toolName: string, input: Record<string, unknown>) => {
+    canUseTool: async (
+      toolName: string,
+      input: Record<string, unknown>,
+      { toolUseID }: { toolUseID: string }
+    ): Promise<PermissionResult> => {
       // In safe mode, deny all tools
       if (denyAllTools) {
         return { behavior: 'deny' as const, message: 'Tool use is disabled in safe mode' };
@@ -491,7 +527,7 @@ export async function runClaudeCommand(options: RunClaudeCommandOptions): Promis
 
       // Handle tools that require user input
       if (toolName === 'AskUserQuestion' || toolName === 'ExitPlanMode') {
-        log.info('canUseTool: Waiting for user input', { sessionId, toolName });
+        log.info('canUseTool: Waiting for user input', { sessionId, toolName, toolUseID });
 
         // Signal that Claude is waiting for input (not actively running)
         // so the frontend enables the answer UI
@@ -499,11 +535,9 @@ export async function runClaudeCommand(options: RunClaudeCommandOptions): Promis
 
         // Park a promise that will be resolved when the user answers
         try {
-          return await new Promise<{ behavior: 'allow'; updatedInput: Record<string, unknown> }>(
-            (resolve, reject) => {
-              state.pendingInput = { toolName, input, resolve, reject };
-            }
-          );
+          return await new Promise<PermissionResult>((resolve, reject) => {
+            state.pendingInput = { toolName, toolUseId: toolUseID, input, resolve, reject };
+          });
         } finally {
           // Resume "running" state after user answers
           sseEvents.emitClaudeRunning(sessionId, true);
@@ -704,41 +738,98 @@ export async function runClaudeCommand(options: RunClaudeCommandOptions): Promis
 }
 
 /**
- * Submit an answer to a pending AskUserQuestion or ExitPlanMode tool call.
- * Resolves the parked canUseTool promise so the SDK continues.
+ * Resolve a still-parked AskUserQuestion / ExitPlanMode tool call so the SDK
+ * continues the current turn.
  *
- * @returns true if there was a pending input to answer, false otherwise
+ * Only the in-memory parked promise can do this; once the query has ended the
+ * caller must fall back to resuming with a new turn (see `submitToolResponse`
+ * in the claude router).
+ *
+ * Because the answer round-trips from the browser, the parked promise is
+ * essentially always registered by the time this is called. The short wait only
+ * covers the rare race where the answer beats the SDK's `canUseTool` call: we
+ * wait briefly while a query is actively running, but return immediately when
+ * nothing is running (so the caller can fall back without delay).
+ *
+ * @returns true if the live promise was resolved, false if there was none.
  */
-export function answerUserInput(sessionId: string, answers: Record<string, string>): boolean {
-  const state = sessions.get(sessionId);
-  if (!state?.pendingInput) {
-    log.warn('answerUserInput: No pending input', { sessionId });
-    return false;
+export async function submitLiveToolResponse(
+  sessionId: string,
+  toolUseId: string,
+  response: ToolResponse,
+  waitMs = 3000
+): Promise<boolean> {
+  const deadline = Date.now() + waitMs;
+  for (;;) {
+    const state = sessions.get(sessionId);
+    const pending = state?.pendingInput;
+
+    if (pending && pending.toolUseId === toolUseId) {
+      state!.pendingInput = null;
+      log.info('submitLiveToolResponse: resolving live tool call', {
+        sessionId,
+        toolName: pending.toolName,
+      });
+      pending.resolve(buildPermissionResult(response, pending.input));
+      return true;
+    }
+
+    // A live promise only exists while a query is running. If nothing is
+    // running (completed / stopped / server restarted), nothing will appear.
+    if (!state?.isRunning || Date.now() >= deadline) {
+      return false;
+    }
+    await sleep(150);
   }
+}
 
-  const { toolName, input, resolve } = state.pendingInput;
-  state.pendingInput = null;
+/**
+ * Persist a synthetic `tool_result` for a tool_use whose query has ended, so the
+ * UI pairs the dangling block and stops showing answer controls.
+ *
+ * The message id is derived from the tool_use id, so a duplicate submit is a
+ * no-op (insert hits the unique constraint) — this both makes the fallback
+ * idempotent and prevents a double answer from starting two turns.
+ *
+ * @returns true if a result was written, false if one already existed.
+ */
+export async function persistSyntheticToolResult(
+  sessionId: string,
+  toolUseId: string,
+  text: string
+): Promise<boolean> {
+  const id = uuidv5(`${sessionId}:tool_result:${toolUseId}`, ERROR_LINE_NAMESPACE);
 
-  log.info('answerUserInput: Resolving', { sessionId, toolName });
+  const lastMessage = await prisma.message.findFirst({
+    where: { sessionId },
+    orderBy: { sequence: 'desc' },
+    select: { sequence: true },
+  });
+  const sequence = (lastMessage?.sequence ?? -1) + 1;
 
-  if (toolName === 'AskUserQuestion') {
-    // Return answers in the format the SDK expects
-    resolve({
-      behavior: 'allow',
-      updatedInput: {
-        questions: (input as { questions?: unknown }).questions,
-        answers,
-      },
+  const content = buildSyntheticToolResultContent({ sessionId, toolUseId, uuid: id, text });
+
+  try {
+    const message = await prisma.message.create({
+      data: { id, sessionId, sequence, type: 'user', content: JSON.stringify(content) },
     });
-  } else if (toolName === 'ExitPlanMode') {
-    // For ExitPlanMode, just allow it to proceed
-    resolve({
-      behavior: 'allow',
-      updatedInput: input,
+
+    sseEvents.emitNewMessage(sessionId, {
+      id: message.id,
+      sessionId,
+      sequence,
+      type: 'user',
+      content,
+      createdAt: message.createdAt,
     });
+    return true;
+  } catch (err) {
+    if (err && typeof err === 'object' && 'code' in err && err.code === 'P2002') {
+      log.debug('persistSyntheticToolResult: tool call already answered', { sessionId, toolUseId });
+      return false;
+    }
+    throw err;
   }
-
-  return true;
 }
 
 /**
@@ -748,27 +839,6 @@ export function answerUserInput(sessionId: string, answers: Record<string, strin
  */
 export function getSessionCommands(sessionId: string): SlashCommand[] {
   return persistedCommands.get(sessionId) ?? sessions.get(sessionId)?.commands ?? [];
-}
-
-/**
- * Check if a session has a pending user input request.
- */
-export function hasPendingInput(sessionId: string): boolean {
-  return sessions.get(sessionId)?.pendingInput != null;
-}
-
-/**
- * Get the pending input details for a session (for rendering in the UI on reconnect).
- */
-export function getPendingInput(
-  sessionId: string
-): { toolName: string; input: Record<string, unknown> } | null {
-  const state = sessions.get(sessionId);
-  if (!state?.pendingInput) return null;
-  return {
-    toolName: state.pendingInput.toolName,
-    input: state.pendingInput.input,
-  };
 }
 
 /**


### PR DESCRIPTION
## Problem

Answering an `AskUserQuestion`/`ExitPlanMode` prompt was unreliable: sometimes the UI wouldn't let you select an answer, and sometimes selecting and submitting did nothing.

Two root causes:

1. **The "pending" question lived in two places that disagreed.** The thing that can actually answer a question is an in-memory parked promise (`canUseTool`), keyed by session. But the UI inferred "pending" purely from the DB (a `tool_use` block with no `tool_result`). The in-memory promise is destroyed by query completion, stop, interrupt, and **server restart** — while the DB record lives forever. So after any of those, the UI still showed answer controls but submitting threw `PRECONDITION_FAILED`.

2. **The controls were gated on a transient running-state signal.** `canInteract` required `!isClaudeRunning`, driven by a one-shot `claude_running` SSE event that isn't replayed on reconnect and reads as `true` on refetch while parked. So reopening/refocusing the tab disabled the controls.

## Approach

Per discussion, **make the server authoritative and the UI dumb** (the user suggested centralizing this so the UI doesn't have to care).

- **UI rule**: answer controls show whenever a `tool_use` block is unpaired (DB-derived). No running-state gate. On submit it sends the block's `toolUseId`.
- **Server routing** (`submitToolResponse`): 
  1. **Live** — if a query is still parked on that `toolUseId`, resolve the in-memory promise and continue the turn (short wait covers the answer-beats-park race).
  2. **Fallback** — if the query is gone, the original tool call can't be resolved, so persist a synthetic `tool_result` (pairs the block in the UI; idempotent via a deterministic id) and **resume the session with a new turn** built from the answer. This is the automatic "fall back to the normal chat interface" the user asked for.
- `canUseTool` now captures the SDK's `toolUseID`; `ExitPlanMode` gains Approve / Request-changes controls (previously it had no way to respond), with rejection mapped to `deny` so Claude revises in place.

This fixes the dominant cases (tab closed/reopened while the query is alive, and answering mid-turn) entirely via the live path, with no dependency on resume.

## Testing

- New pure-function tests (`tool-response.test.ts`), server integration tests for the fallback path (resume + synthetic result + idempotency + CONFLICT/PRECONDITION), and component tests for the ungated answer UI.
- `pnpm test:run`, `pnpm test:component`, `pnpm lint`, `pnpm build` all green.
- **Verified live in the running app** (every interactive path, end-to-end):
  - Select & submit (the core "selecting did nothing" bug)
  - Refresh while parked (the `isClaudeRunning`-gated "can't select" bug)
  - **Server-restart fallback** — asked a question, restarted the server (killing the parked promise), restarted the session, answered → the answer arrived as a resumed turn. This confirms the one thing I couldn't verify statically: the CLI reconciles the orphaned `tool_use` on `resume` (no API error).
  - Multi-question with the "Submit Answers" button
  - Plan approve, and plan request-changes (deny + feedback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
