### PR TITLE
Render plans in the ExitPlanMode approval panel

### DIFF
--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -9,7 +9,7 @@ import { ContextUsageIndicator } from '@/components/ContextUsageIndicator';
 import type { TokenUsageStats } from '@/lib/token-estimation';
 import { useNotification } from '@/hooks/useNotification';
 import { useVoicePlaybackContext } from '@/hooks/useVoicePlayback';
-import { isPlanFile } from './messages/plan-utils';
+import { isPlanFile, reconstructPlansByToolUseId, type PlanEvent } from './messages/plan-utils';
 import { isIgnoredSystemMessage } from '@/lib/claude-messages';
 import { hasRenderableAssistantContent } from './messages/messageHelpers';
 
@@ -179,44 +179,45 @@ function getPendingAskUserQuestions(
   return pending;
 }
 
-interface PlanToolCall {
-  sequence: number;
-  type: 'write' | 'edit';
-  content?: string; // For Write: full content
-  oldString?: string; // For Edit: string to replace
-  newString?: string; // For Edit: replacement string
-}
-
 /**
- * Extract plan file Write/Edit tool calls from messages, ordered by sequence.
- * Then reconstruct the current plan content by replaying writes and edits.
+ * Extract plan Write/Edit tool calls and ExitPlanMode calls from the messages,
+ * then reconstruct the plan content for each ExitPlanMode (keyed by its tool_use
+ * id). Handles multiple plans per session — see {@link reconstructPlansByToolUseId}.
  */
