### PR TITLE
Consolidate SSE into two streams with idiomatic resume

### DIFF
--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -222,7 +222,7 @@ claude.getHistory({
 4. Messages stream from the SDK:
    - **Partial messages**: `stream_event` messages are accumulated by `StreamAccumulator` and emitted via SSE for real-time UI updates (not persisted).
    - **Complete messages**: Saved to database with incrementing sequence numbers, emitted via SSE.
-5. Browser client receives SSE events and updates the message cache.
+5. Browser client receives SSE events (over the single multiplexed per-session stream — see [Real-Time Updates](#real-time-updates-sse)) and updates the message cache.
 6. On completion, `result` message marks end of turn.
 
 ### System Prompt
@@ -249,11 +249,18 @@ This ensures users can see all changes through GitHub, which is their only way t
 
 ### Reconnection Flow
 
-1. Client reconnects after disconnect
-2. Client calls `claude.getHistory({ sessionId, cursor: lastSeenSequence, direction: 'after' })`
-3. Server returns all messages after that sequence
-4. Client merges into local state
-5. If a `claude` process is still running, client re-subscribes to stream
+Reconnection is handled by the SSE layer's native resume rather than an explicit
+catch-up query (see [Real-Time Updates](#real-time-updates-sse)):
+
+1. `EventSource` auto-reconnects after a transient drop, sending the `Last-Event-ID`
+   header tRPC delivers as the subscription's `lastEventId` input.
+2. The server parses the resume token, replays persisted messages with `sequence`
+   greater than the token's watermark, then resumes live streaming.
+3. The client merges replayed messages into the React Query cache (deduped by id).
+4. Latest-value state (running, commands, PR, session) is not replayed; the client
+   refetches those queries on reconnect (`useRefetchOnReconnect`) as a resync.
+5. A `ConnectionStatusIndicator` shows a "reconnecting" banner while the stream is
+   not connected.
 
 ### Deletion Flow
 
@@ -297,6 +304,48 @@ The hard part is that the parked `Promise` lives only in the in-memory session m
 The SDK emits `stream_event` messages which are accumulated by `StreamAccumulator` into partial assistant messages for real-time UI updates. These are emitted to the browser via SSE but not persisted.
 
 **Implementation:** [`src/server/services/claude-runner.ts`](../src/server/services/claude-runner.ts)
+
+### Real-Time Updates (SSE)
+
+All live server→client updates flow over **SSE** via tRPC's `httpSubscriptionLink`
+(client→server actions are ordinary HTTP mutations, so a bidirectional transport like
+WebSockets is unnecessary). `httpSubscriptionLink` opens one `EventSource` per
+subscription, so the app is deliberately structured around just **two** streams:
+
+1. **Per-session multiplexed stream** — `sse.onSessionEvents({ sessionId })`. A single
+   subscription yields a discriminated union of every event kind for the session
+   (`message`, `running`, `commands`, `pr`, `session`). The server folds the five
+   in-process emitter channels into this union via `sseEvents.onSessionEvents`
+   ([`events.ts`](../src/server/services/events.ts)). On the client, `useSessionStream`
+   ([`src/hooks/useSessionStream.ts`](../src/hooks/useSessionStream.ts)) is mounted once
+   per session page and fans each event to the relevant React Query cache (the message
+   merge uses the pure `mergeMessageIntoCache` in
+   [`src/lib/message-cache.ts`](../src/lib/message-cache.ts)). The query hooks
+   (`useSessionMessages`, `useSessionState`, `useClaudeState`, `usePullRequestStatus`)
+   are read/mutate-only and never open their own subscriptions.
+
+2. **Global session-list stream** — `sse.onSessionListEvents()`. `emitSessionUpdate`
+   fans every session change out to a global channel; `useSessionListStream`
+   ([`src/hooks/useSessionListStream.ts`](../src/hooks/useSessionListStream.ts)) refetches
+   the home-page list so it updates live for any session, without one subscription per row.
+
+**Resume tokens & catch-up.** The subscription input is **stable** (`{ sessionId }`); a
+reactive cursor would tear the `EventSource` down on every turn. Instead each yielded event
+is wrapped in tRPC's `tracked(id, ...)` where the id is a
+`` `${watermark}:${counter}` `` token ([`src/lib/sse-resume.ts`](../src/lib/sse-resume.ts)):
+
+- `watermark` = the highest persisted message `sequence` yielded so far. On reconnect tRPC
+  resends it as `lastEventId`; the server replays `message.sequence > watermark`. Only
+  complete (persisted) messages advance the watermark — partials and latest-value events do
+  not, so they are streamed live but never replayed (the client refetches their state on
+  reconnect instead).
+- `counter` = strictly increasing per connection, seeded from the previous `lastEventId`, so
+  ids never repeat across reconnects (tRPC drops events with a repeated tracked id).
+
+**Failure handling.** `EventSource` auto-reconnects with `Last-Event-ID`; on a connection
+error the client also refetches the affected queries (`useSessionStream` / `useRefetchOnReconnect`)
+and surfaces a `ConnectionStatusIndicator` banner. tRPC SSE ping/reconnect is configured in
+[`src/server/trpc.ts`](../src/server/trpc.ts) (`ping.intervalMs`, `client.reconnectAfterInactivityMs`).
 
 ### Thinking Blocks
 
@@ -542,8 +591,11 @@ clawed-abode/
 │   │   ├── logger.ts             # Centralized logging (createLogger)
 │   │   ├── prisma.ts             # Prisma client initialization
 │   │   ├── trpc.ts               # tRPC client setup
+│   │   ├── message-cache.ts      # Pure merge of live messages into the infinite-query cache
+│   │   ├── sse-resume.ts         # Resume-token (watermark:counter) format/parse for SSE
 │   │   └── types.ts              # Global TypeScript types
-│   ├── hooks/                    # React hooks (session state, messages, etc.)
+│   ├── hooks/                    # React hooks (useSessionStream + useSessionListStream for SSE,
+│   │                             #   useSessionMessages/State, useClaudeState, etc.)
 │   ├── app/
 │   │   ├── page.tsx              # Session list
 │   │   ├── new/page.tsx          # New session
@@ -554,6 +606,7 @@ clawed-abode/
 │       ├── MessageList.tsx
 │       ├── PromptInput.tsx
 │       ├── SessionList.tsx
+│       ├── ConnectionStatusIndicator.tsx # "Reconnecting" banner when the SSE stream is down
 │       ├── Header.tsx
 │       ├── messages/             # Tool-specific display components (Bash, Edit, Read, etc.)
 │       ├── settings/             # Settings UI (global settings, repo settings, audio, env vars, MCP)

--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -329,16 +329,20 @@ subscription, so the app is deliberately structured around just **two** streams:
    ([`src/hooks/useSessionListStream.ts`](../src/hooks/useSessionListStream.ts)) refetches
    the home-page list so it updates live for any session, without one subscription per row.
 
-**Resume tokens & catch-up.** The subscription input is **stable** (`{ sessionId }`); a
-reactive cursor would tear the `EventSource` down on every turn. Instead each yielded event
-is wrapped in tRPC's `tracked(id, ...)` where the id is a
+**Resume tokens & catch-up.** The subscription input is **stable** — `{ sessionId,
+afterSequence }`, where `afterSequence` is the client's newest cached sequence captured
+**once** when history first loads and then frozen (`useSessionStream` gates the subscription
+until then). Feeding the live newest sequence reactively would tear the `EventSource` down
+every turn. Each yielded event is wrapped in tRPC's `tracked(id, ...)` where the id is a
 `` `${watermark}:${counter}` `` token ([`src/lib/sse-resume.ts`](../src/lib/sse-resume.ts)):
 
-- `watermark` = the highest persisted message `sequence` yielded so far. On reconnect tRPC
-  resends it as `lastEventId`; the server replays `message.sequence > watermark`. Only
-  complete (persisted) messages advance the watermark — partials and latest-value events do
-  not, so they are streamed live but never replayed (the client refetches their state on
-  reconnect instead).
+- `watermark` = the highest persisted message `sequence` yielded so far. The server replays
+  `message.sequence > floor`, where the floor is the `lastEventId` watermark on reconnect,
+  or the initial `afterSequence` on first connect (which closes the window between the
+  `getHistory` snapshot and the stream attaching), or none (anchor at current max) otherwise.
+  Only complete (persisted) messages advance the watermark — partials and latest-value
+  events do not, so they are streamed live but never replayed (the client refetches their
+  state on reconnect instead).
 - `counter` = strictly increasing per connection, seeded from the previous `lastEventId`, so
   ids never repeat across reconnects (tRPC drops events with a repeated tracked id).
 

--- a/doc/architecture.d2
+++ b/doc/architecture.d2
@@ -21,7 +21,7 @@ server: Home Server {
     auth: Auth
     session_mgmt: Session Management
     sdk: Claude Agent SDK (in-process)
-    sse: SSE to Browser
+    sse: SSE to Browser (multiplexed per-session + global list streams)
   }
 
   workspaces: ~/worktrees/ {
@@ -52,7 +52,7 @@ tailscale -> server.app: HTTP
 server.app.sdk -> server.workspaces: "cwd"
 server.app.session_mgmt -> server.db: "read/write"
 server.app.sdk -> server.db.messages: "persist"
-server.app.sse -> mobile: "stream messages"
+server.app.sse -> mobile: "stream events (resume via lastEventId)"
 
 # Data Model
 data: Data Model {

--- a/src/app/session/[id]/page.tsx
+++ b/src/app/session/[id]/page.tsx
@@ -25,9 +25,6 @@ import { getNewAutoReadMessages } from '@/lib/auto-read-helpers';
 import { VoiceControlPanel } from '@/components/voice/VoiceControlPanel';
 
 function SessionView({ sessionId }: { sessionId: string }) {
-  // Single multiplexed SSE stream: fans live events into the relevant caches.
-  const { status: streamStatus } = useSessionStream(sessionId);
-
   // Session state: data, start/stop/archive
   const {
     session,
@@ -48,7 +45,13 @@ function SessionView({ sessionId }: { sessionId: string }) {
     hasMore,
     fetchMore,
     tokenUsage,
+    historyLoaded,
+    newestSequence,
   } = useSessionMessages(sessionId);
+
+  // Single multiplexed SSE stream: fans live events into the relevant caches.
+  // Anchored to the loaded history so no messages are missed between snapshots.
+  const { status: streamStatus } = useSessionStream(sessionId, { historyLoaded, newestSequence });
 
   // Claude state: running, send, interrupt, commands
   const {

--- a/src/app/session/[id]/page.tsx
+++ b/src/app/session/[id]/page.tsx
@@ -8,6 +8,7 @@ import { SessionHeader } from '@/components/SessionHeader';
 import { MessageList } from '@/components/MessageList';
 import { PromptInput } from '@/components/PromptInput';
 import { ClaudeStatusIndicator } from '@/components/ClaudeStatusIndicator';
+import { ConnectionStatusIndicator } from '@/components/ConnectionStatusIndicator';
 import { Button } from '@/components/ui/button';
 import { Spinner } from '@/components/ui/spinner';
 import { useNotification } from '@/hooks/useNotification';
@@ -16,6 +17,7 @@ import { useWorkingContext } from '@/lib/working-context';
 import { useSessionState } from '@/hooks/useSessionState';
 import { useSessionMessages } from '@/hooks/useSessionMessages';
 import { useClaudeState } from '@/hooks/useClaudeState';
+import { useSessionStream } from '@/hooks/useSessionStream';
 import { useWorkCompleteNotification } from '@/hooks/useWorkCompleteNotification';
 import { useVoiceConfig } from '@/hooks/useVoiceConfig';
 import { useVoicePlayback, VoicePlaybackContext } from '@/hooks/useVoicePlayback';
@@ -23,6 +25,9 @@ import { getNewAutoReadMessages } from '@/lib/auto-read-helpers';
 import { VoiceControlPanel } from '@/components/voice/VoiceControlPanel';
 
 function SessionView({ sessionId }: { sessionId: string }) {
+  // Single multiplexed SSE stream: fans live events into the relevant caches.
+  const { status: streamStatus } = useSessionStream(sessionId);
+
   // Session state: data, start/stop/archive
   const {
     session,
@@ -273,6 +278,7 @@ function SessionView({ sessionId }: { sessionId: string }) {
           />
         ) : (
           <>
+            <ConnectionStatusIndicator status={streamStatus} />
             <ClaudeStatusIndicator isRunning={isClaudeRunning} containerStatus={session.status} />
             <PromptInput
               onSubmit={handleSendPromptWithVoice}

--- a/src/components/ConnectionStatusIndicator.tsx
+++ b/src/components/ConnectionStatusIndicator.tsx
@@ -1,0 +1,29 @@
+import { Spinner } from '@/components/ui/spinner';
+
+/**
+ * Status reported by tRPC's `useSubscription`. While the stream is live the value
+ * is `pending`; `connecting`/`error` indicate the live feed is (temporarily) down.
+ */
+export type StreamStatus = 'idle' | 'connecting' | 'pending' | 'error';
+
+interface ConnectionStatusIndicatorProps {
+  status: StreamStatus;
+}
+
+/**
+ * Shows a small banner when the live SSE stream is not connected, so the user knows
+ * updates are paused. The stream auto-reconnects and catches up via lastEventId; the
+ * queries also refetch on reconnect, so this is informational only.
+ */
+export function ConnectionStatusIndicator({ status }: ConnectionStatusIndicatorProps) {
+  if (status !== 'connecting' && status !== 'error') {
+    return null;
+  }
+
+  return (
+    <div className="flex items-center justify-center gap-2 py-2 px-4 bg-amber-500/10 border-t text-sm text-amber-700 dark:text-amber-400">
+      <Spinner size="sm" />
+      <span>Reconnecting to live updates…</span>
+    </div>
+  );
+}

--- a/src/components/SessionList.test.tsx
+++ b/src/components/SessionList.test.tsx
@@ -23,16 +23,6 @@ vi.mock('@/lib/trpc', () => ({
         useQuery: () => ({ data: null, isLoading: false }),
       },
     },
-    sse: {
-      onPrUpdate: {
-        useSubscription: vi.fn(),
-      },
-    },
-    useUtils: () => ({
-      github: {
-        getSessionPrStatus: { setData: vi.fn() },
-      },
-    }),
   },
 }));
 

--- a/src/components/SessionListContainer.tsx
+++ b/src/components/SessionListContainer.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { SessionList } from '@/components/SessionList';
 import { useSessionList } from '@/hooks/useSessionList';
+import { useSessionListStream } from '@/hooks/useSessionListStream';
 
 /**
  * Container component that wires up data fetching hooks with the SessionList presentation component.
@@ -11,6 +12,9 @@ import { useSessionList } from '@/hooks/useSessionList';
 export function SessionListContainer() {
   const [showArchived, setShowArchived] = useState(false);
   const { sessions, isLoading, refetch } = useSessionList({ includeArchived: showArchived });
+
+  // Keep the list live via the global session-list SSE stream.
+  useSessionListStream(refetch);
 
   return (
     <SessionList

--- a/src/hooks/useClaudeState.ts
+++ b/src/hooks/useClaudeState.ts
@@ -6,8 +6,6 @@ import { useRefetchOnReconnect } from './useRefetchOnReconnect';
  * Hook for managing Claude process state: running status, send prompts, interrupt, and commands.
  */
 export function useClaudeState(sessionId: string) {
-  const utils = trpc.useUtils();
-
   // Fetch Claude running state
   const { data: runningData, refetch } = trpc.claude.isRunning.useQuery({ sessionId });
 
@@ -24,35 +22,8 @@ export function useClaudeState(sessionId: string) {
   }, [refetch, refetchCommands]);
   useRefetchOnReconnect(refetchAll);
 
-  // Subscribe to Claude running state via SSE - update cache directly
-  trpc.sse.onClaudeRunning.useSubscription(
-    { sessionId },
-    {
-      onData: (trackedData) => {
-        utils.claude.isRunning.setData({ sessionId }, { running: trackedData.data.running });
-        // When Claude finishes running, refetch commands in case new ones were discovered
-        if (!trackedData.data.running) {
-          refetchCommands();
-        }
-      },
-      onError: (err) => {
-        console.error('Claude running SSE error:', err);
-      },
-    }
-  );
-
-  // Subscribe to commands updates via SSE - update cache directly
-  trpc.sse.onCommands.useSubscription(
-    { sessionId },
-    {
-      onData: (trackedData) => {
-        utils.claude.getCommands.setData({ sessionId }, { commands: trackedData.data.commands });
-      },
-      onError: (err) => {
-        console.error('Commands SSE error:', err);
-      },
-    }
-  );
+  // Live running-state and command updates arrive via the multiplexed SSE stream
+  // (useSessionStream), which writes directly into these query caches.
 
   const sendMutation = trpc.claude.send.useMutation();
   const interruptMutation = trpc.claude.interrupt.useMutation();

--- a/src/hooks/usePullRequestStatus.ts
+++ b/src/hooks/usePullRequestStatus.ts
@@ -36,8 +36,6 @@ export function usePullRequestStatus(
   sessionId: string,
   enabled: boolean = true
 ): UsePullRequestStatusResult {
-  const utils = trpc.useUtils();
-
   const { data, isLoading } = trpc.github.getSessionPrStatus.useQuery(
     { sessionId },
     {
@@ -47,20 +45,8 @@ export function usePullRequestStatus(
     }
   );
 
-  // Subscribe to real-time PR updates via SSE
-  trpc.sse.onPrUpdate.useSubscription(
-    { sessionId },
-    {
-      enabled,
-      onData: (trackedData) => {
-        const event = trackedData.data;
-        utils.github.getSessionPrStatus.setData(
-          { sessionId },
-          { pullRequest: event.pullRequest as PullRequestInfo | null }
-        );
-      },
-    }
-  );
+  // Live PR updates arrive via the multiplexed SSE stream (useSessionStream),
+  // which writes directly into this query's cache.
 
   return {
     pullRequest: data?.pullRequest as PullRequestInfo | null | undefined,

--- a/src/hooks/useSessionListStream.ts
+++ b/src/hooks/useSessionListStream.ts
@@ -1,0 +1,25 @@
+'use client';
+
+import { trpc } from '@/lib/trpc';
+import { useRefetchOnReconnect } from './useRefetchOnReconnect';
+
+/**
+ * Subscribes to the global session-list SSE stream so the home page updates live
+ * when any session changes (created, started, finished, archived) — including
+ * changes driven from another tab or by background work.
+ *
+ * The list is small, so on each event we simply refetch rather than surgically
+ * patching the cache. We also refetch on tab-visibility / network reconnect as a
+ * resync fallback if the stream was dropped.
+ */
+export function useSessionListStream(refetch: () => void) {
+  useRefetchOnReconnect(refetch);
+
+  trpc.sse.onSessionListEvents.useSubscription(undefined, {
+    onData: () => refetch(),
+    onError: (err) => {
+      console.error('Session list stream SSE error:', err);
+      refetch();
+    },
+  });
+}

--- a/src/hooks/useSessionMessages.ts
+++ b/src/hooks/useSessionMessages.ts
@@ -11,14 +11,16 @@ interface Message {
 const MESSAGE_PAGE_SIZE = 20;
 
 /**
- * Hook for managing message state: history pagination, SSE updates for new messages, and token usage.
+ * Hook for reading message history with infinite-scroll pagination and token usage.
+ *
+ * Live messages are delivered by the single SSE stream in `useSessionStream`, which
+ * writes them directly into this query's cache. This hook is read-only over that
+ * cache plus backward pagination.
  */
 export function useSessionMessages(sessionId: string) {
-  const utils = trpc.useUtils();
-
   // Bidirectional infinite query for message history
   // - fetchNextPage: loads older messages (backward) when user scrolls up
-  // - New messages arrive via SSE and are added directly to the cache
+  // - New messages arrive via SSE (useSessionStream) and are added to the cache
   const {
     data: historyData,
     isLoading,
@@ -54,97 +56,12 @@ export function useSessionMessages(sessionId: string) {
     }
   );
 
-  // Fetch token usage stats (computed server-side from all messages)
-  const { data: tokenUsageData, refetch: refetchTokenUsage } = trpc.claude.getTokenUsage.useQuery(
+  // Fetch token usage stats (computed server-side from all messages).
+  // Refetched by useSessionStream when complete messages arrive.
+  const { data: tokenUsageData } = trpc.claude.getTokenUsage.useQuery(
     { sessionId },
     {
-      // Refetch less frequently since it's just for display
       refetchOnWindowFocus: false,
-    }
-  );
-
-  // Compute newest sequence from cache for SSE catch-up cursor
-  const newestSequence = useMemo(() => {
-    if (!historyData?.pages) return undefined;
-    let newest: number | undefined;
-    for (const page of historyData.pages) {
-      for (const msg of page.messages) {
-        if (newest === undefined || msg.sequence > newest) {
-          newest = msg.sequence;
-        }
-      }
-    }
-    return newest;
-  }, [historyData]);
-
-  // Subscribe to new messages via SSE - update cache directly
-  // Pass cursor to catch up on missed messages when connecting/reconnecting
-  // Handles both complete messages (persisted) and partial messages (transient streaming updates)
-  trpc.sse.onNewMessage.useSubscription(
-    { sessionId, afterSequence: newestSequence },
-    {
-      onData: (trackedData) => {
-        const newMessage = trackedData.data.message;
-        const isPartial = newMessage.id.startsWith('partial-');
-
-        // Add message directly to the infinite query cache
-        utils.claude.getHistory.setInfiniteData({ sessionId, limit: MESSAGE_PAGE_SIZE }, (old) => {
-          if (!old) {
-            // No existing data - create initial page
-            return {
-              pages: [{ messages: [newMessage], hasMore: false }],
-              pageParams: [{ direction: 'backward' as const, sequence: undefined }],
-            };
-          }
-
-          if (isPartial) {
-            // Partial message: replace existing partial or add new one
-            const newPages = old.pages.map((page, pageIndex) => {
-              if (pageIndex !== 0) return page;
-              // Replace existing partial, or append if none exists
-              const hasExistingPartial = page.messages.some((m) => m.id.startsWith('partial-'));
-              if (hasExistingPartial) {
-                return {
-                  ...page,
-                  messages: page.messages.map((m) =>
-                    m.id.startsWith('partial-') ? newMessage : m
-                  ),
-                };
-              }
-              return { ...page, messages: [...page.messages, newMessage] };
-            });
-            return { ...old, pages: newPages };
-          }
-
-          // Complete message: remove any partial messages and add the new one
-          // Check for deduplication first
-          for (const page of old.pages) {
-            if (page.messages.some((m) => m.id === newMessage.id)) {
-              return old; // Already have this message
-            }
-          }
-
-          const newPages = [...old.pages];
-          // Remove partial messages from the first page (they're replaced by complete messages)
-          const firstPageMessages = newPages[0].messages.filter(
-            (m) => !m.id.startsWith('partial-')
-          );
-          newPages[0] = {
-            ...newPages[0],
-            messages: [...firstPageMessages, newMessage],
-          };
-
-          return { ...old, pages: newPages };
-        });
-
-        // Refetch token usage only for complete messages (partials don't affect totals)
-        if (!isPartial) {
-          refetchTokenUsage();
-        }
-      },
-      onError: (err) => {
-        console.error('Message SSE error:', err);
-      },
     }
   );
 

--- a/src/hooks/useSessionMessages.ts
+++ b/src/hooks/useSessionMessages.ts
@@ -65,6 +65,21 @@ export function useSessionMessages(sessionId: string) {
     }
   );
 
+  // Newest sequence currently in the cache. Used once by useSessionStream as the
+  // initial SSE catch-up anchor (it is NOT fed reactively into the subscription).
+  const newestSequence = useMemo(() => {
+    if (!historyData?.pages) return undefined;
+    let newest: number | undefined;
+    for (const page of historyData.pages) {
+      for (const msg of page.messages) {
+        if (newest === undefined || msg.sequence > newest) {
+          newest = msg.sequence;
+        }
+      }
+    }
+    return newest;
+  }, [historyData]);
+
   // Flatten bidirectional pages into chronological order
   // Pages array structure:
   // - pages[0] = newest (from fetchPreviousPage, or initial if no previous fetched)
@@ -95,5 +110,8 @@ export function useSessionMessages(sessionId: string) {
     hasMore: hasNextPage ?? false,
     fetchMore: fetchNextPage,
     tokenUsage: tokenUsageData,
+    // Whether the initial history load has completed (used to anchor the SSE stream).
+    historyLoaded: !isLoading,
+    newestSequence,
   };
 }

--- a/src/hooks/useSessionState.ts
+++ b/src/hooks/useSessionState.ts
@@ -16,19 +16,7 @@ export function useSessionState(sessionId: string) {
   // Refetch session data when app regains visibility or network reconnects
   useRefetchOnReconnect(refetch);
 
-  // Subscribe to session updates via SSE - update cache directly
-  trpc.sse.onSessionUpdate.useSubscription(
-    { sessionId },
-    {
-      onData: (trackedData) => {
-        const session = trackedData.data.session as NonNullable<typeof sessionData>['session'];
-        utils.sessions.get.setData({ sessionId }, { session });
-      },
-      onError: (err) => {
-        console.error('Session SSE error:', err);
-      },
-    }
-  );
+  // Live session updates arrive via the multiplexed SSE stream (useSessionStream).
 
   // Mutations - update cache directly from returned data
   const startMutation = trpc.sessions.start.useMutation({

--- a/src/hooks/useSessionStream.ts
+++ b/src/hooks/useSessionStream.ts
@@ -1,8 +1,9 @@
 'use client';
 
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { trpc } from '@/lib/trpc';
-import { mergeMessageIntoCache } from '@/lib/message-cache';
+import { mergeMessageIntoCache, isPartialMessageId } from '@/lib/message-cache';
+import { assertNeverFallback } from '@/lib/claude-messages';
 import type { PullRequestInfo } from './usePullRequestStatus';
 import type { inferRouterOutputs } from '@trpc/server';
 import type { AppRouter } from '@/server/routers';
@@ -20,20 +21,42 @@ interface CachedMessage {
   createdAt: Date;
 }
 
+interface UseSessionStreamOptions {
+  /** True once the initial `getHistory` load has completed. */
+  historyLoaded: boolean;
+  /** Newest message sequence in the cache at the time history first loaded. */
+  newestSequence: number | undefined;
+}
+
 /**
  * Single multiplexed SSE subscription for a session. Replaces the previous five
  * per-channel subscriptions: it opens one `EventSource` and fans each event kind
  * out to the relevant React Query cache.
  *
- * The subscription input is stable (`{ sessionId }`) — catch-up after a reconnect
- * is handled by tRPC's native `lastEventId` resume, not by a reactive cursor. On a
- * connection error we additionally refetch the session queries as a belt-and-
- * suspenders resync.
+ * Catch-up: the subscription is gated until history has loaded, then started with
+ * a one-time `afterSequence` anchor (the client's newest cached sequence, frozen in
+ * a ref so it never changes — feeding it reactively would tear the stream down each
+ * turn). That closes the gap between the `getHistory` snapshot and the stream
+ * attaching. Subsequent reconnects use tRPC's native `lastEventId` resume instead.
  *
- * Returns the subscription connection status for a UI indicator.
+ * On a connection error we refetch the session queries as a belt-and-suspenders
+ * resync. Returns the subscription connection status for a UI indicator.
  */
-export function useSessionStream(sessionId: string) {
+export function useSessionStream(sessionId: string, options: UseSessionStreamOptions) {
   const utils = trpc.useUtils();
+
+  // Freeze the catch-up anchor the first time history is loaded so the subscription
+  // input stays stable across the rest of the session (feeding the live newest
+  // sequence reactively would tear the stream down every turn).
+  const [anchor, setAnchor] = useState<{ captured: boolean; afterSequence: number | undefined }>({
+    captured: false,
+    afterSequence: undefined,
+  });
+  // Capture the anchor once, during render (React's supported "adjust state from a
+  // prior render" pattern). The guard makes it fire at most once, so no loop.
+  if (!anchor.captured && options.historyLoaded) {
+    setAnchor({ captured: true, afterSequence: options.newestSequence });
+  }
 
   const resync = useCallback(() => {
     void utils.claude.isRunning.refetch({ sessionId });
@@ -43,8 +66,9 @@ export function useSessionStream(sessionId: string) {
   }, [utils, sessionId]);
 
   const subscription = trpc.sse.onSessionEvents.useSubscription(
-    { sessionId },
+    { sessionId, afterSequence: anchor.afterSequence },
     {
+      enabled: anchor.captured,
       onData: (tracked) => {
         const event = tracked.data;
         switch (event.kind) {
@@ -54,7 +78,7 @@ export function useSessionStream(sessionId: string) {
               (old) => mergeMessageIntoCache(old, event.message as CachedMessage)
             );
             // Complete (persisted) messages affect token totals; partials do not.
-            if (!event.message.id.startsWith('partial-')) {
+            if (!isPartialMessageId(event.message.id)) {
               void utils.claude.getTokenUsage.refetch({ sessionId });
             }
             break;
@@ -85,6 +109,9 @@ export function useSessionStream(sessionId: string) {
             );
             break;
           }
+          default:
+            // Compile-time guard: a new SessionStreamEvent kind must be handled here.
+            assertNeverFallback(event, undefined);
         }
       },
       onError: (err) => {

--- a/src/hooks/useSessionStream.ts
+++ b/src/hooks/useSessionStream.ts
@@ -1,0 +1,99 @@
+'use client';
+
+import { useCallback } from 'react';
+import { trpc } from '@/lib/trpc';
+import { mergeMessageIntoCache } from '@/lib/message-cache';
+import type { PullRequestInfo } from './usePullRequestStatus';
+import type { inferRouterOutputs } from '@trpc/server';
+import type { AppRouter } from '@/server/routers';
+
+type SessionGetOutput = inferRouterOutputs<AppRouter>['sessions']['get'];
+
+const MESSAGE_PAGE_SIZE = 20;
+
+interface CachedMessage {
+  id: string;
+  sessionId: string;
+  sequence: number;
+  type: string;
+  content: unknown;
+  createdAt: Date;
+}
+
+/**
+ * Single multiplexed SSE subscription for a session. Replaces the previous five
+ * per-channel subscriptions: it opens one `EventSource` and fans each event kind
+ * out to the relevant React Query cache.
+ *
+ * The subscription input is stable (`{ sessionId }`) — catch-up after a reconnect
+ * is handled by tRPC's native `lastEventId` resume, not by a reactive cursor. On a
+ * connection error we additionally refetch the session queries as a belt-and-
+ * suspenders resync.
+ *
+ * Returns the subscription connection status for a UI indicator.
+ */
+export function useSessionStream(sessionId: string) {
+  const utils = trpc.useUtils();
+
+  const resync = useCallback(() => {
+    void utils.claude.isRunning.refetch({ sessionId });
+    void utils.claude.getCommands.refetch({ sessionId });
+    void utils.sessions.get.refetch({ sessionId });
+    void utils.claude.getTokenUsage.refetch({ sessionId });
+  }, [utils, sessionId]);
+
+  const subscription = trpc.sse.onSessionEvents.useSubscription(
+    { sessionId },
+    {
+      onData: (tracked) => {
+        const event = tracked.data;
+        switch (event.kind) {
+          case 'message': {
+            utils.claude.getHistory.setInfiniteData(
+              { sessionId, limit: MESSAGE_PAGE_SIZE },
+              (old) => mergeMessageIntoCache(old, event.message as CachedMessage)
+            );
+            // Complete (persisted) messages affect token totals; partials do not.
+            if (!event.message.id.startsWith('partial-')) {
+              void utils.claude.getTokenUsage.refetch({ sessionId });
+            }
+            break;
+          }
+          case 'running': {
+            utils.claude.isRunning.setData({ sessionId }, { running: event.running });
+            // When Claude stops, new slash commands may have been discovered.
+            if (!event.running) {
+              void utils.claude.getCommands.refetch({ sessionId });
+            }
+            break;
+          }
+          case 'commands': {
+            utils.claude.getCommands.setData({ sessionId }, { commands: event.commands });
+            break;
+          }
+          case 'pr': {
+            utils.github.getSessionPrStatus.setData(
+              { sessionId },
+              { pullRequest: event.pullRequest as PullRequestInfo | null }
+            );
+            break;
+          }
+          case 'session': {
+            utils.sessions.get.setData(
+              { sessionId },
+              { session: event.session as SessionGetOutput['session'] }
+            );
+            break;
+          }
+        }
+      },
+      onError: (err) => {
+        console.error('Session stream SSE error:', err);
+        // The stream will auto-reconnect; refetch so the UI is correct meanwhile.
+        resync();
+      },
+    }
+  );
+
+  return { status: subscription.status };
+}

--- a/src/lib/message-cache.test.ts
+++ b/src/lib/message-cache.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import {
+  mergeMessageIntoCache,
+  isPartialMessageId,
+  PARTIAL_MESSAGE_ID_PREFIX,
+  type MessageInfiniteCache,
+} from './message-cache';
+
+interface Msg {
+  id: string;
+  sequence: number;
+}
+
+const partial = (uuid: string, seq: number): Msg => ({
+  id: `${PARTIAL_MESSAGE_ID_PREFIX}${uuid}`,
+  sequence: seq,
+});
+const complete = (id: string, seq: number): Msg => ({ id, sequence: seq });
+
+function cache(pages: Msg[][]): MessageInfiniteCache<Msg> {
+  return {
+    pages: pages.map((messages) => ({ messages, hasMore: false })),
+    pageParams: pages.map(() => undefined),
+  };
+}
+
+describe('isPartialMessageId', () => {
+  it('detects the partial prefix', () => {
+    expect(isPartialMessageId('partial-abc')).toBe(true);
+    expect(isPartialMessageId('msg-1')).toBe(false);
+  });
+});
+
+describe('mergeMessageIntoCache', () => {
+  it('bootstraps a page when there is no existing cache', () => {
+    const result = mergeMessageIntoCache<Msg>(undefined, complete('a', 0));
+    expect(result.pages).toHaveLength(1);
+    expect(result.pages[0].messages).toEqual([complete('a', 0)]);
+  });
+
+  it('bootstraps a page when the cache has zero pages', () => {
+    const result = mergeMessageIntoCache(cache([]), complete('a', 0));
+    expect(result.pages[0].messages).toEqual([complete('a', 0)]);
+  });
+
+  it('appends a partial when none exists on the newest page', () => {
+    const result = mergeMessageIntoCache(cache([[complete('a', 0)]]), partial('p', 1));
+    expect(result.pages[0].messages).toEqual([complete('a', 0), partial('p', 1)]);
+  });
+
+  it('replaces an existing partial instead of appending a second one', () => {
+    const result = mergeMessageIntoCache(
+      cache([[complete('a', 0), partial('p', 1)]]),
+      partial('p', 1)
+    );
+    const partials = result.pages[0].messages.filter((m) => isPartialMessageId(m.id));
+    expect(partials).toHaveLength(1);
+  });
+
+  it('only touches the newest page when handling partials', () => {
+    const older = [complete('a', 0)];
+    const result = mergeMessageIntoCache(cache([[complete('b', 1)], older]), partial('p', 2));
+    // page[1] (older) is returned by reference, unchanged
+    expect(result.pages[1].messages).toBe(older);
+  });
+
+  it('drops partials and appends when a complete message arrives', () => {
+    const result = mergeMessageIntoCache(
+      cache([[complete('a', 0), partial('p', 1)]]),
+      complete('b', 1)
+    );
+    expect(result.pages[0].messages).toEqual([complete('a', 0), complete('b', 1)]);
+  });
+
+  it('dedupes a complete message that is already present', () => {
+    const existing = cache([[complete('a', 0)], [complete('b', 1)]]);
+    const result = mergeMessageIntoCache(existing, complete('b', 1));
+    expect(result).toBe(existing);
+  });
+});

--- a/src/lib/message-cache.ts
+++ b/src/lib/message-cache.ts
@@ -1,0 +1,87 @@
+/**
+ * Pure helpers for merging live SSE messages into the React Query infinite-query
+ * cache used by the session message list.
+ *
+ * Two kinds of messages arrive over the stream:
+ * - **Partial** messages (id prefixed with {@link PARTIAL_MESSAGE_ID_PREFIX}) are
+ *   transient streaming snapshots of the in-progress assistant turn. At most one
+ *   lives in the cache at a time; each new one replaces it.
+ * - **Complete** messages are persisted and immutable. When one arrives it removes
+ *   any lingering partials and is appended (deduped by id).
+ *
+ * Pages are ordered newest-page-last is NOT the case here: page[0] holds the
+ * newest messages (matching `getHistory`'s backward pagination), so live messages
+ * are appended to page[0].
+ */
+
+/** Prefix for transient streaming (partial) message ids. */
+export const PARTIAL_MESSAGE_ID_PREFIX = 'partial-';
+
+export function isPartialMessageId(id: string): boolean {
+  return id.startsWith(PARTIAL_MESSAGE_ID_PREFIX);
+}
+
+export interface MessageLike {
+  id: string;
+}
+
+export interface MessagePage<M extends MessageLike> {
+  messages: M[];
+  hasMore: boolean;
+}
+
+export interface MessageInfiniteCache<M extends MessageLike> {
+  pages: MessagePage<M>[];
+  pageParams: unknown[];
+}
+
+/**
+ * Merge a single live message into the infinite-query cache. Pure: returns a new
+ * cache object (or the same reference when nothing changes, e.g. a duplicate).
+ */
+export function mergeMessageIntoCache<M extends MessageLike>(
+  old: MessageInfiniteCache<M> | undefined,
+  message: M
+): MessageInfiniteCache<M> {
+  const isPartial = isPartialMessageId(message.id);
+
+  if (!old || old.pages.length === 0) {
+    // No existing data - bootstrap a single page.
+    return {
+      pages: [{ messages: [message], hasMore: false }],
+      pageParams: [{ direction: 'backward' as const, sequence: undefined }],
+    };
+  }
+
+  if (isPartial) {
+    // Replace the existing partial on the newest page, or append if none exists.
+    const newPages = old.pages.map((page, pageIndex) => {
+      if (pageIndex !== 0) return page;
+      const hasExistingPartial = page.messages.some((m) => isPartialMessageId(m.id));
+      if (hasExistingPartial) {
+        return {
+          ...page,
+          messages: page.messages.map((m) => (isPartialMessageId(m.id) ? message : m)),
+        };
+      }
+      return { ...page, messages: [...page.messages, message] };
+    });
+    return { ...old, pages: newPages };
+  }
+
+  // Complete message: dedupe by id across all pages first.
+  for (const page of old.pages) {
+    if (page.messages.some((m) => m.id === message.id)) {
+      return old;
+    }
+  }
+
+  // Drop any partials from the newest page (they are now superseded) and append.
+  const newPages = [...old.pages];
+  const firstPageMessages = newPages[0].messages.filter((m) => !isPartialMessageId(m.id));
+  newPages[0] = {
+    ...newPages[0],
+    messages: [...firstPageMessages, message],
+  };
+  return { ...old, pages: newPages };
+}

--- a/src/lib/message-cache.ts
+++ b/src/lib/message-cache.ts
@@ -30,26 +30,26 @@ export interface MessagePage<M extends MessageLike> {
   hasMore: boolean;
 }
 
-export interface MessageInfiniteCache<M extends MessageLike> {
+export interface MessageInfiniteCache<M extends MessageLike, P = unknown> {
   pages: MessagePage<M>[];
-  pageParams: unknown[];
+  pageParams: P[];
 }
 
 /**
  * Merge a single live message into the infinite-query cache. Pure: returns a new
  * cache object (or the same reference when nothing changes, e.g. a duplicate).
  */
-export function mergeMessageIntoCache<M extends MessageLike>(
-  old: MessageInfiniteCache<M> | undefined,
+export function mergeMessageIntoCache<M extends MessageLike, P = unknown>(
+  old: MessageInfiniteCache<M, P> | undefined,
   message: M
-): MessageInfiniteCache<M> {
+): MessageInfiniteCache<M, P> {
   const isPartial = isPartialMessageId(message.id);
 
   if (!old || old.pages.length === 0) {
     // No existing data - bootstrap a single page.
     return {
       pages: [{ messages: [message], hasMore: false }],
-      pageParams: [{ direction: 'backward' as const, sequence: undefined }],
+      pageParams: [{ direction: 'backward' as const, sequence: undefined }] as unknown as P[],
     };
   }
 

--- a/src/lib/sse-resume.test.ts
+++ b/src/lib/sse-resume.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { formatResumeToken, parseResumeToken, EMPTY_WATERMARK } from './sse-resume';
+
+describe('sse-resume', () => {
+  describe('formatResumeToken', () => {
+    it('joins watermark and counter with a colon', () => {
+      expect(formatResumeToken(42, 7)).toBe('42:7');
+    });
+
+    it('formats the empty watermark', () => {
+      expect(formatResumeToken(EMPTY_WATERMARK, 0)).toBe('-1:0');
+    });
+  });
+
+  describe('parseResumeToken', () => {
+    it('round-trips a formatted token', () => {
+      expect(parseResumeToken(formatResumeToken(42, 7))).toEqual({ watermark: 42, counter: 7 });
+    });
+
+    it('round-trips the empty watermark', () => {
+      expect(parseResumeToken(formatResumeToken(EMPTY_WATERMARK, 3))).toEqual({
+        watermark: -1,
+        counter: 3,
+      });
+    });
+
+    it('returns null for a missing token', () => {
+      expect(parseResumeToken(null)).toBeNull();
+      expect(parseResumeToken(undefined)).toBeNull();
+      expect(parseResumeToken('')).toBeNull();
+    });
+
+    it('returns null for a token without exactly two parts', () => {
+      expect(parseResumeToken('42')).toBeNull();
+      expect(parseResumeToken('42:7:9')).toBeNull();
+    });
+
+    it('returns null for non-integer parts (e.g. an old-format id)', () => {
+      expect(parseResumeToken('abc:7')).toBeNull();
+      expect(parseResumeToken('42:xyz')).toBeNull();
+      expect(parseResumeToken('partial-uuid')).toBeNull();
+      expect(parseResumeToken('4.2:7')).toBeNull();
+    });
+  });
+});

--- a/src/lib/sse-resume.ts
+++ b/src/lib/sse-resume.ts
@@ -1,0 +1,50 @@
+/**
+ * Resume-token helpers for the multiplexed per-session SSE stream.
+ *
+ * The stream carries a union of event kinds, but only persisted messages are
+ * replayable on reconnect (they have monotonic `sequence` numbers). The single
+ * `tracked()` id therefore encodes two things:
+ *
+ * - `watermark`: the highest persisted message sequence yielded so far on this
+ *   connection. On reconnect the server replays `message.sequence > watermark`.
+ * - `counter`: a per-connection value that strictly increases for every yielded
+ *   event (seeded from the previous `lastEventId` on reconnect). Because tRPC
+ *   drops events whose tracked id repeats, the counter guarantees uniqueness even
+ *   when several events share the same watermark.
+ *
+ * Token format: `${watermark}:${counter}` — e.g. `42:7`.
+ *
+ * `-1` is the watermark used when a session has no persisted messages yet
+ * (sequences start at 0), so `sequence > -1` replays everything.
+ */
+
+export interface ResumeToken {
+  watermark: number;
+  counter: number;
+}
+
+/** Watermark used before any message has been persisted (sequences start at 0). */
+export const EMPTY_WATERMARK = -1;
+
+export function formatResumeToken(watermark: number, counter: number): string {
+  return `${watermark}:${counter}`;
+}
+
+/**
+ * Parse a `lastEventId` produced by {@link formatResumeToken}. Returns `null` for
+ * a missing or malformed token (e.g. a fresh connection, or an id from an older
+ * format), in which case the caller should start from the current high-water mark
+ * without replaying.
+ */
+export function parseResumeToken(token: string | null | undefined): ResumeToken | null {
+  if (!token) return null;
+
+  const parts = token.split(':');
+  if (parts.length !== 2) return null;
+
+  const watermark = Number(parts[0]);
+  const counter = Number(parts[1]);
+  if (!Number.isInteger(watermark) || !Number.isInteger(counter)) return null;
+
+  return { watermark, counter };
+}

--- a/src/server/routers/sse.ts
+++ b/src/server/routers/sse.ts
@@ -1,105 +1,72 @@
 import { z } from 'zod';
 import { router, protectedProcedure } from '../trpc';
 import { sseEvents } from '../services/events';
-import type { PrUpdateEvent } from '../services/events';
+import type { SessionStreamEvent, SessionUpdateEvent } from '../services/events';
 import { tracked } from '@trpc/server';
 import { prisma } from '@/lib/prisma';
+import { isPartialMessageId } from '@/lib/message-cache';
+import { formatResumeToken, parseResumeToken, EMPTY_WATERMARK } from '@/lib/sse-resume';
+
+/**
+ * Eagerly subscribe to an event source and buffer events into a queue. Subscribing
+ * synchronously (rather than on the first generator `next()`) ensures events that
+ * arrive while we replay history are not missed.
+ */
+function createEventQueue<T>(subscribe: (push: (event: T) => void) => () => void) {
+  const queue: T[] = [];
+  let resolveWait: (() => void) | null = null;
+  const unsubscribe = subscribe((event) => {
+    queue.push(event);
+    resolveWait?.();
+  });
+  const waitForEvent = (signal: AbortSignal | undefined): Promise<void> =>
+    new Promise<void>((resolve) => {
+      const onAbort = () => resolve();
+      resolveWait = () => {
+        signal?.removeEventListener('abort', onAbort);
+        resolve();
+      };
+      signal?.addEventListener('abort', onAbort, { once: true });
+    });
+  return { queue, waitForEvent, unsubscribe };
+}
 
 export const sseRouter = router({
-  // Subscribe to session updates (status changes, etc.)
-  onSessionUpdate: protectedProcedure
-    .input(z.object({ sessionId: z.string().uuid() }))
-    .subscription(async function* ({ input, signal }) {
-      // Create an async iterator from event emitter
-      const events: Array<{ type: 'session_update'; sessionId: string; session: unknown }> = [];
-      let resolveWait: (() => void) | null = null;
-
-      const unsubscribe = sseEvents.onSessionUpdate(input.sessionId, (event) => {
-        events.push(event);
-        resolveWait?.();
-      });
-
-      try {
-        while (!signal?.aborted) {
-          if (events.length > 0) {
-            const event = events.shift()!;
-            yield tracked(event.sessionId, event);
-          } else {
-            // Wait for next event or abort
-            await new Promise<void>((resolve) => {
-              const onAbort = () => resolve();
-              resolveWait = () => {
-                signal?.removeEventListener('abort', onAbort);
-                resolve();
-              };
-              signal?.addEventListener('abort', onAbort, { once: true });
-            });
-          }
-        }
-      } finally {
-        unsubscribe();
-      }
-    }),
-
-  // Subscribe to new messages for a session
-  // Optionally accepts afterSequence to catch up on missed messages
-  onNewMessage: protectedProcedure
+  // Single multiplexed stream of all event kinds for one session.
+  //
+  // `lastEventId` is supplied by tRPC automatically on reconnect (from the SSE
+  // `Last-Event-ID` header). Its token encodes the message high-water mark, so we
+  // replay persisted messages missed while disconnected. Non-message events are
+  // "latest value" and are resynced by the client's React Query refetch — they are
+  // streamed live but never replayed.
+  onSessionEvents: protectedProcedure
     .input(
       z.object({
         sessionId: z.string().uuid(),
-        afterSequence: z.number().int().optional(),
+        lastEventId: z.string().nullish(),
       })
     )
     .subscription(async function* ({ input, signal }) {
-      const events: Array<{
-        type: 'new_message';
-        sessionId: string;
-        message: {
-          id: string;
-          sessionId: string;
-          sequence: number;
-          type: string;
-          content: unknown;
-          createdAt: Date;
-        };
-      }> = [];
-      let resolveWait: (() => void) | null = null;
+      const resume = parseResumeToken(input.lastEventId);
+      let counter = resume?.counter ?? 0;
+      let watermark = resume?.watermark ?? EMPTY_WATERMARK;
 
-      // Start listening to real-time events FIRST (before DB query)
-      // to avoid missing messages during the query
-      const unsubscribe = sseEvents.onNewMessage(input.sessionId, (event) => {
-        // Send full message data so client can update cache directly
-        events.push({
-          type: 'new_message',
-          sessionId: event.sessionId,
-          message: {
-            id: event.message.id,
-            sessionId: event.message.sessionId,
-            sequence: event.message.sequence,
-            type: event.message.type,
-            content: event.message.content,
-            createdAt: event.message.createdAt,
-          },
-        });
-        resolveWait?.();
-      });
+      // Subscribe before any awaits so we don't miss live events during replay.
+      const { queue, waitForEvent, unsubscribe } = createEventQueue<SessionStreamEvent>((push) =>
+        sseEvents.onSessionEvents(input.sessionId, push)
+      );
 
       try {
-        // Query for missed messages if cursor provided
-        if (input.afterSequence !== undefined) {
-          const missedMessages = await prisma.message.findMany({
-            where: {
-              sessionId: input.sessionId,
-              sequence: { gt: input.afterSequence },
-            },
+        if (resume) {
+          // Replay messages persisted since the client's last known sequence.
+          const missed = await prisma.message.findMany({
+            where: { sessionId: input.sessionId, sequence: { gt: resume.watermark } },
             orderBy: { sequence: 'asc' },
           });
-
-          // Yield missed messages first
-          for (const msg of missedMessages) {
-            yield tracked(msg.id, {
-              type: 'new_message' as const,
-              sessionId: msg.sessionId,
+          for (const msg of missed) {
+            watermark = msg.sequence;
+            yield tracked(formatResumeToken(watermark, ++counter), {
+              kind: 'message' as const,
               message: {
                 id: msg.id,
                 sessionId: msg.sessionId,
@@ -110,29 +77,27 @@ export const sseRouter = router({
               },
             });
           }
+        } else {
+          // Fresh connect: anchor the watermark at the current max so a later
+          // reconnect replays only messages created from here on.
+          const last = await prisma.message.findFirst({
+            where: { sessionId: input.sessionId },
+            orderBy: { sequence: 'desc' },
+            select: { sequence: true },
+          });
+          watermark = last?.sequence ?? EMPTY_WATERMARK;
         }
 
-        // Then stream real-time events (client deduplicates any overlap)
-        // Partial messages (id starting with "partial-") need unique tracking IDs
-        // so tRPC doesn't deduplicate subsequent updates to the same partial
-        let partialCounter = 0;
         while (!signal?.aborted) {
-          if (events.length > 0) {
-            const event = events.shift()!;
-            const isPartial = event.message.id.startsWith('partial-');
-            const trackingId = isPartial
-              ? `${event.message.id}-${partialCounter++}`
-              : event.message.id;
-            yield tracked(trackingId, event);
+          if (queue.length > 0) {
+            const event = queue.shift()!;
+            // Only persisted (complete) messages advance the resume watermark.
+            if (event.kind === 'message' && !isPartialMessageId(event.message.id)) {
+              watermark = event.message.sequence;
+            }
+            yield tracked(formatResumeToken(watermark, ++counter), event);
           } else {
-            await new Promise<void>((resolve) => {
-              const onAbort = () => resolve();
-              resolveWait = () => {
-                signal?.removeEventListener('abort', onAbort);
-                resolve();
-              };
-              signal?.addEventListener('abort', onAbort, { once: true });
-            });
+            await waitForEvent(signal);
           }
         }
       } finally {
@@ -140,104 +105,29 @@ export const sseRouter = router({
       }
     }),
 
-  // Subscribe to Claude running state changes
-  onClaudeRunning: protectedProcedure
-    .input(z.object({ sessionId: z.string().uuid() }))
+  // Global stream of session changes for the home page (all sessions). The list is
+  // small and also refetched on reconnect, so we only need monotonic tracked ids
+  // (seeded from lastEventId) to avoid client-side dedup dropping the first event.
+  onSessionListEvents: protectedProcedure
+    .input(z.object({ lastEventId: z.string().nullish() }).optional())
     .subscription(async function* ({ input, signal }) {
-      const events: Array<{ type: 'claude_running'; sessionId: string; running: boolean }> = [];
-      let resolveWait: (() => void) | null = null;
+      const seeded = Number(input?.lastEventId);
+      let counter = Number.isInteger(seeded) ? seeded + 1 : 0;
 
-      const unsubscribe = sseEvents.onClaudeRunning(input.sessionId, (event) => {
-        events.push(event);
-        resolveWait?.();
-      });
+      const { queue, waitForEvent, unsubscribe } = createEventQueue<SessionUpdateEvent>((push) =>
+        sseEvents.onSessionListChanged(push)
+      );
 
       try {
         while (!signal?.aborted) {
-          if (events.length > 0) {
-            const event = events.shift()!;
-            yield tracked(`${event.sessionId}-${event.running}`, event);
-          } else {
-            await new Promise<void>((resolve) => {
-              const onAbort = () => resolve();
-              resolveWait = () => {
-                signal?.removeEventListener('abort', onAbort);
-                resolve();
-              };
-              signal?.addEventListener('abort', onAbort, { once: true });
+          if (queue.length > 0) {
+            const event = queue.shift()!;
+            yield tracked(String(counter++), {
+              kind: 'session' as const,
+              session: event.session,
             });
-          }
-        }
-      } finally {
-        unsubscribe();
-      }
-    }),
-
-  // Subscribe to supported slash commands updates
-  onCommands: protectedProcedure
-    .input(z.object({ sessionId: z.string().uuid() }))
-    .subscription(async function* ({ input, signal }) {
-      const events: Array<{
-        type: 'commands';
-        sessionId: string;
-        commands: Array<{ name: string; description: string; argumentHint: string }>;
-      }> = [];
-      let resolveWait: (() => void) | null = null;
-      let counter = 0;
-
-      const unsubscribe = sseEvents.onCommands(input.sessionId, (event) => {
-        events.push(event);
-        resolveWait?.();
-      });
-
-      try {
-        while (!signal?.aborted) {
-          if (events.length > 0) {
-            const event = events.shift()!;
-            yield tracked(`${event.sessionId}-commands-${counter++}`, event);
           } else {
-            await new Promise<void>((resolve) => {
-              const onAbort = () => resolve();
-              resolveWait = () => {
-                signal?.removeEventListener('abort', onAbort);
-                resolve();
-              };
-              signal?.addEventListener('abort', onAbort, { once: true });
-            });
-          }
-        }
-      } finally {
-        unsubscribe();
-      }
-    }),
-
-  // Subscribe to PR status updates for a session
-  onPrUpdate: protectedProcedure
-    .input(z.object({ sessionId: z.string().uuid() }))
-    .subscription(async function* ({ input, signal }) {
-      const events: PrUpdateEvent[] = [];
-      let resolveWait: (() => void) | null = null;
-      let counter = 0;
-
-      const unsubscribe = sseEvents.onPrUpdate(input.sessionId, (event) => {
-        events.push(event);
-        resolveWait?.();
-      });
-
-      try {
-        while (!signal?.aborted) {
-          if (events.length > 0) {
-            const event = events.shift()!;
-            yield tracked(`${event.sessionId}-pr-${counter++}`, event);
-          } else {
-            await new Promise<void>((resolve) => {
-              const onAbort = () => resolve();
-              resolveWait = () => {
-                signal?.removeEventListener('abort', onAbort);
-                resolve();
-              };
-              signal?.addEventListener('abort', onAbort, { once: true });
-            });
+            await waitForEvent(signal);
           }
         }
       } finally {

--- a/src/server/routers/sse.ts
+++ b/src/server/routers/sse.ts
@@ -21,6 +21,12 @@ function createEventQueue<T>(subscribe: (push: (event: T) => void) => () => void
   });
   const waitForEvent = (signal: AbortSignal | undefined): Promise<void> =>
     new Promise<void>((resolve) => {
+      // If already aborted, the 'abort' event has fired and won't fire again,
+      // so resolve synchronously to avoid hanging the generator.
+      if (signal?.aborted) {
+        resolve();
+        return;
+      }
       const onAbort = () => resolve();
       resolveWait = () => {
         signal?.removeEventListener('abort', onAbort);
@@ -34,22 +40,34 @@ function createEventQueue<T>(subscribe: (push: (event: T) => void) => () => void
 export const sseRouter = router({
   // Single multiplexed stream of all event kinds for one session.
   //
-  // `lastEventId` is supplied by tRPC automatically on reconnect (from the SSE
-  // `Last-Event-ID` header). Its token encodes the message high-water mark, so we
-  // replay persisted messages missed while disconnected. Non-message events are
-  // "latest value" and are resynced by the client's React Query refetch — they are
-  // streamed live but never replayed.
+  // Catch-up uses a replay floor: messages with `sequence > floor` are replayed
+  // before live streaming begins. The floor comes from one of two places:
+  //   - `lastEventId` — supplied by tRPC automatically on reconnect (from the SSE
+  //     `Last-Event-ID` header); its token encodes the high-water mark.
+  //   - `afterSequence` — the client's newest cached message sequence, captured
+  //     once at mount and sent on the *initial* connect (no lastEventId yet). This
+  //     closes the window between the client's `getHistory` snapshot and the stream
+  //     attaching, during which messages could otherwise be missed by both paths.
+  // With neither, we anchor at the current max (nothing to replay).
+  //
+  // Non-message events are "latest value" and are resynced by the client's React
+  // Query refetch — they are streamed live but never replayed.
   onSessionEvents: protectedProcedure
     .input(
       z.object({
         sessionId: z.string().uuid(),
+        afterSequence: z.number().int().optional(),
         lastEventId: z.string().nullish(),
       })
     )
     .subscription(async function* ({ input, signal }) {
       const resume = parseResumeToken(input.lastEventId);
       let counter = resume?.counter ?? 0;
-      let watermark = resume?.watermark ?? EMPTY_WATERMARK;
+
+      // Replay floor: lastEventId (reconnect) takes precedence over the initial
+      // afterSequence anchor; with neither we don't replay.
+      const replayFloor = resume ? resume.watermark : input.afterSequence;
+      let watermark = replayFloor ?? EMPTY_WATERMARK;
 
       // Subscribe before any awaits so we don't miss live events during replay.
       const { queue, waitForEvent, unsubscribe } = createEventQueue<SessionStreamEvent>((push) =>
@@ -57,10 +75,10 @@ export const sseRouter = router({
       );
 
       try {
-        if (resume) {
+        if (replayFloor !== undefined) {
           // Replay messages persisted since the client's last known sequence.
           const missed = await prisma.message.findMany({
-            where: { sessionId: input.sessionId, sequence: { gt: resume.watermark } },
+            where: { sessionId: input.sessionId, sequence: { gt: replayFloor } },
             orderBy: { sequence: 'asc' },
           });
           for (const msg of missed) {
@@ -78,8 +96,8 @@ export const sseRouter = router({
             });
           }
         } else {
-          // Fresh connect: anchor the watermark at the current max so a later
-          // reconnect replays only messages created from here on.
+          // No catch-up requested: anchor the watermark at the current max so a
+          // later reconnect replays only messages created from here on.
           const last = await prisma.message.findFirst({
             where: { sessionId: input.sessionId },
             orderBy: { sequence: 'desc' },
@@ -111,7 +129,8 @@ export const sseRouter = router({
   onSessionListEvents: protectedProcedure
     .input(z.object({ lastEventId: z.string().nullish() }).optional())
     .subscription(async function* ({ input, signal }) {
-      const seeded = Number(input?.lastEventId);
+      // Guard against Number(null) === 0: only seed from a non-empty id.
+      const seeded = input?.lastEventId ? Number(input.lastEventId) : NaN;
       let counter = Number.isInteger(seeded) ? seeded + 1 : 0;
 
       const { queue, waitForEvent, unsubscribe } = createEventQueue<SessionUpdateEvent>((push) =>

--- a/src/server/services/claude-runner.ts
+++ b/src/server/services/claude-runner.ts
@@ -28,6 +28,7 @@ import { createLogger, toError } from '@/lib/logger';
 import { fetchPullRequestForBranch } from './github';
 import { getCurrentBranch } from './worktree-manager';
 import { StreamAccumulator } from './stream-accumulator';
+import { PARTIAL_MESSAGE_ID_PREFIX } from '@/lib/message-cache';
 import type { ContainerEnvVar } from './repo-settings';
 
 const execFileAsync = promisify(execFile);
@@ -575,7 +576,6 @@ export async function runClaudeCommand(options: RunClaudeCommandOptions): Promis
 
   try {
     const accumulator = new StreamAccumulator();
-    const PARTIAL_MESSAGE_ID_PREFIX = 'partial-';
 
     // Start the query
     const q = query({ prompt, options: sdkOptions });

--- a/src/server/services/events.ts
+++ b/src/server/services/events.ts
@@ -44,10 +44,33 @@ export type SSEEvent =
   | CommandsEvent
   | PrUpdateEvent;
 
+/**
+ * Normalized union delivered over the single multiplexed per-session SSE stream.
+ * The five per-channel events above are folded into this discriminated union by
+ * {@link SSEEventEmitter.onSessionEvents}. A `message`'s id distinguishes partial
+ * (transient streaming) from complete (persisted) messages.
+ */
+export type SessionStreamEvent =
+  | { kind: 'message'; message: ParsedMessage }
+  | { kind: 'running'; running: boolean }
+  | { kind: 'commands'; commands: SlashCommand[] }
+  | { kind: 'pr'; pullRequest: PullRequestInfo | null }
+  | { kind: 'session'; session: Session };
+
+// Global channel name for cross-session list updates (not session-scoped).
+const SESSION_LIST_EVENT = 'session-list';
+
 // Create a typed event emitter
 class SSEEventEmitter extends EventEmitter {
   emitSessionUpdate(sessionId: string, session: Session): void {
     this.emit(`session:${sessionId}`, {
+      type: 'session_update',
+      sessionId,
+      session,
+    } satisfies SessionUpdateEvent);
+    // Fan out to the global list channel so the home page updates live for any
+    // session, without each row needing its own subscription.
+    this.emit(SESSION_LIST_EVENT, {
       type: 'session_update',
       sessionId,
       session,
@@ -118,6 +141,27 @@ class SSEEventEmitter extends EventEmitter {
     const eventName = `pr:${sessionId}`;
     this.on(eventName, callback);
     return () => this.off(eventName, callback);
+  }
+
+  /**
+   * Subscribe to all event kinds for a session as a single normalized stream.
+   * Returns one unsubscribe that detaches every underlying channel listener.
+   */
+  onSessionEvents(sessionId: string, callback: (event: SessionStreamEvent) => void): () => void {
+    const unsubscribes = [
+      this.onNewMessage(sessionId, (e) => callback({ kind: 'message', message: e.message })),
+      this.onClaudeRunning(sessionId, (e) => callback({ kind: 'running', running: e.running })),
+      this.onCommands(sessionId, (e) => callback({ kind: 'commands', commands: e.commands })),
+      this.onPrUpdate(sessionId, (e) => callback({ kind: 'pr', pullRequest: e.pullRequest })),
+      this.onSessionUpdate(sessionId, (e) => callback({ kind: 'session', session: e.session })),
+    ];
+    return () => unsubscribes.forEach((unsubscribe) => unsubscribe());
+  }
+
+  // Subscribe to session list changes across all sessions (home page).
+  onSessionListChanged(callback: (event: SessionUpdateEvent) => void): () => void {
+    this.on(SESSION_LIST_EVENT, callback);
+    return () => this.off(SESSION_LIST_EVENT, callback);
   }
 }
 


### PR DESCRIPTION
## Summary

Refactors the real-time layer in response to a review of the SSE/hooks setup. **Keeps SSE** (the data flow is one-directional; client→server is already HTTP mutations) but fixes the two things that made it fragile: too many connections and hand-rolled resync.

### Before
- **5 SSE connections per session page** — `httpSubscriptionLink` doesn't multiplex, so `onNewMessage`/`onClaudeRunning`/`onCommands`/`onPrUpdate`/`onSessionUpdate` were each their own `EventSource` (near the browser's 6-conn/HTTP-1.1 cap).
- **Reactive catch-up cursor** — `useSessionMessages` passed `afterSequence: newestSequence` as subscription *input*, which changes each turn, tearing down and reopening the `EventSource` (+ a DB catch-up query) roughly once per turn. A silent reconnect resumed from a stale cursor.
- **tRPC's native `lastEventId` resume was unused.**
- **Home page had no live updates**; SSE failure was `console.error`-only.

### After
- **2 streams across the app**: one multiplexed `onSessionEvents({ sessionId })` per session (discriminated union of all event kinds) + one global `onSessionListEvents()` for the home page.
- **Idiomatic resume**: stable subscription input; each event is `tracked()` with a `` `${watermark}:${counter}` `` token. On reconnect the server replays `sequence > watermark`; latest-value events (running/commands/pr/session) aren't replayed but are refetched on reconnect.
- **Connection indicator** + error→refetch resync fallback.
- Fragile message-merge and token logic extracted into pure, unit-tested helpers (`message-cache.ts`, `sse-resume.ts`).

## Commits
1. Pure helpers + tests (`sse-resume`, `message-cache`)
2. Server union + two subscriptions; client `useSessionStream` + trimmed hooks + indicator + live list
3. Docs (`DESIGN.md`, `architecture.d2`)

## Testing
- `pnpm test:run` — 476 passing (incl. new pure-function tests).
- `npx tsc --noEmit` clean. (`pnpm build` segfaults in Next's TS *worker thread* in this sandbox — environment crash, not a type error; `tsc` is authoritative.)
- ⚠️ Not yet manually verified in a running browser — recommend confirming: single `EventSource` per page in devtools, streaming partials settle into persisted messages, kill-server-mid-stream reconnect catches up with no dupes, and home list updates live across tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Claude