### PR TITLE
Render plan-file Write/Edit like normal files (show diffs)

### DIFF
--- a/src/components/messages/EditDisplay.tsx
+++ b/src/components/messages/EditDisplay.tsx
@@ -1,11 +1,9 @@
 'use client';
 
-import { useMemo } from 'react';
 import { cn } from '@/lib/utils';
 import { Badge } from '@/components/ui/badge';
 import { ToolDisplayWrapper } from './ToolDisplayWrapper';
 import { InlineDiff } from './InlineDiff';
-import { isPlanFile } from './plan-utils';
 import type { ToolCall } from './types';
 
 interface EditInput {
@@ -18,7 +16,10 @@ interface EditInput {
 /**
  * Specialized display for Edit tool calls.
  * Shows file path and a diff-like view of old vs new content.
- * For plan files, shows a simplified "Plan updated" view.
+ *
+ * Plan files render the same as any other file — the full plan is shown in the
+ * ExitPlanMode approval panel, so seeing the diff here is useful for tracking
+ * how the plan changed.
  */
 export function EditDisplay({ tool }: { tool: ToolCall }) {
   const hasOutput = tool.output !== undefined;
@@ -31,34 +32,6 @@ export function EditDisplay({ tool }: { tool: ToolCall }) {
 
   // Extract just the filename for the header
   const fileName = filePath.split('/').pop() ?? filePath;
-
-  // Check if this is a plan file
-  const isPlan = useMemo(() => isPlanFile(filePath), [filePath]);
-
-  // For plan files, show a simplified compact view
-  if (isPlan) {
-    return (
-      <ToolDisplayWrapper
-        tool={tool}
-        title="Plan Updated"
-        subtitle={
-          <div className="text-muted-foreground text-xs mt-1">Plan was updated with changes</div>
-        }
-        doneBadge={
-          <Badge
-            variant="outline"
-            className="text-xs border-purple-500 text-purple-700 dark:text-purple-400"
-          >
-            Updated
-          </Badge>
-        }
-        cardClassName="border-purple-300 dark:border-purple-700"
-      >
-        {/* Show the changes as an inline diff */}
-        <InlineDiff oldString={oldString} newString={newString} className="max-h-64" />
-      </ToolDisplayWrapper>
-    );
-  }
 
   return (
     <ToolDisplayWrapper

--- a/src/components/messages/WriteDisplay.tsx
+++ b/src/components/messages/WriteDisplay.tsx
@@ -4,11 +4,9 @@ import { useMemo } from 'react';
 import { cn } from '@/lib/utils';
 import { Badge } from '@/components/ui/badge';
 import { getFileType } from '@/lib/file-types';
-import { MarkdownContent } from '@/components/MarkdownContent';
 import { FileIcon } from './FileIcon';
 import { ToolDisplayWrapper } from './ToolDisplayWrapper';
 import { CodeBlock } from './CodeBlock';
-import { isPlanFile } from './plan-utils';
 import type { ToolCall } from './types';
 
 interface WriteInput {
@@ -19,7 +17,10 @@ interface WriteInput {
 /**
  * Specialized display for Write tool calls.
  * Shows file path and the content being written to the file.
- * For plan files (.md inside .claude/projects/), renders content as Markdown.
+ *
+ * Plan files render the same as any other file — the full plan is shown in the
+ * ExitPlanMode approval panel, and seeing the raw Write here is useful for
+ * tracking how the plan file changed.
  */
 export function WriteDisplay({ tool }: { tool: ToolCall }) {
   const hasOutput = tool.output !== undefined;
@@ -32,9 +33,6 @@ export function WriteDisplay({ tool }: { tool: ToolCall }) {
   const fileName = filePath.split('/').pop() ?? filePath;
   const fileType = useMemo(() => getFileType(filePath), [filePath]);
 
-  // Check if this is a plan file
-  const isPlan = useMemo(() => isPlanFile(filePath), [filePath]);
-
   // Count lines in content
   const lineCount = useMemo(() => {
     if (!content) return 0;
@@ -45,44 +43,23 @@ export function WriteDisplay({ tool }: { tool: ToolCall }) {
     <ToolDisplayWrapper
       tool={tool}
       icon={<FileIcon variant="write" />}
-      title={isPlan ? 'Plan' : 'Write'}
-      pendingText={isPlan ? 'Writing plan...' : 'Writing...'}
+      title="Write"
+      pendingText="Writing..."
       headerContent={
-        !isPlan ? (
-          <span className="text-muted-foreground font-mono text-xs truncate">{fileName}</span>
-        ) : undefined
+        <span className="text-muted-foreground font-mono text-xs truncate">{fileName}</span>
       }
-      subtitle={
-        isPlan ? (
-          <div className="text-muted-foreground text-xs mt-1">
-            Claude is writing a plan for your review
-          </div>
-        ) : (
-          <div className="text-muted-foreground text-xs mt-1 truncate">{filePath}</div>
-        )
-      }
+      subtitle={<div className="text-muted-foreground text-xs mt-1 truncate">{filePath}</div>}
       doneBadge={
-        isPlan ? (
-          <Badge
-            variant="outline"
-            className="text-xs border-purple-500 text-purple-700 dark:text-purple-400"
-          >
-            Plan
-          </Badge>
-        ) : (
-          <Badge
-            variant="outline"
-            className="text-xs border-green-500 text-green-700 dark:text-green-400"
-          >
-            {lineCount} {lineCount === 1 ? 'line' : 'lines'}
-          </Badge>
-        )
+        <Badge
+          variant="outline"
+          className="text-xs border-green-500 text-green-700 dark:text-green-400"
+        >
+          {lineCount} {lineCount === 1 ? 'line' : 'lines'}
+        </Badge>
       }
-      cardClassName={isPlan ? 'border-purple-300 dark:border-purple-700' : undefined}
-      defaultExpanded={isPlan}
     >
-      {/* File type badge (non-plan files only) */}
-      {!isPlan && fileType !== 'text' && (
+      {/* File type badge */}
+      {fileType !== 'text' && (
         <div>
           <Badge variant="secondary" className="text-xs">
             {fileType}
@@ -90,32 +67,23 @@ export function WriteDisplay({ tool }: { tool: ToolCall }) {
         </div>
       )}
 
-      {/* Plan file: render as Markdown */}
-      {isPlan && content && (
-        <div className="bg-muted/50 rounded p-3 overflow-y-auto max-h-[600px]">
-          <MarkdownContent content={content} />
+      {/* File content */}
+      <div>
+        <div className="flex items-center gap-2 mb-1">
+          <span className="text-green-600 dark:text-green-400 font-medium">Content</span>
+          <span className="text-muted-foreground">
+            ({lineCount} {lineCount === 1 ? 'line' : 'lines'})
+          </span>
         </div>
-      )}
+        {content ? (
+          <CodeBlock code={content} fileType={fileType} />
+        ) : (
+          <div className="text-muted-foreground italic py-2">(empty file)</div>
+        )}
+      </div>
 
-      {/* Non-plan file: show raw content */}
-      {!isPlan && (
-        <div>
-          <div className="flex items-center gap-2 mb-1">
-            <span className="text-green-600 dark:text-green-400 font-medium">Content</span>
-            <span className="text-muted-foreground">
-              ({lineCount} {lineCount === 1 ? 'line' : 'lines'})
-            </span>
-          </div>
-          {content ? (
-            <CodeBlock code={content} fileType={fileType} />
-          ) : (
-            <div className="text-muted-foreground italic py-2">(empty file)</div>
-          )}
-        </div>
-      )}
-
-      {/* Output/Result if available (non-plan files only) */}
-      {!isPlan && hasOutput && (
+      {/* Output/Result if available */}
+      {hasOutput && (
         <div>
           <div className="text-muted-foreground mb-1">Result:</div>
           <pre


### PR DESCRIPTION
## Why

Now that the ExitPlanMode approval panel shows the full plan (#357), the special collapsed Markdown view for plan-file `Write`/`Edit` hides the useful part: *how the plan changed* between revisions. With the complete plan visible at approval time, the raw `Write` content and the `Edit` inline diff are more useful than a "Plan updated" placeholder.

## Change

Drop the `isPlan` rendering branch in `WriteDisplay` and `EditDisplay` so plan files render like any other file:
- `Write` → full content with line count
- `Edit` → inline diff

`isPlanFile` is unchanged and still used — it drives plan reconstruction for the approval panel in `MessageList` (`getPlanContentByToolUseId` / `reconstructPlansByToolUseId`).

## Testing

`pnpm tsc`, `pnpm test:component` (108), `pnpm lint`, `pnpm build` all green. No tests asserted the old plan-specific rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)