### PR TITLE
Make api_retry messages ephemeral live status, not transcript noise

### DIFF
--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -314,7 +314,7 @@ subscription, so the app is deliberately structured around just **two** streams:
 
 1. **Per-session multiplexed stream** — `sse.onSessionEvents({ sessionId })`. A single
    subscription yields a discriminated union of every event kind for the session
-   (`message`, `running`, `commands`, `pr`, `session`). The server folds the five
+   (`message`, `running`, `commands`, `pr`, `session`, `retry`). The server folds the six
    in-process emitter channels into this union via `sseEvents.onSessionEvents`
    ([`events.ts`](../src/server/services/events.ts)). On the client, `useSessionStream`
    ([`src/hooks/useSessionStream.ts`](../src/hooks/useSessionStream.ts)) is mounted once
@@ -365,11 +365,13 @@ Every message yielded by the SDK is routed through `classifyMessage(message)` in
 
 The SDK emits many `type: 'system'` subtypes. A single `type`-level switch can't distinguish them, so subtype handling is split into three buckets (none of which is compile-time exhaustive — unknown subtypes fall through to a safe default):
 
-1. **Ignored** (`IGNORED_SYSTEM_SUBTYPES` + any message flagged `skip_transcript`): pure progress ticks and internal state — `thinking_tokens`, `task_progress`, `task_updated`, `hook_progress`, `status`, `session_state_changed`, `files_persisted`, `elicitation_complete`, `commands_changed`. `classifyMessage` returns `skip`, so they are never persisted; `isIgnoredSystemMessage` also filters any persisted before a subtype was added (both at the list level in `MessageList` so they leave no empty spacer row, and as a guard in `MessageBubble`).
+1. **Ignored** (`IGNORED_SYSTEM_SUBTYPES` + any message flagged `skip_transcript`): pure progress ticks and internal state — `thinking_tokens`, `task_progress`, `task_updated`, `hook_progress`, `status`, `session_state_changed`, `files_persisted`, `elicitation_complete`, `commands_changed`, `api_retry`. `classifyMessage` returns `skip`, so they are never persisted; `isIgnoredSystemMessage` also filters any persisted before a subtype was added (both at the list level in `MessageList` so they leave no empty spacer row, and as a guard in `MessageBubble`).
 2. **Dedicated displays**: `init`, `compact_boundary`, `hook_started`, `hook_response`, and the app's synthetic `error` each have their own component.
-3. **Generic summary**: everything else (e.g. `notification`, `api_retry`, `permission_denied`, `model_refusal_fallback`, `plugin_install`, `memory_recall`, `mirror_error`, `task_started`, `task_notification`) renders through `SystemMessageDisplay`, which calls `summarizeSystemMessage` to produce a never-blank `{ label, body, level }`. Unknown/future subtypes degrade to a humanized label plus any string `content`, so a system message is never an empty bubble. `level: 'warn'` (retries, denials, errors) gets an amber treatment.
+3. **Generic summary**: everything else (e.g. `notification`, `permission_denied`, `model_refusal_fallback`, `plugin_install`, `memory_recall`, `mirror_error`, `task_started`, `task_notification`) renders through `SystemMessageDisplay`, which calls `summarizeSystemMessage` to produce a never-blank `{ label, body, level }`. Unknown/future subtypes degrade to a humanized label plus any string `content`, so a system message is never an empty bubble. `level: 'warn'` (retries, denials, errors) gets an amber treatment.
 
 Subagent (`Task` tool) lifecycle: `task_started` and `task_notification` are the meaningful bookends and are summarized; the high-frequency `task_progress` ticks and intermediate `task_updated` patches are ignored (their terminal outcome arrives via `task_notification`).
+
+**Ephemeral retry status.** `api_retry` messages (the SDK retrying a rate-limited/overloaded request) are ignored above so they never pollute the transcript, but the _current_ retry state is surfaced live. The runner parses each via `parseRetryState` ([`claude-messages.ts`](../src/lib/claude-messages.ts)), stores it on the in-memory session state, and emits it over the `retry` SSE channel as a latest-value event (`{ attempt, maxRetries, errorStatus?, error? } | null`). Any non-retry message clears it (the request recovered), as does turn end. The client reads it via `claude.getRetryState` (seeded once, updated by the stream, resynced on reconnect) and `ClaudeStatusIndicator` shows "Retrying (overloaded) — attempt n/10…" while it is set. Because it is in-memory only, a server restart loses it — acceptable for a transient indicator.
 
 ## Message Storage & Pagination
 

