### PR TITLE
Add global advisor-model setting (defaults to claude-fable-5)

### DIFF
--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -45,7 +45,7 @@ The database schema is defined in [`prisma/schema.prisma`](../prisma/schema.pris
 - **Session**: Claude Code sessions tied to git clones or standalone workspaces. `repoUrl` and `branch` are nullable — when null, the session has no repository (workspace-only).
 - **Message**: Chat messages with sequence numbers for cursor-based pagination
 - **AuthSession**: Login sessions with tokens and audit info
-- **GlobalSettings**: Global application settings (system prompt override and append, Claude model, Claude API key, TTS speed, voice auto-send)
+- **GlobalSettings**: Global application settings (system prompt override and append, Claude model, advisor model, Claude API key, TTS speed, voice auto-send)
 - **RepoSettings**: Per-repository settings (favorites, custom system prompt, Claude model override)
 - **EnvVar**: Environment variables for a repository or global (encrypted if secret). When `repoSettingsId` is null, the variable is global and applies to all sessions.
 - **McpServer**: MCP server configurations for a repository or global. When `repoSettingsId` is null, the server is global and applies to all sessions.
@@ -507,6 +507,7 @@ Users can configure per-repository settings that are automatically applied when 
 Users can configure global settings that apply to all sessions:
 
 - **Claude Model**: Override the `CLAUDE_MODEL` environment variable. Free-text field accepting model names like `opus`, `sonnet`, or full IDs like `claude-opus-4-6`. A per-repo model override (if set) takes precedence over this; otherwise this is used, falling back to the env var default when neither is set. Resolution order is `repo model → global model → CLAUDE_MODEL env var` (see `resolveClaudeModel` in `settings-merger.ts`).
+- **Advisor Model**: The model used by the server-side advisor tool (which Claude can consult for a second opinion mid-session). Uses the same free-text model selector as Claude Model. This is a global-only setting with **no env-var or per-repo layer**: the effective value is `global advisor model → DEFAULT_ADVISOR_MODEL` (`claude-fable-5`), resolved by `resolveAdvisorModel` in `settings-merger.ts`. Because the value always resolves, the advisor tool is **always enabled** — clearing the override reverts to the Fable 5 default rather than turning it off. The advisor model is a settings-schema field with no dedicated SDK option, so it is passed to the Claude Agent SDK as an ad-hoc `--settings` source via `Options.extraArgs` (`{ advisorModel }`); see `buildSdkOptions` in `claude-runner.ts`.
 - **Claude API Key**: Override the `CLAUDE_CODE_OAUTH_TOKEN` environment variable. Stored encrypted at rest. The actual value is never exposed to the UI — only a "configured" status is shown. Falls back to the env var when not set.
 - **System Prompt Override**: Replace the default system prompt with a custom one. When editing, the field is pre-populated with the current default prompt. The override can be toggled on/off without losing the custom content.
 - **Global System Prompt Append**: Additional content appended to the base prompt (default or override) for all sessions. This is applied before any per-repo custom prompts.
@@ -527,7 +528,7 @@ Users can configure global settings that apply to all sessions:
 - **MCP Servers**: Global MCP servers are included in all sessions. If a per-repo MCP server has the same name as a global one, the per-repo configuration takes precedence.
 - **Claude Model**: Resolved in precedence order `per-repo model → global model → CLAUDE_MODEL env var`.
 
-**Live vs. restart-bound settings.** Because a session's query is long-lived, settings are bound when the query is established. **Model and MCP servers** are re-applied live on the next `send` when they differ from what the query was built with (`query.setModel` / `query.setMcpServers`, gated by `mcpServersEqual`). **Environment variables and the system prompt** are bound at construction and only take effect after a Stop→Start (which rebuilds the query with fresh settings).
+**Live vs. restart-bound settings.** Because a session's query is long-lived, settings are bound when the query is established. **Model and MCP servers** are re-applied live on the next `send` when they differ from what the query was built with (`query.setModel` / `query.setMcpServers`, gated by `mcpServersEqual`). **Environment variables, the system prompt, and the advisor model** are bound at construction and only take effect after a Stop→Start (which rebuilds the query with fresh settings) — the SDK exposes no live setter for the advisor model.
 
 **Configuration**: Go to Settings → System Prompt to manage prompt and model settings. Go to Settings → Audio to manage voice/audio settings (TTS speed, voice auto-send).
 

--- a/prisma/migrations/20260701000000_add_advisor_model_to_global_settings/migration.sql
+++ b/prisma/migrations/20260701000000_add_advisor_model_to_global_settings/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "GlobalSettings" ADD COLUMN "advisorModel" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -114,6 +114,7 @@ model GlobalSettings {
   systemPromptOverrideEnabled Boolean @default(false) // Whether to use the override
   systemPromptAppend        String?  // Additional content appended after default/override prompt
   claudeModel               String?  // If set, overrides CLAUDE_MODEL env var
+  advisorModel              String?  // Model for the server-side advisor tool. Falls back to DEFAULT_ADVISOR_MODEL when null.
   claudeApiKey              String?  // If set (encrypted), overrides CLAUDE_CODE_OAUTH_TOKEN env var
   ttsSpeed                  Float?   // TTS playback speed (0.25-4.0, default 1.0)
   voiceAutoSend             Boolean  @default(true) // Auto-send after speech-to-text transcription

--- a/src/components/settings/SystemPromptTab.tsx
+++ b/src/components/settings/SystemPromptTab.tsx
@@ -47,6 +47,24 @@ export function SystemPromptTab() {
 
       <Card>
         <CardHeader>
+          <CardTitle>Advisor Model</CardTitle>
+          <CardDescription>
+            The model used by the server-side advisor tool, which Claude can consult for a second
+            opinion during a session. Enabled for all sessions; takes effect after a session is
+            stopped and restarted.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <AdvisorModelSection
+            currentModel={settings?.advisorModel ?? null}
+            defaultModel={settings?.defaultAdvisorModel ?? 'claude-fable-5'}
+            onUpdate={refetch}
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
           <CardTitle>Claude API Key</CardTitle>
           <CardDescription>
             OAuth token for Claude Code authentication. Overrides the CLAUDE_CODE_OAUTH_TOKEN
@@ -345,6 +363,36 @@ function ClaudeModelSection({
       onSave={(claudeModel, onSuccess) => {
         setError(null);
         mutation.mutate({ claudeModel }, { onSuccess });
+      }}
+      isPending={mutation.isPending}
+      error={error}
+    />
+  );
+}
+
+function AdvisorModelSection({
+  currentModel,
+  defaultModel,
+  onUpdate,
+}: {
+  currentModel: string | null;
+  defaultModel: string;
+  onUpdate: () => void;
+}) {
+  const [error, setError] = useState<string | null>(null);
+
+  const mutation = trpc.globalSettings.setAdvisorModel.useMutation({
+    onSuccess: () => onUpdate(),
+    onError: (err) => setError(err.message),
+  });
+
+  return (
+    <ModelOverrideField
+      currentModel={currentModel}
+      defaultModel={defaultModel}
+      onSave={(advisorModel, onSuccess) => {
+        setError(null);
+        mutation.mutate({ advisorModel }, { onSuccess });
       }}
       isPending={mutation.isPending}
       error={error}

--- a/src/server/routers/globalSettings.integration.test.ts
+++ b/src/server/routers/globalSettings.integration.test.ts
@@ -53,10 +53,12 @@ describe('globalSettings router', () => {
         systemPromptOverrideEnabled: false,
         systemPromptAppend: null,
         claudeModel: null,
+        advisorModel: null,
         hasClaudeApiKey: false,
         ttsSpeed: null,
         voiceAutoSend: true,
         defaultClaudeModel: 'opus[1m]',
+        defaultAdvisorModel: 'claude-fable-5',
         hasEnvApiKey: true,
       });
     });
@@ -271,6 +273,45 @@ describe('globalSettings router', () => {
 
       const result = await caller.globalSettings.get();
       expect(result.claudeModel).toBe('opus');
+    });
+  });
+
+  describe('setAdvisorModel', () => {
+    it('should set the advisor model', async () => {
+      const caller = createCaller();
+
+      await caller.globalSettings.setAdvisorModel({ advisorModel: 'claude-opus-4-8' });
+
+      const result = await caller.globalSettings.get();
+      expect(result.advisorModel).toBe('claude-opus-4-8');
+    });
+
+    it('should default to null (resolved to claude-fable-5) when unset', async () => {
+      const caller = createCaller();
+
+      const result = await caller.globalSettings.get();
+      expect(result.advisorModel).toBeNull();
+      expect(result.defaultAdvisorModel).toBe('claude-fable-5');
+    });
+
+    it('should clear the model when set to null', async () => {
+      const caller = createCaller();
+
+      await caller.globalSettings.setAdvisorModel({ advisorModel: 'claude-opus-4-8' });
+      await caller.globalSettings.setAdvisorModel({ advisorModel: null });
+
+      const result = await caller.globalSettings.get();
+      expect(result.advisorModel).toBeNull();
+    });
+
+    it('should trim whitespace and treat blank as cleared', async () => {
+      const caller = createCaller();
+
+      await caller.globalSettings.setAdvisorModel({ advisorModel: '  claude-sonnet-4-6  ' });
+      expect((await caller.globalSettings.get()).advisorModel).toBe('claude-sonnet-4-6');
+
+      await caller.globalSettings.setAdvisorModel({ advisorModel: '  ' });
+      expect((await caller.globalSettings.get()).advisorModel).toBeNull();
     });
   });
 

--- a/src/server/routers/globalSettings.ts
+++ b/src/server/routers/globalSettings.ts
@@ -20,6 +20,7 @@ import {
 } from '../services/settings-helpers';
 import { validateMcpServer } from '../services/mcp-validator';
 import { getModelSuggestions } from '../services/anthropic-models';
+import { DEFAULT_ADVISOR_MODEL } from '../services/settings-merger';
 
 const log = createLogger('globalSettings');
 
@@ -60,10 +61,12 @@ export const globalSettingsRouter = router({
       systemPromptOverrideEnabled: settings?.systemPromptOverrideEnabled ?? false,
       systemPromptAppend: settings?.systemPromptAppend ?? null,
       claudeModel: settings?.claudeModel ?? null,
+      advisorModel: settings?.advisorModel ?? null,
       hasClaudeApiKey: settings?.claudeApiKey !== null && settings?.claudeApiKey !== undefined,
       ttsSpeed: settings?.ttsSpeed ?? null,
       voiceAutoSend: settings?.voiceAutoSend ?? true,
       defaultClaudeModel: env.CLAUDE_MODEL,
+      defaultAdvisorModel: DEFAULT_ADVISOR_MODEL,
       hasEnvApiKey: !!env.CLAUDE_CODE_OAUTH_TOKEN,
     };
   }),