-function getLatestPlanContent(messages: Message[]): string | null {
-  const planCalls: PlanToolCall[] = [];
-  const sortedMessages = [...messages].sort((a, b) => a.sequence - b.sequence);
+function getPlanContentByToolUseId(messages: Message[]): Map<string, string> {
+  const events: PlanEvent[] = [];
 
-  for (const msg of sortedMessages) {
+  for (const msg of messages) {
     if (msg.type !== 'assistant') continue;
     const content = msg.content as MessageContent | undefined;
     const blocks = content?.message?.content;
     if (!Array.isArray(blocks)) continue;
 
     for (const block of blocks) {
-      if (block.type !== 'tool_use' || !block.input) continue;
+      if (block.type !== 'tool_use') continue;
+
+      if (block.name === 'ExitPlanMode' && block.id) {
+        events.push({ kind: 'exit', sequence: msg.sequence, toolUseId: block.id });
+        continue;
+      }
+
+      if (!block.input) continue;
       const input = block.input as Record<string, unknown>;
       const filePath = input.file_path as string | undefined;
       if (!filePath || !isPlanFile(filePath)) continue;
 
       if (block.name === 'Write') {
-        planCalls.push({
+        events.push({
+          kind: 'write',
           sequence: msg.sequence,
-          type: 'write',
+          filePath,
           content: (input.content as string) ?? '',
         });
       } else if (block.name === 'Edit') {
-        planCalls.push({
+        events.push({
+          kind: 'edit',
           sequence: msg.sequence,
-          type: 'edit',
+          filePath,
           oldString: (input.old_string as string) ?? '',
           newString: (input.new_string as string) ?? '',
         });
@@ -224,19 +225,7 @@ function getLatestPlanContent(messages: Message[]): string | null {
     }
   }
 
-  if (planCalls.length === 0) return null;
-
-  // Replay writes and edits to build current plan content
-  let planContent = '';
-  for (const call of planCalls) {
-    if (call.type === 'write') {
-      planContent = call.content ?? '';
-    } else if (call.type === 'edit' && call.oldString) {
-      planContent = planContent.replace(call.oldString, call.newString ?? '');
-    }
-  }
-
-  return planContent || null;
+  return reconstructPlansByToolUseId(events);
 }
 
 // Total cost is now provided by tokenUsage.totalCostUsd from the server-side
@@ -330,8 +319,8 @@ export function MessageList({
 
   // Total cost comes from tokenUsage (server-computed from authoritative result messages)
 
-  // Track the latest plan content from Write/Edit calls to plan files
-  const latestPlanContent = useMemo(() => getLatestPlanContent(messages), [messages]);
+  // Reconstruct plan content per ExitPlanMode call (keyed by tool_use id)
+  const planContentByToolUseId = useMemo(() => getPlanContentByToolUseId(messages), [messages]);
 
   // Find pending AskUserQuestion tool calls
   const pendingQuestions = useMemo(
@@ -554,7 +543,7 @@ export function MessageList({
       onSendResponse,
       onAnswerQuestion,
       onRespondToPlan,
-      latestPlanContent,
+      planContentByToolUseId,
     }),
     [
       latestTodoWriteId,
@@ -563,7 +552,7 @@ export function MessageList({
       onSendResponse,
       onAnswerQuestion,
       onRespondToPlan,
-      latestPlanContent,
+      planContentByToolUseId,
     ]
   );
 

--- a/src/components/messages/AskUserQuestionDisplay.test.tsx
+++ b/src/components/messages/AskUserQuestionDisplay.test.tsx
@@ -33,7 +33,7 @@ function renderWithContext(
         latestTodoWriteId: null,
         manuallyToggledTodoIds: new Set(),
         onTodoManualToggle: vi.fn(),
-        latestPlanContent: null,
+        planContentByToolUseId: new Map(),
         ...ctx,
       }}
     >

--- a/src/components/messages/ExitPlanModeDisplay.tsx
+++ b/src/components/messages/ExitPlanModeDisplay.tsx
@@ -79,11 +79,11 @@ function CheckIcon() {
  */
 export function ExitPlanModeDisplay({ tool }: { tool: ToolCall }) {
   const ctx = useMessageListContext();
-  const planContent = ctx?.latestPlanContent;
   const onRespondToPlan = ctx?.onRespondToPlan;
   const hasOutput = tool.output !== undefined;
   const isPending = !hasOutput;
   const toolUseId = tool.id;
+  const planContent = toolUseId ? ctx?.planContentByToolUseId?.get(toolUseId) : undefined;
   const [copied, setCopied] = useState(false);
   const [showFeedback, setShowFeedback] = useState(false);
   const [feedback, setFeedback] = useState('');

--- a/src/components/messages/MessageBubble.test.tsx
+++ b/src/components/messages/MessageBubble.test.tsx
@@ -501,7 +501,7 @@ describe('MessageBubble', () => {
             latestTodoWriteId: 'todo-1',
             manuallyToggledTodoIds,
             onTodoManualToggle,
-            latestPlanContent: null,
+            planContentByToolUseId: new Map(),
           }}
         >
           <MessageBubble message={message} />

--- a/src/components/messages/MessageListContext.tsx
+++ b/src/components/messages/MessageListContext.tsx
@@ -15,8 +15,8 @@ interface MessageListContextValue {
   onAnswerQuestion?: (toolUseId: string, answers: Record<string, string>) => void;
   /** Respond to an ExitPlanMode tool call (approve or request changes) */
   onRespondToPlan?: (toolUseId: string, approve: boolean, feedback?: string) => void;
-  /** The latest plan content from Write/Edit of plan files, or null */
-  latestPlanContent: string | null;
+  /** Reconstructed plan content per ExitPlanMode call, keyed by its tool_use id */
+  planContentByToolUseId: Map<string, string>;
 }
 
 const MessageListContext = createContext<MessageListContextValue | null>(null);

--- a/src/components/messages/plan-utils.test.ts
+++ b/src/components/messages/plan-utils.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect } from 'vitest';
 import { isPlanFile } from './plan-utils';
 
 describe('isPlanFile', () => {
-  it('should detect plan.md inside .claude/projects/', () => {
+  it('should detect .md files inside the default .claude/plans/ directory', () => {
+    expect(isPlanFile('/home/claude/.claude/plans/dazzling-tinkering-river.md')).toBe(true);
+  });
+
+  it('should detect plan.md inside legacy .claude/projects/', () => {
     expect(isPlanFile('/home/claudeuser/.claude/projects/-workspace-clawed-abode/plan.md')).toBe(
       true
     );
@@ -14,15 +18,16 @@ describe('isPlanFile', () => {
     );
   });
 
-  it('should not detect .md files outside .claude/projects/', () => {
+  it('should not detect .md files outside a plan directory', () => {
     expect(isPlanFile('/workspace/clawed-abode/README.md')).toBe(false);
   });
 
-  it('should not detect non-.md files inside .claude/projects/', () => {
+  it('should not detect non-.md files inside a plan directory', () => {
+    expect(isPlanFile('/home/claude/.claude/plans/notes.json')).toBe(false);
     expect(isPlanFile('/home/claudeuser/.claude/projects/-workspace-foo/config.json')).toBe(false);
   });
 
-  it('should not detect files in .claude but not in projects/', () => {
+  it('should not detect other .md files in .claude (e.g. MEMORY.md)', () => {
     expect(isPlanFile('/home/claudeuser/.claude/MEMORY.md')).toBe(false);
   });
 });

--- a/src/components/messages/plan-utils.test.ts
+++ b/src/components/messages/plan-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isPlanFile } from './plan-utils';
+import { isPlanFile, reconstructPlansByToolUseId, type PlanEvent } from './plan-utils';
 
 describe('isPlanFile', () => {
   it('should detect .md files inside the default .claude/plans/ directory', () => {
@@ -29,5 +29,80 @@ describe('isPlanFile', () => {
 
   it('should not detect other .md files in .claude (e.g. MEMORY.md)', () => {
     expect(isPlanFile('/home/claudeuser/.claude/MEMORY.md')).toBe(false);
+  });
+});
+
+describe('reconstructPlansByToolUseId', () => {
+  const FILE_A = '/home/claude/.claude/plans/plan-a.md';
+  const FILE_B = '/home/claude/.claude/plans/plan-b.md';
+
+  it('ties a single plan to its ExitPlanMode call', () => {
+    const events: PlanEvent[] = [
+      { kind: 'write', sequence: 1, filePath: FILE_A, content: '# Plan A' },
+      { kind: 'exit', sequence: 2, toolUseId: 'exit-1' },
+    ];
+    expect(reconstructPlansByToolUseId(events)).toEqual(new Map([['exit-1', '# Plan A']]));
+  });
+
+  it('applies edits to a plan before its approval', () => {
+    const events: PlanEvent[] = [
+      { kind: 'write', sequence: 1, filePath: FILE_A, content: 'use Redis' },
+      { kind: 'edit', sequence: 2, filePath: FILE_A, oldString: 'Redis', newString: 'Postgres' },
+      { kind: 'exit', sequence: 3, toolUseId: 'exit-1' },
+    ];
+    expect(reconstructPlansByToolUseId(events).get('exit-1')).toBe('use Postgres');
+  });
+
+  it('keeps separate plans separate across multiple plan files', () => {
+    const events: PlanEvent[] = [
+      { kind: 'write', sequence: 1, filePath: FILE_A, content: '# Plan A' },
+      { kind: 'exit', sequence: 2, toolUseId: 'exit-a' },
+      { kind: 'write', sequence: 3, filePath: FILE_B, content: '# Plan B' },
+      { kind: 'exit', sequence: 4, toolUseId: 'exit-b' },
+    ];
+    const result = reconstructPlansByToolUseId(events);
+    // The earlier approval must NOT be overwritten by the later plan.
+    expect(result.get('exit-a')).toBe('# Plan A');
+    expect(result.get('exit-b')).toBe('# Plan B');
+  });
+
+  it('does not let an edit to one plan file corrupt another', () => {
+    const events: PlanEvent[] = [
+      { kind: 'write', sequence: 1, filePath: FILE_A, content: 'shared word here' },
+      { kind: 'write', sequence: 2, filePath: FILE_B, content: 'shared word elsewhere' },
+      // Edit targets FILE_A; must not touch FILE_B's content.
+      { kind: 'edit', sequence: 3, filePath: FILE_A, oldString: 'shared', newString: 'unique' },
+      { kind: 'exit', sequence: 4, toolUseId: 'exit-b' },
+    ];
+    // exit-b ties to the most-recently-touched file (FILE_A after the edit),
+    // and FILE_B's content remains intact regardless.
+    const result = reconstructPlansByToolUseId(events);
+    expect(result.get('exit-b')).toBe('unique word here');
+  });
+
+  it('handles a revised plan to the same file (each exit reflects its moment)', () => {
+    const events: PlanEvent[] = [
+      { kind: 'write', sequence: 1, filePath: FILE_A, content: 'v1' },
+      { kind: 'exit', sequence: 2, toolUseId: 'exit-1' },
+      { kind: 'write', sequence: 3, filePath: FILE_A, content: 'v2' },
+      { kind: 'exit', sequence: 4, toolUseId: 'exit-2' },
+    ];
+    const result = reconstructPlansByToolUseId(events);
+    expect(result.get('exit-1')).toBe('v1');
+    expect(result.get('exit-2')).toBe('v2');
+  });
+
+  it('omits an ExitPlanMode with no preceding plan content', () => {
+    const events: PlanEvent[] = [{ kind: 'exit', sequence: 1, toolUseId: 'exit-1' }];
+    expect(reconstructPlansByToolUseId(events).has('exit-1')).toBe(false);
+  });
+
+  it('sorts by sequence regardless of input order', () => {
+    const events: PlanEvent[] = [
+      { kind: 'exit', sequence: 3, toolUseId: 'exit-1' },
+      { kind: 'write', sequence: 1, filePath: FILE_A, content: 'early' },
+      { kind: 'edit', sequence: 2, filePath: FILE_A, oldString: 'early', newString: 'late' },
+    ];
+    expect(reconstructPlansByToolUseId(events).get('exit-1')).toBe('late');
   });
 });

--- a/src/components/messages/plan-utils.ts
+++ b/src/components/messages/plan-utils.ts
@@ -21,3 +21,58 @@ export function isPlanFile(filePath: string): boolean {
   if (!filePath.endsWith('.md')) return false;
   return PLAN_DIR_SEGMENTS.some((segment) => filePath.includes(segment));
 }
+
+/**
+ * A plan-relevant event extracted from the message stream, in `sequence` order.
+ * - `write`/`edit`: a Write/Edit tool call against a plan file
+ * - `exit`: an ExitPlanMode tool call (identified by its tool_use id)
+ */
+export type PlanEvent =
+  | { kind: 'write'; sequence: number; filePath: string; content: string }
+  | { kind: 'edit'; sequence: number; filePath: string; oldString: string; newString: string }
+  | { kind: 'exit'; sequence: number; toolUseId: string };
+
+/**
+ * Reconstruct the plan content shown by each ExitPlanMode approval, keyed by the
+ * ExitPlanMode tool_use id.
+ *
+ * A session can contain several plans — revisions to the same file, or entirely
+ * separate plan files across multiple plan-mode rounds. So we replay Write/Edit
+ * **per file** (a Write resets that file, an Edit replaces within it) and tie
+ * each ExitPlanMode to the plan file most recently touched before it. This keeps
+ * each approval showing the plan that was actually being approved, instead of a
+ * single global "latest plan" leaking backward onto earlier approvals.
+ */
+export function reconstructPlansByToolUseId(events: PlanEvent[]): Map<string, string> {
+  const sorted = [...events].sort((a, b) => a.sequence - b.sequence);
+  const contentByFile = new Map<string, string>();
+  const result = new Map<string, string>();
+  let lastPlanFile: string | null = null;
+
+  for (const event of sorted) {
+    switch (event.kind) {
+      case 'write':
+        contentByFile.set(event.filePath, event.content);
+        lastPlanFile = event.filePath;
+        break;
+      case 'edit': {
+        // `replace` mirrors the Edit tool: first occurrence only. An empty
+        // oldString is a no-op (matches the previous behavior's guard).
+        const current = contentByFile.get(event.filePath) ?? '';
+        contentByFile.set(
+          event.filePath,
+          event.oldString ? current.replace(event.oldString, event.newString) : current
+        );
+        lastPlanFile = event.filePath;
+        break;
+      }
+      case 'exit': {
+        const content = lastPlanFile ? (contentByFile.get(lastPlanFile) ?? '') : '';
+        if (content) result.set(event.toolUseId, content);
+        break;
+      }
+    }
+  }
+
+  return result;
+}

--- a/src/components/messages/plan-utils.ts
+++ b/src/components/messages/plan-utils.ts
@@ -1,17 +1,23 @@
 /**
  * Utility functions for detecting and handling plan mode files.
  *
- * Plan files are written by Claude during plan mode to a path like:
- *   /home/claudeuser/.claude/projects/<project>/plan.md
+ * In plan mode Claude writes its plan to a Markdown file, which both the
+ * ExitPlanMode approval panel (via reconstructed `latestPlanContent`) and the
+ * Write/Edit displays render as Markdown rather than raw code.
  *
- * These files should be rendered as Markdown rather than raw code.
+ * The SDK defaults this to `~/.claude/plans/<name>.md` (see `plansDirectory` in
+ * the SDK options, which defaults to `~/.claude/plans/`). Older versions wrote
+ * to `.claude/projects/<project>/plan.md`, which we still recognize.
  */
 
+/** Directory segments that hold Claude plan files. */
+const PLAN_DIR_SEGMENTS = ['.claude/plans/', '.claude/projects/'];
+
 /**
- * Check if a file path looks like a Claude plan file.
- * Plan files live inside .claude/projects/ directories and end with plan.md
- * (or sometimes have other names, but are always .md inside .claude/projects/).
+ * Check if a file path looks like a Claude plan file: a `.md` file inside a
+ * known plan directory.
  */
 export function isPlanFile(filePath: string): boolean {
-  return filePath.includes('.claude/projects/') && filePath.endsWith('.md');
+  if (!filePath.endsWith('.md')) return false;
+  return PLAN_DIR_SEGMENTS.some((segment) => filePath.includes(segment));
 }


### PR DESCRIPTION
## Problem

When approving a plan, the ExitPlanMode panel showed no plan content — you had to scroll up and read the generic `Write`/`Edit` tool call, which rendered the plan as raw text instead of Markdown. (Reported after testing #355.)

## Cause

Both the approval panel (`latestPlanContent`, reconstructed from `Write`/`Edit` calls in `MessageList.getLatestPlanContent`) and the Markdown rendering in `WriteDisplay`/`EditDisplay` gate on `isPlanFile(filePath)`. But `isPlanFile` only matched the legacy `.claude/projects/` path, while plan mode now writes to `~/.claude/plans/<name>.md` — the SDK's default `plansDirectory`. So nothing was ever recognized as a plan file.

## Fix

`isPlanFile` now matches `.claude/plans/` as well as the legacy `.claude/projects/` (still `.md`-only). One change fixes both symptoms: the approval panel renders the plan, and the plan's `Write`/`Edit` shows as Markdown.

Custom `plansDirectory` overrides (relative to project root) aren't path-detectable and remain out of scope — the default covers the common case.

## Testing

- Updated `plan-utils.test.ts` to cover the `.claude/plans/` path and keep the negative cases.
- `pnpm test:unit` (454), `pnpm test:component` (108), `pnpm lint` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Follow-up: multiple plans per session

Reviewing the reconstruction surfaced a related correctness bug (latent before this PR, since plan files were never recognized): plan content was replayed into a single global "latest plan" buffer ignoring file identity, and every `ExitPlanMode` panel showed that one value. With more than one plan in a session, older approvals retroactively displayed the newest plan, and an `Edit` to one plan file could replay against another's content.

Now reconstruction is **per file** and keyed by `ExitPlanMode` tool_use id — each approval ties to the plan file most recently touched before it, so every approval shows the plan that was actually being approved. The tricky logic lives in the pure, unit-tested `reconstructPlansByToolUseId` (covers revised-same-file, separate-files, and cross-file-edit-isolation cases).