--- a/src/app/session/[id]/page.tsx
+++ b/src/app/session/[id]/page.tsx
@@ -56,6 +56,7 @@ function SessionView({ sessionId }: { sessionId: string }) {
   // Claude state: running, send, interrupt, commands
   const {
     isRunning: isClaudeRunning,
+    retry: claudeRetry,
     send: sendPrompt,
     interrupt,
     isInterrupting,
@@ -282,7 +283,11 @@ function SessionView({ sessionId }: { sessionId: string }) {
         ) : (
           <>
             <ConnectionStatusIndicator status={streamStatus} />
-            <ClaudeStatusIndicator isRunning={isClaudeRunning} containerStatus={session.status} />
+            <ClaudeStatusIndicator
+              isRunning={isClaudeRunning}
+              retry={claudeRetry}
+              containerStatus={session.status}
+            />
             <PromptInput
               onSubmit={handleSendPromptWithVoice}
               onInterrupt={interrupt}

--- a/src/components/ClaudeStatusIndicator.tsx
+++ b/src/components/ClaudeStatusIndicator.tsx
@@ -1,18 +1,11 @@
 import { Spinner } from '@/components/ui/spinner';
-import type { RetryState } from '@/lib/claude-messages';
+import { formatRetryReason, type RetryState } from '@/lib/claude-messages';
 
 interface ClaudeStatusIndicatorProps {
   isRunning: boolean;
   containerStatus: string;
   /** Ephemeral API-retry status (rate limit / overload), or null if not retrying. */
   retry?: RetryState | null;
-}
-
-/** Human-readable reason for an API retry, e.g. "rate limited" or "overloaded". */
-function retryReason(retry: RetryState): string | null {
-  if (retry.error === 'overloaded' || retry.errorStatus === 529) return 'overloaded';
-  if (retry.errorStatus === 429) return 'rate limited';
-  return retry.error ?? null;
 }
 
 export function ClaudeStatusIndicator({
@@ -28,7 +21,7 @@ export function ClaudeStatusIndicator({
   // A retry only happens mid-request, so it implies Claude is still working.
   // Surface the live attempt count instead of the generic "working" message.
   if (isRunning && retry) {
-    const reason = retryReason(retry);
+    const reason = formatRetryReason(retry);
     return (
       <div className="flex items-center justify-center gap-2 py-3 px-4 bg-amber-500/10 border-t text-sm text-amber-700 dark:text-amber-400">
         <Spinner size="sm" />

--- a/src/components/ClaudeStatusIndicator.tsx
+++ b/src/components/ClaudeStatusIndicator.tsx
@@ -1,14 +1,42 @@
 import { Spinner } from '@/components/ui/spinner';
+import type { RetryState } from '@/lib/claude-messages';
 
 interface ClaudeStatusIndicatorProps {
   isRunning: boolean;
   containerStatus: string;
+  /** Ephemeral API-retry status (rate limit / overload), or null if not retrying. */
+  retry?: RetryState | null;
 }
 
-export function ClaudeStatusIndicator({ isRunning, containerStatus }: ClaudeStatusIndicatorProps) {
+/** Human-readable reason for an API retry, e.g. "rate limited" or "overloaded". */
+function retryReason(retry: RetryState): string | null {
+  if (retry.error === 'overloaded' || retry.errorStatus === 529) return 'overloaded';
+  if (retry.errorStatus === 429) return 'rate limited';
+  return retry.error ?? null;
+}
+
+export function ClaudeStatusIndicator({
+  isRunning,
+  containerStatus,
+  retry,
+}: ClaudeStatusIndicatorProps) {
   // Don't show anything if the container isn't running
   if (containerStatus !== 'running') {
     return null;
+  }
+
+  // A retry only happens mid-request, so it implies Claude is still working.
+  // Surface the live attempt count instead of the generic "working" message.
+  if (isRunning && retry) {
+    const reason = retryReason(retry);
+    return (
+      <div className="flex items-center justify-center gap-2 py-3 px-4 bg-amber-500/10 border-t text-sm text-amber-700 dark:text-amber-400">
+        <Spinner size="sm" />
+        <span>
+          Retrying{reason ? ` (${reason})` : ''} — attempt {retry.attempt}/{retry.maxRetries}…
+        </span>
+      </div>
+    );
   }
 
   if (isRunning) {

--- a/src/components/messages/MessageBubble.test.tsx
+++ b/src/components/messages/MessageBubble.test.tsx
@@ -200,7 +200,7 @@ describe('MessageBubble', () => {
   });
 
   describe('ignored system messages', () => {
-    it.each(['thinking_tokens', 'task_progress', 'commands_changed'])(
+    it.each(['thinking_tokens', 'task_progress', 'commands_changed', 'api_retry'])(
       'renders nothing for %s system messages',
       (subtype) => {
         const message = {
@@ -263,24 +263,6 @@ describe('MessageBubble', () => {
 
       expect(screen.getByText('Notification')).toBeInTheDocument();
       expect(screen.getByText('Your token will expire soon')).toBeInTheDocument();
-    });
-
-    it('summarizes an api_retry with attempt count', () => {
-      const message = {
-        type: 'system',
-        content: {
-          type: 'system',
-          subtype: 'api_retry',
-          attempt: 2,
-          max_retries: 5,
-          error: { message: 'overloaded' },
-        } as MessageContent,
-      };
-
-      render(<MessageBubble message={message} />);
-
-      expect(screen.getByText('Retrying request')).toBeInTheDocument();
-      expect(screen.getByText('Attempt 2/5 — overloaded')).toBeInTheDocument();
     });
 
     it('falls back to a humanized label for unknown subtypes', () => {

--- a/src/components/messages/messageHelpers.test.ts
+++ b/src/components/messages/messageHelpers.test.ts
@@ -477,15 +477,6 @@ describe('summarizeSystemMessage', () => {
     });
   });
 
-  it('summarizes api_retry with attempt count and error code', () => {
-    // SDKAssistantMessageError is a string union (e.g. 'overloaded').
-    expect(sys({ subtype: 'api_retry', attempt: 3, max_retries: 5, error: 'overloaded' })).toEqual({
-      label: 'Retrying request',
-      body: 'Attempt 3/5 — overloaded',
-      level: 'warn',
-    });
-  });
-
   it('summarizes permission_denied with tool and message', () => {
     expect(
       sys({ subtype: 'permission_denied', tool_name: 'Bash', message: 'not allowed' })

--- a/src/components/messages/messageHelpers.ts
+++ b/src/components/messages/messageHelpers.ts
@@ -242,15 +242,6 @@ export function summarizeSystemMessage(content: MessageContent): SystemMessageSu
         level: priority === 'high' || priority === 'immediate' ? 'warn' : 'info',
       };
     }
-    case 'api_retry': {
-      const attempt = typeof content.attempt === 'number' ? content.attempt : undefined;
-      const max = typeof content.max_retries === 'number' ? content.max_retries : undefined;
-      const parts: string[] = [];
-      if (attempt !== undefined && max !== undefined) parts.push(`Attempt ${attempt}/${max}`);
-      const errMsg = extractErrorMessage(content.error);
-      if (errMsg) parts.push(errMsg);
-      return { label: 'Retrying request', body: parts.join(' — ') || undefined, level: 'warn' };
-    }
     case 'permission_denied': {
       const tool = asString(content.tool_name) ?? 'tool';
       const message = asString(content.message);

--- a/src/hooks/useClaudeState.ts
+++ b/src/hooks/useClaudeState.ts
@@ -15,11 +15,17 @@ export function useClaudeState(sessionId: string) {
     { staleTime: Infinity }
   );
 
+  // Fetch ephemeral API-retry status (rate limit / overload)
+  const { data: retryData, refetch: refetchRetry } = trpc.claude.getRetryState.useQuery({
+    sessionId,
+  });
+
   // Refetch when app regains visibility or network reconnects
   const refetchAll = useCallback(() => {
     refetch();
     refetchCommands();
-  }, [refetch, refetchCommands]);
+    refetchRetry();
+  }, [refetch, refetchCommands, refetchRetry]);
   useRefetchOnReconnect(refetchAll);
 
   // Live running-state and command updates arrive via the multiplexed SSE stream
@@ -57,9 +63,11 @@ export function useClaudeState(sessionId: string) {
 
   const isRunning = runningData?.running ?? false;
   const commands = commandsData?.commands ?? [];
+  const retry = retryData?.retry ?? null;
 
   return {
     isRunning,
+    retry,
     send,
     interrupt,
     isInterrupting: interruptMutation.isPending,

--- a/src/hooks/useClaudeState.ts
+++ b/src/hooks/useClaudeState.ts
@@ -15,10 +15,13 @@ export function useClaudeState(sessionId: string) {
     { staleTime: Infinity }
   );
 
-  // Fetch ephemeral API-retry status (rate limit / overload)
-  const { data: retryData, refetch: refetchRetry } = trpc.claude.getRetryState.useQuery({
-    sessionId,
-  });
+  // Fetch ephemeral API-retry status (rate limit / overload). Seeded once and
+  // then kept current by the SSE `retry` channel, so staleTime is Infinity to
+  // stop a window-focus refetch from clobbering the live value with a stale read.
+  const { data: retryData, refetch: refetchRetry } = trpc.claude.getRetryState.useQuery(
+    { sessionId },
+    { staleTime: Infinity }
+  );
 
   // Refetch when app regains visibility or network reconnects
   const refetchAll = useCallback(() => {

--- a/src/hooks/useSessionStream.ts
+++ b/src/hooks/useSessionStream.ts
@@ -63,6 +63,7 @@ export function useSessionStream(sessionId: string, options: UseSessionStreamOpt
     void utils.claude.getCommands.refetch({ sessionId });
     void utils.sessions.get.refetch({ sessionId });
     void utils.claude.getTokenUsage.refetch({ sessionId });
+    void utils.claude.getRetryState.refetch({ sessionId });
   }, [utils, sessionId]);
 
   const subscription = trpc.sse.onSessionEvents.useSubscription(
@@ -107,6 +108,10 @@ export function useSessionStream(sessionId: string, options: UseSessionStreamOpt
               { sessionId },
               { session: event.session as SessionGetOutput['session'] }
             );
+            break;
+          }
+          case 'retry': {
+            utils.claude.getRetryState.setData({ sessionId }, { retry: event.retry });
             break;
           }
           default:

--- a/src/lib/claude-messages.test.ts
+++ b/src/lib/claude-messages.test.ts
@@ -22,6 +22,7 @@ import {
   SystemMessage,
   ResultMessage,
   RawMessage,
+  parseRetryState,
 } from './claude-messages';
 
 describe('claude-messages', () => {
@@ -679,6 +680,7 @@ describe('claude-messages', () => {
         'files_persisted',
         'elicitation_complete',
         'commands_changed',
+        'api_retry',
       ]) {
         expect(msg({ type: 'system', subtype })).toEqual({ kind: 'skip' });
       }
@@ -691,12 +693,7 @@ describe('claude-messages', () => {
     });
 
     it('persists summarized system subtypes', () => {
-      for (const subtype of [
-        'notification',
-        'api_retry',
-        'permission_denied',
-        'task_notification',
-      ]) {
+      for (const subtype of ['notification', 'permission_denied', 'task_notification']) {
         expect(msg({ type: 'system', subtype })).toEqual({ kind: 'persist', dbType: 'system' });
       }
     });
@@ -735,6 +732,38 @@ describe('claude-messages', () => {
       expect(isIgnoredSystemMessage(null)).toBe(false);
       expect(isIgnoredSystemMessage(undefined)).toBe(false);
       expect(isIgnoredSystemMessage('thinking_tokens')).toBe(false);
+    });
+  });
+
+  describe('parseRetryState', () => {
+    it('extracts retry state from an api_retry message', () => {
+      expect(
+        parseRetryState({
+          type: 'system',
+          subtype: 'api_retry',
+          attempt: 2,
+          max_retries: 10,
+          retry_delay_ms: 1184.18,
+          error_status: 529,
+          error: 'overloaded',
+          session_id: 'sess',
+          uuid: 'u1',
+        })
+      ).toEqual({ attempt: 2, maxRetries: 10, errorStatus: 529, error: 'overloaded' });
+    });
+
+    it('omits optional fields when absent', () => {
+      expect(
+        parseRetryState({ type: 'system', subtype: 'api_retry', attempt: 1, max_retries: 5 })
+      ).toEqual({ attempt: 1, maxRetries: 5, errorStatus: undefined, error: undefined });
+    });
+
+    it('returns null for non-retry messages', () => {
+      expect(parseRetryState({ type: 'system', subtype: 'notification' })).toBeNull();
+      expect(parseRetryState({ type: 'assistant' })).toBeNull();
+      expect(parseRetryState(null)).toBeNull();
+      // Missing required attempt/max_retries fields.
+      expect(parseRetryState({ type: 'system', subtype: 'api_retry' })).toBeNull();
     });
   });
 

--- a/src/lib/claude-messages.test.ts
+++ b/src/lib/claude-messages.test.ts
@@ -23,6 +23,7 @@ import {
   ResultMessage,
   RawMessage,
   parseRetryState,
+  formatRetryReason,
 } from './claude-messages';
 
 describe('claude-messages', () => {
@@ -758,12 +759,61 @@ describe('claude-messages', () => {
       ).toEqual({ attempt: 1, maxRetries: 5, errorStatus: undefined, error: undefined });
     });
 
+    it('accepts a null error_status (connection error / timeout) as undefined', () => {
+      // The SDK sends error_status: null for connection errors with no HTTP
+      // response; this must parse rather than failing the whole object.
+      expect(
+        parseRetryState({
+          type: 'system',
+          subtype: 'api_retry',
+          attempt: 4,
+          max_retries: 10,
+          error_status: null,
+          error: 'unknown',
+        })
+      ).toEqual({ attempt: 4, maxRetries: 10, errorStatus: undefined, error: 'unknown' });
+    });
+
     it('returns null for non-retry messages', () => {
       expect(parseRetryState({ type: 'system', subtype: 'notification' })).toBeNull();
       expect(parseRetryState({ type: 'assistant' })).toBeNull();
       expect(parseRetryState(null)).toBeNull();
       // Missing required attempt/max_retries fields.
       expect(parseRetryState({ type: 'system', subtype: 'api_retry' })).toBeNull();
+    });
+  });
+
+  describe('formatRetryReason', () => {
+    it('maps canonical SDK error codes to friendly labels', () => {
+      expect(formatRetryReason({ attempt: 1, maxRetries: 10, error: 'overloaded' })).toBe(
+        'overloaded'
+      );
+      expect(formatRetryReason({ attempt: 1, maxRetries: 10, error: 'rate_limit' })).toBe(
+        'rate limited'
+      );
+      expect(formatRetryReason({ attempt: 1, maxRetries: 10, error: 'server_error' })).toBe(
+        'server error'
+      );
+    });
+
+    it('falls back to HTTP status when no error code matches', () => {
+      expect(formatRetryReason({ attempt: 1, maxRetries: 10, errorStatus: 529 })).toBe(
+        'overloaded'
+      );
+      expect(formatRetryReason({ attempt: 1, maxRetries: 10, errorStatus: 429 })).toBe(
+        'rate limited'
+      );
+    });
+
+    it('humanizes other known error codes', () => {
+      expect(formatRetryReason({ attempt: 1, maxRetries: 10, error: 'model_not_found' })).toBe(
+        'model not found'
+      );
+    });
+
+    it('returns null when nothing is known', () => {
+      expect(formatRetryReason({ attempt: 1, maxRetries: 10 })).toBeNull();
+      expect(formatRetryReason({ attempt: 1, maxRetries: 10, error: 'unknown' })).toBeNull();
     });
   });
 

--- a/src/lib/claude-messages.ts
+++ b/src/lib/claude-messages.ts
@@ -837,6 +837,10 @@ export type MessageHandling =
  * - `status`, `session_state_changed`: transient session/run state.
  * - `files_persisted`, `elicitation_complete`: internal bookkeeping events.
  * - `commands_changed`: slash-command list updates (not chat content).
+ * - `api_retry`: transient "retrying due to rate limit / overload" ticks. The
+ *   live attempt count is surfaced ephemerally via the `retry` SSE channel (see
+ *   {@link parseRetryState}); persisting each one would pollute the transcript
+ *   with notices that carry no value once the request recovers.
  *
  * Without this filter each would render as an empty "System" bubble.
  */
@@ -850,7 +854,53 @@ export const IGNORED_SYSTEM_SUBTYPES = [
   'files_persisted',
   'elicitation_complete',
   'commands_changed',
+  'api_retry',
 ] as const;
+
+/**
+ * An `api_retry` system message: the SDK is retrying a failed API request
+ * (typically a 429 rate limit or 529 overload). These are not persisted — the
+ * latest attempt count is streamed live as ephemeral status (see
+ * {@link parseRetryState}).
+ */
+export const ApiRetryContentSchema = z.object({
+  type: z.literal('system'),
+  subtype: z.literal('api_retry'),
+  attempt: z.number(),
+  max_retries: z.number(),
+  error_status: z.number().optional(),
+  error: z.string().optional(),
+});
+
+/**
+ * Ephemeral "Claude is retrying" status surfaced over the `retry` SSE channel.
+ * `null` means no retry is in progress (the request recovered or the turn ended).
+ */
+export interface RetryState {
+  /** 1-based attempt number for the in-flight retry. */
+  attempt: number;
+  /** Maximum attempts the SDK will make before giving up. */
+  maxRetries: number;
+  /** HTTP status that triggered the retry (e.g. 429, 529), if known. */
+  errorStatus?: number;
+  /** Short error code from the API (e.g. "overloaded"), if known. */
+  error?: string;
+}
+
+/**
+ * Extract {@link RetryState} from an SDK message, or `null` if it is not an
+ * `api_retry` message.
+ */
+export function parseRetryState(message: unknown): RetryState | null {
+  const parsed = ApiRetryContentSchema.safeParse(message);
+  if (!parsed.success) return null;
+  return {
+    attempt: parsed.data.attempt,
+    maxRetries: parsed.data.max_retries,
+    errorStatus: parsed.data.error_status,
+    error: parsed.data.error,
+  };
+}
 
 /**
  * Whether a system message should be dropped entirely (never persisted or shown).

--- a/src/lib/claude-messages.ts
+++ b/src/lib/claude-messages.ts
@@ -868,7 +868,11 @@ export const ApiRetryContentSchema = z.object({
   subtype: z.literal('api_retry'),
   attempt: z.number(),
   max_retries: z.number(),
-  error_status: z.number().optional(),
+  // The SDK sends `null` (not absent) for connection errors like timeouts that
+  // had no HTTP response, so this must accept null — not just undefined — or the
+  // whole parse fails and the retry indicator never shows for those.
+  error_status: z.number().nullable().optional(),
+  // A `SDKAssistantMessageError` code, e.g. "rate_limit" | "overloaded" | "server_error".
   error: z.string().optional(),
 });
 
@@ -892,14 +896,48 @@ export interface RetryState {
  * `api_retry` message.
  */
 export function parseRetryState(message: unknown): RetryState | null {
+  // Cheap subtype guard before the full Zod parse: this runs on every message in
+  // the streaming loop (including high-frequency token deltas), and only
+  // `api_retry` frames can ever match.
+  if (
+    typeof message !== 'object' ||
+    message === null ||
+    (message as { subtype?: unknown }).subtype !== 'api_retry'
+  ) {
+    return null;
+  }
   const parsed = ApiRetryContentSchema.safeParse(message);
   if (!parsed.success) return null;
   return {
     attempt: parsed.data.attempt,
     maxRetries: parsed.data.max_retries,
-    errorStatus: parsed.data.error_status,
+    // Collapse the SDK's null (connection error, no HTTP response) to undefined.
+    errorStatus: parsed.data.error_status ?? undefined,
     error: parsed.data.error,
   };
+}
+
+/** Friendly labels for the API error codes that actually trigger retries. */
+const RETRY_REASON_LABELS: Record<string, string> = {
+  overloaded: 'overloaded',
+  rate_limit: 'rate limited',
+  server_error: 'server error',
+};
+
+/**
+ * Human-readable reason for an in-flight retry (e.g. "overloaded", "rate
+ * limited"), or `null` if none can be determined. Prefers the SDK's canonical
+ * `error` code, falling back to the HTTP status, then a humanized code.
+ */
+export function formatRetryReason(retry: RetryState): string | null {
+  if (retry.error && RETRY_REASON_LABELS[retry.error]) {
+    return RETRY_REASON_LABELS[retry.error];
+  }
+  if (retry.errorStatus === 529) return 'overloaded';
+  if (retry.errorStatus === 429) return 'rate limited';
+  // Humanize any other known code (e.g. "model_not_found" → "model not found").
+  if (retry.error && retry.error !== 'unknown') return retry.error.replace(/_/g, ' ');
+  return null;
 }
 
 /**

--- a/src/server/routers/claude.ts
+++ b/src/server/routers/claude.ts
@@ -10,6 +10,7 @@ import {
   submitLiveToolResponse,
   persistSyntheticToolResult,
   getSessionCommands,
+  getSessionRetry,
 } from '../services/claude-runner';
 import { loadMergedSessionSettings } from '../services/settings-merger';
 import { getSessionWorkingDir } from '../services/worktree-manager';
@@ -339,5 +340,14 @@ export const claudeRouter = router({
     .input(z.object({ sessionId: z.string().uuid() }))
     .query(async ({ input }) => {
       return { commands: getSessionCommands(input.sessionId) };
+    }),
+
+  // Ephemeral API-retry status (rate limit / overload). Updates stream live over
+  // the `retry` SSE channel; this query seeds the initial value and resyncs on
+  // reconnect.
+  getRetryState: protectedProcedure
+    .input(z.object({ sessionId: z.string().uuid() }))
+    .query(async ({ input }) => {
+      return { retry: getSessionRetry(input.sessionId) };
     }),
 });

--- a/src/server/services/claude-runner.ts
+++ b/src/server/services/claude-runner.ts
@@ -733,9 +733,12 @@ export async function runClaudeCommand(options: RunClaudeCommandOptions): Promis
     sessions.delete(sessionId);
 
     sseEvents.emitClaudeRunning(sessionId, false);
-    // The retry status is tied to an in-flight request; clear it when the turn
-    // ends so a stale "retrying" indicator never lingers.
-    sseEvents.emitClaudeRetry(sessionId, null);
+    // The retry status is tied to an in-flight request; if it was still set when
+    // the turn ended (e.g. the SDK gave up), clear it so no stale "retrying"
+    // indicator lingers. Skip the emit for the common turn that never retried.
+    if (state.retry) {
+      sseEvents.emitClaudeRetry(sessionId, null);
+    }
 
     // Detect branch changes and check for PR updates (fire-and-forget)
     void (async () => {

--- a/src/server/services/claude-runner.ts
+++ b/src/server/services/claude-runner.ts
@@ -19,7 +19,12 @@ import {
   type PermissionResult,
 } from '@anthropic-ai/claude-agent-sdk';
 import { prisma } from '@/lib/prisma';
-import { classifyMessage, SystemInitContentSchema } from '@/lib/claude-messages';
+import {
+  classifyMessage,
+  parseRetryState,
+  SystemInitContentSchema,
+  type RetryState,
+} from '@/lib/claude-messages';
 import { type ToolResponse, buildSyntheticToolResultContent } from '@/lib/tool-response';
 import { extractRepoFullName } from '@/lib/utils';
 import { v4 as uuid, v5 as uuidv5 } from 'uuid';
@@ -118,6 +123,8 @@ interface SessionState {
   workingDir: string;
   /** Discovered slash commands (cached for getCommands endpoint) */
   commands: SlashCommand[];
+  /** Current API-retry status (rate limit / overload), or null if not retrying */
+  retry: RetryState | null;
 }
 
 /** Active sessions tracked in memory */
@@ -229,6 +236,7 @@ function getSessionState(sessionId: string, workingDir: string): SessionState {
       pendingInput: null,
       workingDir,
       commands: persistedCommands.get(sessionId) ?? [],
+      retry: null,
     };
     sessions.set(sessionId, state);
   }
@@ -601,6 +609,19 @@ export async function runClaudeCommand(options: RunClaudeCommandOptions): Promis
       });
 
     for await (const message of q) {
+      // Surface API-retry status ephemerally: an `api_retry` message sets the
+      // live retry state; any other message means the request recovered (or the
+      // run moved on), so clear it. These messages are never persisted (see
+      // IGNORED_SYSTEM_SUBTYPES) — only the latest attempt count is streamed.
+      const retryState = parseRetryState(message);
+      if (retryState) {
+        state.retry = retryState;
+        sseEvents.emitClaudeRetry(sessionId, retryState);
+      } else if (state.retry) {
+        state.retry = null;
+        sseEvents.emitClaudeRetry(sessionId, null);
+      }
+
       // Extract slash_commands from system init messages and merge with
       // rich commands from supportedCommands(). The SDK's supportedCommands()
       // only returns "skills", but the system init message contains all
@@ -712,6 +733,9 @@ export async function runClaudeCommand(options: RunClaudeCommandOptions): Promis
     sessions.delete(sessionId);
 
     sseEvents.emitClaudeRunning(sessionId, false);
+    // The retry status is tied to an in-flight request; clear it when the turn
+    // ends so a stale "retrying" indicator never lingers.
+    sseEvents.emitClaudeRetry(sessionId, null);
 
     // Detect branch changes and check for PR updates (fire-and-forget)
     void (async () => {
@@ -870,6 +894,15 @@ export async function persistSyntheticToolResult(
  */
 export function getSessionCommands(sessionId: string): SlashCommand[] {
   return persistedCommands.get(sessionId) ?? sessions.get(sessionId)?.commands ?? [];
+}
+
+/**
+ * Current API-retry status for a session, or null if not retrying. Lives only in
+ * memory for the duration of a query — there is no persisted state to read once
+ * the run ends.
+ */
+export function getSessionRetry(sessionId: string): RetryState | null {
+  return sessions.get(sessionId)?.retry ?? null;
 }
 
 /**

--- a/src/server/services/events.ts
+++ b/src/server/services/events.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'events';
 import type { Message, Session } from '@prisma/client';
 import type { SlashCommand } from '@anthropic-ai/claude-agent-sdk';
 import type { PullRequestInfo } from './github';
+import type { RetryState } from '@/lib/claude-messages';
 
 // Message with parsed content (for SSE events)
 export type ParsedMessage = Omit<Message, 'content'> & { content: unknown };
@@ -37,12 +38,19 @@ export interface PrUpdateEvent {
   pullRequest: PullRequestInfo | null;
 }
 
+export interface ClaudeRetryEvent {
+  type: 'claude_retry';
+  sessionId: string;
+  retry: RetryState | null;
+}
+
 export type SSEEvent =
   | SessionUpdateEvent
   | MessageEvent
   | ClaudeRunningEvent
   | CommandsEvent
-  | PrUpdateEvent;
+  | PrUpdateEvent
+  | ClaudeRetryEvent;
 
 /**
  * Normalized union delivered over the single multiplexed per-session SSE stream.
@@ -55,7 +63,8 @@ export type SessionStreamEvent =
   | { kind: 'running'; running: boolean }
   | { kind: 'commands'; commands: SlashCommand[] }
   | { kind: 'pr'; pullRequest: PullRequestInfo | null }
-  | { kind: 'session'; session: Session };
+  | { kind: 'session'; session: Session }
+  | { kind: 'retry'; retry: RetryState | null };
 
 // Global channel name for cross-session list updates (not session-scoped).
 const SESSION_LIST_EVENT = 'session-list';
@@ -143,6 +152,20 @@ class SSEEventEmitter extends EventEmitter {
     return () => this.off(eventName, callback);
   }
 
+  emitClaudeRetry(sessionId: string, retry: RetryState | null): void {
+    this.emit(`retry:${sessionId}`, {
+      type: 'claude_retry',
+      sessionId,
+      retry,
+    } satisfies ClaudeRetryEvent);
+  }
+
+  onClaudeRetry(sessionId: string, callback: (event: ClaudeRetryEvent) => void): () => void {
+    const eventName = `retry:${sessionId}`;
+    this.on(eventName, callback);
+    return () => this.off(eventName, callback);
+  }
+
   /**
    * Subscribe to all event kinds for a session as a single normalized stream.
    * Returns one unsubscribe that detaches every underlying channel listener.
@@ -154,6 +177,7 @@ class SSEEventEmitter extends EventEmitter {
       this.onCommands(sessionId, (e) => callback({ kind: 'commands', commands: e.commands })),
       this.onPrUpdate(sessionId, (e) => callback({ kind: 'pr', pullRequest: e.pullRequest })),
       this.onSessionUpdate(sessionId, (e) => callback({ kind: 'session', session: e.session })),
+      this.onClaudeRetry(sessionId, (e) => callback({ kind: 'retry', retry: e.retry })),
     ];
     return () => unsubscribes.forEach((unsubscribe) => unsubscribe());
   }


### PR DESCRIPTION
## Summary

`api_retry` system messages — emitted when the SDK retries a rate-limited/overloaded API request — were being persisted and rendered as transcript bubbles. They pollute the conversation history with notices that carry no value once the request recovers.

This makes them **ephemeral**, mirroring how no-content thinking-token ticks are already handled: dropped from history, but the *current* retry state is surfaced live so the UI can show "Retrying (overloaded) — attempt n/10…".

## Changes

- **Drop from transcript**: add `api_retry` to `IGNORED_SYSTEM_SUBTYPES` so `classifyMessage` returns `skip` (never persisted, and any pre-existing rows are filtered by `isIgnoredSystemMessage`). Removed the now-dead `summarizeSystemMessage` case.
- **Live status**: new `retry` latest-value SSE channel (like `running`/`commands`). The runner parses each message via `parseRetryState`, stores it on in-memory session state, emits it, and clears it on recovery (any non-retry message) or turn end.
- **API + client**: `claude.getRetryState` query (seeded once, updated by the stream, resynced on reconnect); `useClaudeState` exposes `retry`; `ClaudeStatusIndicator` renders the amber "Retrying…" indicator with the attempt count.
- Updated `doc/DESIGN.md` (SSE event kinds, System Message Subtypes) and tests.

Because the retry state is in-memory only, a server restart loses it — acceptable for a transient indicator.

## Testing

- `pnpm tsc --noEmit` — clean
- `pnpm test:run` — 478 passed
- Added `parseRetryState` unit tests; updated classification/display tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)