@@ -367,6 +370,30 @@ export const globalSettingsRouter = router({
       });
 
       log.info('Set Claude model', { claudeModel: model });
+
+      return { success: true };
+    }),
+
+  /**
+   * Set the advisor model (server-side advisor tool).
+   * Pass null or empty string to clear (reverts to DEFAULT_ADVISOR_MODEL).
+   */
+  setAdvisorModel: protectedProcedure
+    .input(
+      z.object({
+        advisorModel: z.string().max(200).nullable(),
+      })
+    )
+    .mutation(async ({ input }) => {
+      const model = input.advisorModel?.trim() || null;
+
+      await prisma.globalSettings.upsert({
+        where: { id: GLOBAL_SETTINGS_ID },
+        create: { id: GLOBAL_SETTINGS_ID, advisorModel: model },
+        update: { advisorModel: model },
+      });
+
+      log.info('Set advisor model', { advisorModel: model });
 
       return { success: true };
     }),

--- a/src/server/services/claude-runner.integration.test.ts
+++ b/src/server/services/claude-runner.integration.test.ts
@@ -39,6 +39,7 @@ const baseSettings = {
   envVars: [],
   mcpServers: [],
   claudeModel: undefined as string | undefined,
+  advisorModel: 'claude-fable-5',
   claudeApiKey: undefined,
   customSystemPrompt: null,
   globalSettings: {
@@ -46,6 +47,7 @@ const baseSettings = {
     systemPromptOverrideEnabled: false,
     systemPromptAppend: null,
     claudeModel: null,
+    advisorModel: null,
     claudeApiKey: null,
     envVars: [],
     mcpServers: [],

--- a/src/server/services/claude-runner.ts
+++ b/src/server/services/claude-runner.ts
@@ -472,6 +472,16 @@ async function buildSdkOptions(params: {
     options.mcpServers = mcpServersRecord;
   }
 
+  // The advisor model is a settings-schema field (no dedicated SDK option), so
+  // inject it as an ad-hoc `--settings` source. This enables the server-side
+  // advisor tool for the session using the resolved model. Like env vars and the
+  // system prompt, it is bound at query construction — a change takes effect on
+  // the next Stop→Start, not live mid-session.
+  options.extraArgs = {
+    ...options.extraArgs,
+    settings: JSON.stringify({ advisorModel: settings.advisorModel }),
+  };
+
   return options;
 }
 

--- a/src/server/services/global-settings.ts
+++ b/src/server/services/global-settings.ts
@@ -14,6 +14,7 @@ export interface GlobalDisplaySettings {
   systemPromptOverrideEnabled: boolean;
   systemPromptAppend: string | null;
   claudeModel: string | null;
+  advisorModel: string | null;
   hasClaudeApiKey: boolean;
   ttsSpeed: number | null;
   voiceAutoSend: boolean;
@@ -33,6 +34,7 @@ export interface GlobalSystemPromptSettings {
  */
 export interface GlobalContainerSettings extends GlobalSystemPromptSettings {
   claudeModel: string | null;
+  advisorModel: string | null;
   claudeApiKey: string | null;
   envVars: ContainerEnvVar[];
   mcpServers: ContainerMcpServer[];
@@ -53,6 +55,7 @@ export async function getGlobalSettings(): Promise<GlobalDisplaySettings> {
       systemPromptOverrideEnabled: false,
       systemPromptAppend: null,
       claudeModel: null,
+      advisorModel: null,
       hasClaudeApiKey: false,
       ttsSpeed: null,
       voiceAutoSend: true,
@@ -64,6 +67,7 @@ export async function getGlobalSettings(): Promise<GlobalDisplaySettings> {
     systemPromptOverrideEnabled: settings.systemPromptOverrideEnabled,
     systemPromptAppend: settings.systemPromptAppend,
     claudeModel: settings.claudeModel,
+    advisorModel: settings.advisorModel,
     hasClaudeApiKey: settings.claudeApiKey !== null,
     ttsSpeed: settings.ttsSpeed,
     voiceAutoSend: settings.voiceAutoSend,
@@ -94,6 +98,7 @@ export async function getGlobalSettingsForContainer(): Promise<GlobalContainerSe
     systemPromptOverrideEnabled: settings?.systemPromptOverrideEnabled ?? false,
     systemPromptAppend: settings?.systemPromptAppend ?? null,
     claudeModel: settings?.claudeModel ?? null,
+    advisorModel: settings?.advisorModel ?? null,
     claudeApiKey,
     envVars: decryptEnvVarsForContainer(envVarRows),
     mcpServers: decryptMcpServersForContainer(mcpServerRows),

--- a/src/server/services/settings-merger.test.ts
+++ b/src/server/services/settings-merger.test.ts
@@ -4,6 +4,8 @@ import {
   mergeMcpServers,
   mcpServersEqual,
   resolveClaudeModel,
+  resolveAdvisorModel,
+  DEFAULT_ADVISOR_MODEL,
 } from './settings-merger';
 import type { ContainerEnvVar, ContainerMcpServer } from './repo-settings';
 
@@ -23,6 +25,18 @@ describe('resolveClaudeModel', () => {
 
   it('returns undefined when nothing is set', () => {
     expect(resolveClaudeModel(null, null, undefined)).toBeUndefined();
+  });
+});
+
+describe('resolveAdvisorModel', () => {
+  it('uses the global override when set', () => {
+    expect(resolveAdvisorModel('claude-opus-4-8')).toBe('claude-opus-4-8');
+  });
+
+  it('falls back to the default advisor model when unset', () => {
+    expect(resolveAdvisorModel(null)).toBe(DEFAULT_ADVISOR_MODEL);
+    expect(resolveAdvisorModel(undefined)).toBe(DEFAULT_ADVISOR_MODEL);
+    expect(DEFAULT_ADVISOR_MODEL).toBe('claude-fable-5');
   });
 });
 

--- a/src/server/services/settings-merger.test.ts
+++ b/src/server/services/settings-merger.test.ts
@@ -33,10 +33,16 @@ describe('resolveAdvisorModel', () => {
     expect(resolveAdvisorModel('claude-opus-4-8')).toBe('claude-opus-4-8');
   });
 
-  it('falls back to the default advisor model when unset', () => {
+  it('falls back to the default advisor model when unset or blank', () => {
     expect(resolveAdvisorModel(null)).toBe(DEFAULT_ADVISOR_MODEL);
     expect(resolveAdvisorModel(undefined)).toBe(DEFAULT_ADVISOR_MODEL);
+    expect(resolveAdvisorModel('')).toBe(DEFAULT_ADVISOR_MODEL);
+    expect(resolveAdvisorModel('   ')).toBe(DEFAULT_ADVISOR_MODEL);
     expect(DEFAULT_ADVISOR_MODEL).toBe('claude-fable-5');
+  });
+
+  it('trims a surrounding-whitespace override', () => {
+    expect(resolveAdvisorModel('  claude-opus-4-8  ')).toBe('claude-opus-4-8');
   });
 });
 

--- a/src/server/services/settings-merger.ts
+++ b/src/server/services/settings-merger.ts
@@ -5,6 +5,13 @@ import { buildSystemPrompt } from '@/lib/system-prompt';
 import { env } from '@/lib/env';
 
 /**
+ * Model used for the server-side advisor tool when no global override is set.
+ * Setting an advisor model is also what enables the advisor tool for a session,
+ * so this default means the advisor tool is available (on Fable 5) out of the box.
+ */
+export const DEFAULT_ADVISOR_MODEL = 'claude-fable-5';
+
+/**
  * Fully merged session settings ready for container creation and Claude queries.
  */
 export interface MergedSessionSettings {
@@ -12,6 +19,8 @@ export interface MergedSessionSettings {
   envVars: ContainerEnvVar[];
   mcpServers: ContainerMcpServer[];
   claudeModel: string | undefined;
+  /** Always resolved (never undefined) — see {@link resolveAdvisorModel}. */
+  advisorModel: string;
   claudeApiKey: string | undefined;
   customSystemPrompt: string | null | undefined;
   globalSettings: GlobalContainerSettings;
@@ -47,6 +56,7 @@ export async function loadMergedSessionSettings(
       globalSettings.claudeModel,
       env.CLAUDE_MODEL
     ),
+    advisorModel: resolveAdvisorModel(globalSettings.advisorModel),
     claudeApiKey: globalSettings.claudeApiKey ?? undefined,
     customSystemPrompt: repoSettings?.customSystemPrompt,
     globalSettings,
@@ -63,6 +73,16 @@ export function resolveClaudeModel(
   envModel: string | undefined
 ): string | undefined {
   return repoModel ?? globalModel ?? envModel;
+}
+
+/**
+ * Resolve the effective advisor model: the global override, falling back to
+ * {@link DEFAULT_ADVISOR_MODEL}. Always returns a value, so the advisor tool is
+ * always enabled for a session (there is no "off" state — a global override only
+ * changes which model the advisor uses).
+ */
+export function resolveAdvisorModel(globalModel: string | null | undefined): string {
+  return globalModel ?? DEFAULT_ADVISOR_MODEL;
 }
 
 /**

--- a/src/server/services/settings-merger.ts
+++ b/src/server/services/settings-merger.ts
@@ -82,7 +82,10 @@ export function resolveClaudeModel(
  * changes which model the advisor uses).
  */
 export function resolveAdvisorModel(globalModel: string | null | undefined): string {
-  return globalModel ?? DEFAULT_ADVISOR_MODEL;
+  // Guard against an empty/whitespace value: returning "" would hand the SDK an
+  // invalid model. The write path already stores blank input as null, so this is
+  // defensive — it keeps the resolver correct regardless of how the value got there.
+  return globalModel?.trim() || DEFAULT_ADVISOR_MODEL;
 }
 
 /**


### PR DESCRIPTION
## Summary

Enables the server-side **advisor tool** for all Claude sessions by adding a global **Advisor Model** setting, defaulting to `claude-fable-5`. Setting an advisor model is what enables the advisor tool in the Claude Agent SDK, so this makes it available out of the box.

## What changed

- **Prisma**: nullable `advisorModel` column on `GlobalSettings` (+ migration).
- **settings-merger**: new pure `resolveAdvisorModel(globalModel)` → global override or `DEFAULT_ADVISOR_MODEL` (`claude-fable-5`). It always returns a value, so the advisor tool is always enabled; clearing the override reverts to Fable 5 rather than turning it off. `advisorModel` is added to `MergedSessionSettings`.
- **claude-runner** (`buildSdkOptions`): the advisor model is a settings-schema field with **no dedicated SDK `Options` field**, so it's injected as an ad-hoc `--settings` source via `Options.extraArgs` (`{ advisorModel }`). It does **not** write anything into the session workspace. Bound at query construction → takes effect on Stop→Start, like env vars and the system prompt (the SDK has no live setter for it).
- **globalSettings router**: `get` now returns `advisorModel` + `defaultAdvisorModel`; new `setAdvisorModel` mutation (mirrors `setClaudeModel`).
- **UI**: an **Advisor Model** card in Settings → System Prompt, reusing the shared `ModelOverrideField` selector (same free-text + suggestions component as the normal model selector — all models supported).
- **DESIGN.md** updated (global settings list, settings-merging, live-vs-restart-bound section, data model).

## Tests

- `resolveAdvisorModel` unit tests.
- `setAdvisorModel` router tests + updated `get` defaults assertion + updated runner mock settings.
- Full integration suite green (162 passed). Unit suite green except one **pre-existing, environment-driven** failure (`buildAgentEnv` expects `CLAUDE_CODE_OAUTH_TOKEN` unset, but this sandbox's login shell exports a real token) — unrelated to this change and reproduces on `main`.

## Note for reviewer / testing

The wiring uses the Agent SDK's `extraArgs → --settings '{"advisorModel":"…"}'` path. Worth a quick live check that the advisor tool actually appears in a session after a Stop→Start with the default in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)