### PR TITLE
Show running vs waiting in the session list

### DIFF
--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -140,7 +140,11 @@ sessions.create({
   // If initialPrompt is provided, it is sent automatically server-side when session becomes running
 
 sessions.list({ status?: SessionStatus })
-  → { sessions: Session[] }
+  → { sessions: (Session & { turnActive: boolean })[] }
+  // turnActive is the live in-memory main-agent turn state (see "Two-Axis
+  // Status"), attached per session so the list can show "running" (generating)
+  // vs "waiting" (live but idle). Always false for sessions without a live query
+  // (stopped, archived, or after a server restart until revived).
 
 sessions.get({ sessionId: string })
   → { session: Session }
@@ -360,9 +364,13 @@ subscription, so the app is deliberately structured around just **two** streams:
    are read/mutate-only and never open their own subscriptions.
 
 2. **Global session-list stream** — `sse.onSessionListEvents()`. `emitSessionUpdate`
-   fans every session change out to a global channel; `useSessionListStream`
+   and `emitClaudeRunning` fan every session change and main-agent turn-state flip out
+   to a global channel; `useSessionListStream`
    ([`src/hooks/useSessionListStream.ts`](../src/hooks/useSessionListStream.ts)) refetches
-   the home-page list so it updates live for any session, without one subscription per row.
+   the home-page list so it updates live for any session (including its
+   running/waiting badge), without one subscription per row. The refetched
+   `sessions.list` carries `turnActive`, so reload, tab-switch, and reconnect all
+   resync to the server's in-memory truth rather than trusting streamed state.
 
 **Resume tokens & catch-up.** The subscription input is **stable** — `{ sessionId,
 afterSequence }`, where `afterSequence` is the client's newest cached sequence captured
@@ -410,7 +418,7 @@ Subagent (`Task` tool) lifecycle: `task_started` and `task_notification` are the
 
 With one persistent query per session, "is Claude busy?" splits into two **independent** facts, both derived purely from the message stream by `reduceSessionMessage` ([`src/lib/session-status.ts`](../src/lib/session-status.ts)) and held in memory:
 
-- **`turnActive`** — whether the **main agent** is actively generating. Driven by the message **stream**, not the SDK turn `result`: a top-level (`parent_tool_use_id == null`) `stream_event` of `message_start` sets it true; a top-level `message_delta` whose `stop_reason` is terminal (`end_turn`/`stop_sequence`/`max_tokens`/`refusal`; `tool_use`/`pause_turn` mean the turn continues) sets it false. A top-level `result` also clears it as a safety net (and covers an interrupt's `error_during_execution`). **Why the stream and not the `result`:** a `run_in_background` subagent keeps the parent turn open — the SDK defers the turn `result` until the child settles — but the main agent finishes generating much earlier, so keying off `result` alone would wrongly show "running" for the entire background-subagent duration (confirmed by `scripts/spike-background-agent.ts`). Subagent traffic never moves it. This is the **only** input gate: emitted over the `running` SSE channel and read via `claude.isRunning`; the composer and Stop button key off it.
+- **`turnActive`** — whether the **main agent** is actively generating. Driven by the message **stream**, not the SDK turn `result`: a top-level (`parent_tool_use_id == null`) `stream_event` of `message_start` sets it true; a top-level `message_delta` whose `stop_reason` is terminal (`end_turn`/`stop_sequence`/`max_tokens`/`refusal`; `tool_use`/`pause_turn` mean the turn continues) sets it false. A top-level `result` also clears it as a safety net (and covers an interrupt's `error_during_execution`). **Why the stream and not the `result`:** a `run_in_background` subagent keeps the parent turn open — the SDK defers the turn `result` until the child settles — but the main agent finishes generating much earlier, so keying off `result` alone would wrongly show "running" for the entire background-subagent duration (confirmed by `scripts/spike-background-agent.ts`). Subagent traffic never moves it. This is the **only** input gate: emitted over the `running` SSE channel (and fanned out to the global session-list channel, so the home page can show running vs waiting per session) and read via `claude.isRunning` plus the `turnActive` field on `sessions.list`; the composer and Stop button key off it.
 - **background tasks** — a `Map<task_id, BackgroundTask>` driven by `task_started` (add) / `task_notification` **or** a terminal `task_updated.patch.status` (remove — two signals because the SDK only explicitly promises `task_notification` for `stopTask` and foreground-backgrounding; the authoritative `task_updated` state channel backstops every other ending and dropped notifications). Emitted as a latest-value `background` SSE event and read via `claude.getBackgroundTasks` (seeded once, updated by the stream, resynced on reconnect). This is an **indicator only** — it never gates input, so a user can keep chatting while a background task runs. This is genuinely interactive, not just cosmetic: a prompt sent while a background subagent runs is answered in a new turn that **interleaves** with the still-running subagent (confirmed by `scripts/spike-concurrent-send.ts` — the reply arrived ~19s before the subagent's `sleep 20` settled), not queued until it finishes. `ClaudeStatusIndicator` shows a separate "N background tasks running — you can keep chatting" line with per-task stop controls (`claude.stopBackgroundTask` → `query.stopTask`, then **optimistic removal**: the runner drops the entry from the live set itself rather than waiting for the SDK's terminal `task_notification`, so the ✕ reliably clears the indicator whether the task is still alive or a phantom whose notification was dropped — if it was real and the notification arrives later, the reducer's removal is a `has`-guarded no-op). The pure map-removal (`removeBackgroundTask` in [`session-status.ts`](../src/lib/session-status.ts)) is shared by the settle paths and the stop path. _Known limitation_: a task lingers in the map only if **all three** of `task_notification`, a terminal `task_updated`, and a user ✕ never happen — at which point it clears when the query is torn down. Since it is indicator-only, the impact is a stale count, never a stuck composer.
 
 `turnActive` is **purely event-driven** — set/cleared only by messages and forced false on every loop-exit path (SDK error, query close, stop/delete/shutdown). There are no status timers: the server can't tell a hung turn from a slow one, so a genuinely hung turn is recovered deterministically by the user (interrupt, or the header Stop which closes the query → `finally` clears the flag). A consequence: a persistent subprocess lives until stop / delete / shutdown / fatal error (no idle reaper) — fine for a single-user host with a handful of sessions. Both facts are in-memory only (lost on restart, re-derived as the revived query streams).
@@ -576,6 +584,11 @@ Voice mode provides speech-to-text input and text-to-speech output for hands-fre
 ### Session List (Home)
 
 - List of sessions with name, repo, status, last activity
+- The status badge splits a live session into **running** (Claude is mid-turn) vs
+  **waiting** (idle, waiting for input), derived from `turnActive` on
+  `sessions.list` (`deriveSessionDisplayStatus` in
+  [`src/lib/session-display-status.ts`](../src/lib/session-display-status.ts));
+  other statuses (stopped, creating, error, archived) show as-is
 - "New Session" button
 - Quick actions: resume, stop, delete
 

--- a/src/components/SessionList.test.tsx
+++ b/src/components/SessionList.test.tsx
@@ -82,6 +82,7 @@ describe('SessionList', () => {
         repoUrl: 'https://github.com/user/repo1.git',
         branch: 'main',
         status: 'running',
+        turnActive: true,
         updatedAt: new Date('2024-01-15T10:00:00Z'),
       },
       {
@@ -90,7 +91,17 @@ describe('SessionList', () => {
         repoUrl: 'https://github.com/user/repo2.git',
         branch: 'feature-branch',
         status: 'stopped',
+        turnActive: false,
         updatedAt: new Date('2024-01-14T09:00:00Z'),
+      },
+      {
+        id: 'session-3',
+        name: 'Test Session 3',
+        repoUrl: 'https://github.com/user/repo3.git',
+        branch: 'main',
+        status: 'running',
+        turnActive: false,
+        updatedAt: new Date('2024-01-13T08:00:00Z'),
       },
     ];
 
@@ -136,7 +147,26 @@ describe('SessionList', () => {
       );
 
       const sessionNames = screen.getAllByRole('listitem');
-      expect(sessionNames).toHaveLength(2);
+      expect(sessionNames).toHaveLength(3);
+    });
+
+    it('shows running/waiting/stopped based on status and turn state', () => {
+      render(
+        <SessionList
+          sessions={mockSessions}
+          isLoading={false}
+          showArchived={false}
+          onToggleArchived={vi.fn()}
+        />
+      );
+
+      const items = screen.getAllByRole('listitem');
+      // Session 1: status running with an active turn → "running"
+      expect(items[0]).toHaveTextContent('running');
+      // Session 2: status stopped → "stopped"
+      expect(items[1]).toHaveTextContent('stopped');
+      // Session 3: status running but idle → "waiting"
+      expect(items[2]).toHaveTextContent('waiting');
     });
   });
 });

--- a/src/components/SessionListItem.tsx
+++ b/src/components/SessionListItem.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { trpc } from '@/lib/trpc';
 import { extractRepoFullName } from '@/lib/utils';
+import { deriveSessionDisplayStatus } from '@/lib/session-display-status';
 import { SessionStatusBadge } from '@/components/SessionStatusBadge';
 import { SessionActionButton } from '@/components/SessionActionButton';
 import { PrStatusIndicator } from '@/components/PrStatusIndicator';
@@ -54,7 +55,9 @@ export function SessionListItem({ session, onMutationSuccess }: SessionListItemP
 
         <div className="flex items-center gap-4">
           {pullRequest && <PrStatusIndicator pullRequest={pullRequest} />}
-          <SessionStatusBadge status={session.status} />
+          <SessionStatusBadge
+            status={deriveSessionDisplayStatus(session.status, session.turnActive)}
+          />
 
           <div className="flex items-center gap-2">
             {/* No controls for archived sessions - they're read-only */}

--- a/src/components/SessionStatusBadge.tsx
+++ b/src/components/SessionStatusBadge.tsx
@@ -1,15 +1,20 @@
 import { Badge } from '@/components/ui/badge';
+import type { SessionDisplayStatus } from '@/lib/session-display-status';
 
-type SessionStatus = 'running' | 'stopped' | 'creating' | 'error' | 'archived';
-
-const statusVariants: Record<SessionStatus, 'default' | 'secondary' | 'destructive' | 'outline'> = {
+const statusVariants: Record<
+  SessionDisplayStatus,
+  'default' | 'secondary' | 'destructive' | 'outline'
+> = {
   running: 'default',
-  stopped: 'secondary',
+  waiting: 'secondary',
+  stopped: 'outline',
   creating: 'outline',
   error: 'destructive',
   archived: 'outline',
 };
 
 export function SessionStatusBadge({ status }: { status: string }) {
-  return <Badge variant={statusVariants[status as SessionStatus] || 'secondary'}>{status}</Badge>;
+  return (
+    <Badge variant={statusVariants[status as SessionDisplayStatus] || 'secondary'}>{status}</Badge>
+  );
 }

--- a/src/hooks/useSessionList.ts
+++ b/src/hooks/useSessionList.ts
@@ -8,6 +8,8 @@ export interface Session {
   repoUrl: string | null;
   branch: string | null;
   status: string;
+  /** Whether the main agent is mid-turn (live, in-memory; false when stopped). */
+  turnActive: boolean;
   updatedAt: Date;
 }
 

--- a/src/hooks/useSessionListStream.ts
+++ b/src/hooks/useSessionListStream.ts
@@ -5,8 +5,9 @@ import { useRefetchOnReconnect } from './useRefetchOnReconnect';
 
 /**
  * Subscribes to the global session-list SSE stream so the home page updates live
- * when any session changes (created, started, finished, archived) — including
- * changes driven from another tab or by background work.
+ * when any session changes (created, started, finished, archived) or Claude's
+ * turn state flips between running and waiting — including changes driven from
+ * another tab or by background work.
  *
  * The list is small, so on each event we simply refetch rather than surgically
  * patching the cache. We also refetch on tab-visibility / network reconnect as a

--- a/src/lib/session-display-status.test.ts
+++ b/src/lib/session-display-status.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { deriveSessionDisplayStatus } from './session-display-status';
+
+describe('deriveSessionDisplayStatus', () => {
+  it('shows "running" for a live session with an active turn', () => {
+    expect(deriveSessionDisplayStatus('running', true)).toBe('running');
+  });
+
+  it('shows "waiting" for a live session with no active turn', () => {
+    expect(deriveSessionDisplayStatus('running', false)).toBe('waiting');
+  });
+
+  it.each(['stopped', 'creating', 'error', 'archived'])(
+    'passes through %s regardless of turnActive',
+    (status) => {
+      expect(deriveSessionDisplayStatus(status, false)).toBe(status);
+      // turnActive can never be true without a live query, but the derivation
+      // must not invent a "running" label for a non-running session either way.
+      expect(deriveSessionDisplayStatus(status, true)).toBe(status);
+    }
+  );
+});

--- a/src/lib/session-display-status.ts
+++ b/src/lib/session-display-status.ts
@@ -1,0 +1,26 @@
+/**
+ * Pure derivation of the status label shown for a session in the session list.
+ *
+ * A DB status of `running` only means the session is live (workspace exists,
+ * query available) — whether Claude is actually generating is the independent
+ * `turnActive` axis (see `session-status.ts`). The list splits `running` into:
+ *
+ *   - `running` — the main agent is mid-turn generating
+ *   - `waiting` — the session is live but idle, waiting for user input
+ *
+ * All other statuses pass through unchanged.
+ */
+export type SessionDisplayStatus =
+  | 'running'
+  | 'waiting'
+  | 'stopped'
+  | 'creating'
+  | 'error'
+  | 'archived';
+
+export function deriveSessionDisplayStatus(status: string, turnActive: boolean): string {
+  if (status === 'running') {
+    return turnActive ? 'running' : 'waiting';
+  }
+  return status;
+}

--- a/src/server/routers/sessions.integration.test.ts
+++ b/src/server/routers/sessions.integration.test.ts
@@ -20,6 +20,7 @@ vi.mock('../services/claude-runner', () => ({
   sendUserMessage: vi.fn().mockResolvedValue(undefined),
   stopSession: vi.fn(),
   cleanupSession: vi.fn(),
+  isClaudeRunning: vi.fn().mockReturnValue(false),
 }));
 
 // Mock settings-merger

--- a/src/server/routers/sessions.integration.test.ts
+++ b/src/server/routers/sessions.integration.test.ts
@@ -208,6 +208,8 @@ describe('sessionsRouter integration', () => {
 
       expect(result.sessions).toHaveLength(2);
       expect(result.sessions.map((s) => s.name).sort()).toEqual(['Session 1', 'Session 2']);
+      // No in-memory query exists for either session, so no turn is active.
+      expect(result.sessions.every((s) => s.turnActive === false)).toBe(true);
     });
 
     it('should filter by status', async () => {

--- a/src/server/routers/sessions.ts
+++ b/src/server/routers/sessions.ts
@@ -3,7 +3,12 @@ import { router, protectedProcedure } from '../trpc';
 import { prisma } from '@/lib/prisma';
 import { TRPCError } from '@trpc/server';
 import { cloneRepo, createEmptyWorkspace, removeWorkspace } from '../services/worktree-manager';
-import { sendUserMessage, stopSession, cleanupSession } from '../services/claude-runner';
+import {
+  sendUserMessage,
+  stopSession,
+  cleanupSession,
+  isClaudeRunning,
+} from '../services/claude-runner';
 import { sseEvents } from '../services/events';
 import { createLogger, toError } from '@/lib/logger';
 import { env } from '@/lib/env';
@@ -150,7 +155,14 @@ export const sessionsRouter = router({
         orderBy: { updatedAt: 'desc' },
       });
 
-      return { sessions };
+      // Attach the live main-agent turn state (in-memory lookup, no extra query)
+      // so the list can distinguish "running" (generating) from "waiting" (idle).
+      return {
+        sessions: sessions.map((session) => ({
+          ...session,
+          turnActive: isClaudeRunning(session.id),
+        })),
+      };
     }),
 
   get: protectedProcedure

--- a/src/server/routers/sse.ts
+++ b/src/server/routers/sse.ts
@@ -5,7 +5,25 @@ import type { SessionStreamEvent, SessionListEvent } from '../services/events';
 import { tracked } from '@trpc/server';
 import { prisma } from '@/lib/prisma';
 import { isPartialMessageId } from '@/lib/message-cache';
+import { assertNeverFallback } from '@/lib/claude-messages';
 import { formatResumeToken, parseResumeToken, EMPTY_WATERMARK } from '@/lib/sse-resume';
+
+/**
+ * Map a session-list channel event to the shape yielded over the SSE stream.
+ * Exhaustive over {@link SessionListEvent}: adding a new member fails to compile
+ * here until it is handled (at runtime an unknown event is skipped — `null` —
+ * which is safe because the client refetches on reconnect anyway).
+ */
+function toSessionListStreamEvent(event: SessionListEvent) {
+  switch (event.type) {
+    case 'session_update':
+      return { kind: 'session' as const, session: event.session };
+    case 'claude_running':
+      return { kind: 'running' as const, sessionId: event.sessionId, running: event.running };
+    default:
+      return assertNeverFallback(event, null);
+  }
+}
 
 /**
  * Eagerly subscribe to an event source and buffer events into a queue. Subscribing
@@ -142,13 +160,10 @@ export const sseRouter = router({
       try {
         while (!signal?.aborted) {
           if (queue.length > 0) {
-            const event = queue.shift()!;
-            yield tracked(
-              String(counter++),
-              event.type === 'session_update'
-                ? { kind: 'session' as const, session: event.session }
-                : { kind: 'running' as const, sessionId: event.sessionId, running: event.running }
-            );
+            const streamEvent = toSessionListStreamEvent(queue.shift()!);
+            if (streamEvent) {
+              yield tracked(String(counter++), streamEvent);
+            }
           } else {
             await waitForEvent(signal);
           }

--- a/src/server/routers/sse.ts
+++ b/src/server/routers/sse.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { router, protectedProcedure } from '../trpc';
 import { sseEvents } from '../services/events';
-import type { SessionStreamEvent, SessionUpdateEvent } from '../services/events';
+import type { SessionStreamEvent, SessionListEvent } from '../services/events';
 import { tracked } from '@trpc/server';
 import { prisma } from '@/lib/prisma';
 import { isPartialMessageId } from '@/lib/message-cache';
@@ -123,9 +123,11 @@ export const sseRouter = router({
       }
     }),
 
-  // Global stream of session changes for the home page (all sessions). The list is
-  // small and also refetched on reconnect, so we only need monotonic tracked ids
-  // (seeded from lastEventId) to avoid client-side dedup dropping the first event.
+  // Global stream of session changes for the home page (all sessions): session
+  // record updates plus main-agent running-state changes (running/waiting). The
+  // list is small and also refetched on reconnect, so we only need monotonic
+  // tracked ids (seeded from lastEventId) to avoid client-side dedup dropping the
+  // first event.
   onSessionListEvents: protectedProcedure
     .input(z.object({ lastEventId: z.string().nullish() }).optional())
     .subscription(async function* ({ input, signal }) {
@@ -133,7 +135,7 @@ export const sseRouter = router({
       const seeded = input?.lastEventId ? Number(input.lastEventId) : NaN;
       let counter = Number.isInteger(seeded) ? seeded + 1 : 0;
 
-      const { queue, waitForEvent, unsubscribe } = createEventQueue<SessionUpdateEvent>((push) =>
+      const { queue, waitForEvent, unsubscribe } = createEventQueue<SessionListEvent>((push) =>
         sseEvents.onSessionListChanged(push)
       );
 
@@ -141,10 +143,12 @@ export const sseRouter = router({
         while (!signal?.aborted) {
           if (queue.length > 0) {
             const event = queue.shift()!;
-            yield tracked(String(counter++), {
-              kind: 'session' as const,
-              session: event.session,
-            });
+            yield tracked(
+              String(counter++),
+              event.type === 'session_update'
+                ? { kind: 'session' as const, session: event.session }
+                : { kind: 'running' as const, sessionId: event.sessionId, running: event.running }
+            );
           } else {
             await waitForEvent(signal);
           }

--- a/src/server/services/events.test.ts
+++ b/src/server/services/events.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Session } from '@prisma/client';
+import { sseEvents, type SessionListEvent } from './events';
+
+const fakeSession = { id: 'session-1', name: 'Test' } as Session;
+
+describe('sseEvents session-list fan-out', () => {
+  it('delivers session updates to the global list channel', () => {
+    const listener = vi.fn<(event: SessionListEvent) => void>();
+    const unsubscribe = sseEvents.onSessionListChanged(listener);
+
+    sseEvents.emitSessionUpdate('session-1', fakeSession);
+
+    expect(listener).toHaveBeenCalledWith({
+      type: 'session_update',
+      sessionId: 'session-1',
+      session: fakeSession,
+    });
+    unsubscribe();
+  });
+
+  it('delivers claude_running changes to the global list channel', () => {
+    const listener = vi.fn<(event: SessionListEvent) => void>();
+    const unsubscribe = sseEvents.onSessionListChanged(listener);
+
+    sseEvents.emitClaudeRunning('session-1', true);
+
+    expect(listener).toHaveBeenCalledWith({
+      type: 'claude_running',
+      sessionId: 'session-1',
+      running: true,
+    });
+    unsubscribe();
+  });
+
+  it('still delivers claude_running on the per-session channel', () => {
+    const listener = vi.fn();
+    const unsubscribe = sseEvents.onClaudeRunning('session-1', listener);
+
+    sseEvents.emitClaudeRunning('session-1', false);
+
+    expect(listener).toHaveBeenCalledWith({
+      type: 'claude_running',
+      sessionId: 'session-1',
+      running: false,
+    });
+    unsubscribe();
+  });
+
+  it('stops delivering after unsubscribe', () => {
+    const listener = vi.fn();
+    const unsubscribe = sseEvents.onSessionListChanged(listener);
+    unsubscribe();
+
+    sseEvents.emitClaudeRunning('session-1', true);
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/events.ts
+++ b/src/server/services/events.ts
@@ -78,6 +78,13 @@ export type SessionStreamEvent =
 // Global channel name for cross-session list updates (not session-scoped).
 const SESSION_LIST_EVENT = 'session-list';
 
+/**
+ * Events fanned out to the global session-list channel: session record changes
+ * plus main-agent running-state changes, so the home page can show
+ * running/waiting per session without a subscription per row.
+ */
+export type SessionListEvent = SessionUpdateEvent | ClaudeRunningEvent;
+
 // Create a typed event emitter
 class SSEEventEmitter extends EventEmitter {
   emitSessionUpdate(sessionId: string, session: Session): void {
@@ -104,11 +111,15 @@ class SSEEventEmitter extends EventEmitter {
   }
 
   emitClaudeRunning(sessionId: string, running: boolean): void {
-    this.emit(`claude:${sessionId}`, {
+    const event: ClaudeRunningEvent = {
       type: 'claude_running',
       sessionId,
       running,
-    } satisfies ClaudeRunningEvent);
+    };
+    this.emit(`claude:${sessionId}`, event);
+    // Fan out to the global list channel so the home page can flip a session
+    // between "running" and "waiting" live.
+    this.emit(SESSION_LIST_EVENT, event);
   }
 
   emitCommands(sessionId: string, commands: SlashCommand[]): void {
@@ -210,7 +221,7 @@ class SSEEventEmitter extends EventEmitter {
   }
 
   // Subscribe to session list changes across all sessions (home page).
-  onSessionListChanged(callback: (event: SessionUpdateEvent) => void): () => void {
+  onSessionListChanged(callback: (event: SessionListEvent) => void): () => void {
     this.on(SESSION_LIST_EVENT, callback);
     return () => this.off(SESSION_LIST_EVENT, callback);
   }


### PR DESCRIPTION
## Summary

The session list's status badge now distinguishes whether Claude is actually generating vs sitting idle in a live session:

- **running** — session is live and the main agent is mid-turn
- **waiting** — session is live but idle, waiting for input
- **stopped** / creating / error / archived — unchanged

## How it works

- `sessions.list` now attaches `turnActive` per session, read from the in-memory live status (`isClaudeRunning`) — no schema change and no extra queries, just a map lookup per row.
- `emitClaudeRunning` fans out to the **existing** global session-list SSE channel (the same one `emitSessionUpdate` already uses), so the home page refetches when any session's turn state flips. No new EventSource streams.
- A pure, unit-tested `deriveSessionDisplayStatus(status, turnActive)` maps the two axes to the badge label; `SessionStatusBadge` gains a `waiting` variant (secondary) and `stopped` moves to outline so live-idle and stopped read differently.

## Reload / tab-switch / reconnect

Because the badge is derived from the `sessions.list` response rather than streamed state, every resync path already does the right thing: SSE events just trigger a refetch, and `useRefetchOnReconnect` refetches on visibility change and network reconnect. After a server restart, `turnActive` is false until a session is revived, which matches reality (no turn is active).

## Tests

- New unit tests for `deriveSessionDisplayStatus` and the session-list event fan-out (`events.test.ts`)
- `SessionList` component test asserts running/waiting/stopped labels
- `sessions.list` integration test asserts `turnActive` defaults to false

`pnpm test:run`: 534 passed; the one failure (`claude-runner.test.ts` base-env oauth token) is pre-existing and environmental — it fails identically on the base commit because this sandbox's login shell exports `CLAUDE_CODE_OAUTH_TOKEN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)