### PR TITLE
Order session list by last message activity

### DIFF
--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -42,7 +42,7 @@ The system runs **directly on the host** without containers:
 
 The database schema is defined in [`prisma/schema.prisma`](../prisma/schema.prisma). Key models:
 
-- **Session**: Claude Code sessions tied to git clones or standalone workspaces. `repoUrl` and `branch` are nullable — when null, the session has no repository (workspace-only).
+- **Session**: Claude Code sessions tied to git clones or standalone workspaces. `repoUrl` and `branch` are nullable — when null, the session has no repository (workspace-only). `lastActivityAt` is bumped whenever a message is persisted for the session and drives session-list ordering, so recently interacted sessions sort first rather than sessions whose row was last touched by a lifecycle change like stop/start.
 - **Message**: Chat messages with sequence numbers for cursor-based pagination
 - **AuthSession**: Login sessions with tokens and audit info
 - **GlobalSettings**: Global application settings (system prompt override and append, Claude model, advisor model, Claude API key, TTS speed, voice auto-send)
@@ -583,7 +583,9 @@ Voice mode provides speech-to-text input and text-to-speech output for hands-fre
 
 ### Session List (Home)
 
-- List of sessions with name, repo, status, last activity
+- List of sessions with name, repo, status, last activity, ordered by
+  `lastActivityAt` (time of the last persisted message) so the most recently
+  interacted sessions are at the top
 - The status badge splits a live session into **running** (Claude is mid-turn) vs
   **waiting** (idle, waiting for input), derived from `turnActive` on
   `sessions.list` (`deriveSessionDisplayStatus` in

--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -42,7 +42,7 @@ The system runs **directly on the host** without containers:
 
 The database schema is defined in [`prisma/schema.prisma`](../prisma/schema.prisma). Key models:
 
-- **Session**: Claude Code sessions tied to git clones or standalone workspaces. `repoUrl` and `branch` are nullable — when null, the session has no repository (workspace-only). `lastActivityAt` is bumped whenever a message is persisted for the session and drives session-list ordering, so recently interacted sessions sort first rather than sessions whose row was last touched by a lifecycle change like stop/start.
+- **Session**: Claude Code sessions tied to git clones or standalone workspaces. `repoUrl` and `branch` are nullable — when null, the session has no repository (workspace-only). `lastActivityAt` drives session-list ordering and is bumped only on **user interactions** (sending a prompt, answering an AskUserQuestion / ExitPlanMode) — not on assistant/background traffic or lifecycle changes like stop/start — so the list orders by where the user last acted and doesn't shuffle while other sessions generate.
 - **Message**: Chat messages with sequence numbers for cursor-based pagination
 - **AuthSession**: Login sessions with tokens and audit info
 - **GlobalSettings**: Global application settings (system prompt override and append, Claude model, advisor model, Claude API key, TTS speed, voice auto-send)
@@ -584,8 +584,9 @@ Voice mode provides speech-to-text input and text-to-speech output for hands-fre
 ### Session List (Home)
 
 - List of sessions with name, repo, status, last activity, ordered by
-  `lastActivityAt` (time of the last persisted message) so the most recently
-  interacted sessions are at the top
+  `lastActivityAt` (time of the last user interaction) so the most recently
+  used sessions are at the top; assistant/background activity doesn't reorder
+  the list, so rows don't jump around while other sessions are generating
 - The status badge splits a live session into **running** (Claude is mid-turn) vs
   **waiting** (idle, waiting for input), derived from `turnActive` on
   `sessions.list` (`deriveSessionDisplayStatus` in

--- a/prisma/migrations/20260701222327_add_session_last_activity/migration.sql
+++ b/prisma/migrations/20260701222327_add_session_last_activity/migration.sql
@@ -1,0 +1,32 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Session" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "repoUrl" TEXT,
+    "branch" TEXT,
+    "workspacePath" TEXT NOT NULL DEFAULT '',
+    "repoPath" TEXT NOT NULL DEFAULT '',
+    "status" TEXT NOT NULL DEFAULT 'creating',
+    "statusMessage" TEXT,
+    "initialPrompt" TEXT,
+    "currentBranch" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "lastActivityAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "archivedAt" DATETIME
+);
+INSERT INTO "new_Session" ("archivedAt", "branch", "createdAt", "currentBranch", "id", "initialPrompt", "name", "repoPath", "repoUrl", "status", "statusMessage", "updatedAt", "workspacePath") SELECT "archivedAt", "branch", "createdAt", "currentBranch", "id", "initialPrompt", "name", "repoPath", "repoUrl", "status", "statusMessage", "updatedAt", "workspacePath" FROM "Session";
+DROP TABLE "Session";
+ALTER TABLE "new_Session" RENAME TO "Session";
+CREATE INDEX "Session_status_idx" ON "Session"("status");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;
+
+-- Backfill: preserve ordering for existing sessions using their real last
+-- activity (latest message time, falling back to updatedAt).
+UPDATE "Session" SET "lastActivityAt" = COALESCE(
+    (SELECT MAX(m."createdAt") FROM "Message" m WHERE m."sessionId" = "Session"."id"),
+    "updatedAt"
+);

--- a/prisma/migrations/20260701222327_add_session_last_activity/migration.sql
+++ b/prisma/migrations/20260701222327_add_session_last_activity/migration.sql
@@ -24,9 +24,9 @@ CREATE INDEX "Session_status_idx" ON "Session"("status");
 PRAGMA foreign_keys=ON;
 PRAGMA defer_foreign_keys=OFF;
 
--- Backfill: preserve ordering for existing sessions using their real last
--- activity (latest message time, falling back to updatedAt).
+-- Backfill: preserve ordering for existing sessions using their last user
+-- interaction (latest user-typed message, falling back to updatedAt).
 UPDATE "Session" SET "lastActivityAt" = COALESCE(
-    (SELECT MAX(m."createdAt") FROM "Message" m WHERE m."sessionId" = "Session"."id"),
+    (SELECT MAX(m."createdAt") FROM "Message" m WHERE m."sessionId" = "Session"."id" AND m."type" = 'user'),
     "updatedAt"
 );

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -34,6 +34,7 @@ model Session {
   currentBranch  String?   // Current git branch (detected after each query)
   createdAt      DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
+  lastActivityAt DateTime @default(now()) // Bumped when a message is persisted; drives session-list ordering
   archivedAt    DateTime? // When the session was archived (null if not archived)
   messages      Message[]
 

--- a/src/components/SessionList.test.tsx
+++ b/src/components/SessionList.test.tsx
@@ -83,7 +83,7 @@ describe('SessionList', () => {
         branch: 'main',
         status: 'running',
         turnActive: true,
-        updatedAt: new Date('2024-01-15T10:00:00Z'),
+        lastActivityAt: new Date('2024-01-15T10:00:00Z'),
       },
       {
         id: 'session-2',
@@ -92,7 +92,7 @@ describe('SessionList', () => {
         branch: 'feature-branch',
         status: 'stopped',
         turnActive: false,
-        updatedAt: new Date('2024-01-14T09:00:00Z'),
+        lastActivityAt: new Date('2024-01-14T09:00:00Z'),
       },
       {
         id: 'session-3',
@@ -101,7 +101,7 @@ describe('SessionList', () => {
         branch: 'main',
         status: 'running',
         turnActive: false,
-        updatedAt: new Date('2024-01-13T08:00:00Z'),
+        lastActivityAt: new Date('2024-01-13T08:00:00Z'),
       },
     ];
 

--- a/src/components/SessionListItem.tsx
+++ b/src/components/SessionListItem.tsx
@@ -93,7 +93,7 @@ export function SessionListItem({ session, onMutationSuccess }: SessionListItemP
       </div>
 
       <div className="mt-2 text-xs text-muted-foreground">
-        Last updated: {new Date(session.updatedAt).toLocaleString()}
+        Last activity: {new Date(session.lastActivityAt).toLocaleString()}
       </div>
     </li>
   );

--- a/src/hooks/useSessionList.ts
+++ b/src/hooks/useSessionList.ts
@@ -10,7 +10,7 @@ export interface Session {
   status: string;
   /** Whether the main agent is mid-turn (live, in-memory; false when stopped). */
   turnActive: boolean;
-  /** Time of the session's last message (drives list ordering). */
+  /** Time of the user's last interaction with the session (drives list ordering). */
   lastActivityAt: Date;
 }
 

--- a/src/hooks/useSessionList.ts
+++ b/src/hooks/useSessionList.ts
@@ -10,7 +10,8 @@ export interface Session {
   status: string;
   /** Whether the main agent is mid-turn (live, in-memory; false when stopped). */
   turnActive: boolean;
-  updatedAt: Date;
+  /** Time of the session's last message (drives list ordering). */
+  lastActivityAt: Date;
 }
 
 export interface UseSessionListOptions {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -34,6 +34,7 @@ export interface Session {
   initialPrompt: string | null;
   createdAt: Date;
   updatedAt: Date;
+  lastActivityAt: Date;
   archivedAt: Date | null;
 }
 

--- a/src/server/routers/sessions.integration.test.ts
+++ b/src/server/routers/sessions.integration.test.ts
@@ -213,6 +213,40 @@ describe('sessionsRouter integration', () => {
       expect(result.sessions.every((s) => s.turnActive === false)).toBe(true);
     });
 
+    it('orders sessions by lastActivityAt, most recent first', async () => {
+      await testPrisma.session.createMany({
+        data: [
+          {
+            name: 'Oldest activity',
+            workspacePath: '/w/1',
+            status: 'stopped',
+            lastActivityAt: new Date('2024-01-01T00:00:00Z'),
+          },
+          {
+            name: 'Newest activity',
+            workspacePath: '/w/2',
+            status: 'stopped',
+            lastActivityAt: new Date('2024-03-01T00:00:00Z'),
+          },
+          {
+            name: 'Middle activity',
+            workspacePath: '/w/3',
+            status: 'running',
+            lastActivityAt: new Date('2024-02-01T00:00:00Z'),
+          },
+        ],
+      });
+
+      const caller = createCaller('auth-session-id');
+      const result = await caller.sessions.list();
+
+      expect(result.sessions.map((s) => s.name)).toEqual([
+        'Newest activity',
+        'Middle activity',
+        'Oldest activity',
+      ]);
+    });
+
     it('should filter by status', async () => {
       await testPrisma.session.createMany({
         data: [

--- a/src/server/routers/sessions.ts
+++ b/src/server/routers/sessions.ts
@@ -152,7 +152,7 @@ export const sessionsRouter = router({
           ...(input?.status ? { status: input.status } : {}),
           ...(!includeArchived && !input?.status ? { status: { not: 'archived' } } : {}),
         },
-        orderBy: { updatedAt: 'desc' },
+        orderBy: { lastActivityAt: 'desc' },
       });
 
       // Attach the live main-agent turn state (in-memory lookup, no extra query)

--- a/src/server/services/claude-runner.integration.test.ts
+++ b/src/server/services/claude-runner.integration.test.ts
@@ -232,7 +232,7 @@ describe('claude-runner persistent streaming loop', () => {
     stopSession(sessionId);
   });
 
-  it('bumps session.lastActivityAt when a message is persisted', async () => {
+  it('bumps lastActivityAt on user sends but not on assistant traffic', async () => {
     const fake = makeFakeQuery();
     _setQueryFactory(fake.factory);
     const sessionId = await createRunningSession();
@@ -242,19 +242,24 @@ describe('claude-runner persistent streaming loop', () => {
       data: { lastActivityAt: past },
     });
 
+    // Sending a prompt is a user interaction — it bumps (awaited before return).
     await sendUserMessage(sessionId, 'hello');
+    const afterSend = await testPrisma.session.findUniqueOrThrow({ where: { id: sessionId } });
+    expect(afterSend.lastActivityAt.getTime()).toBeGreaterThan(past.getTime());
+
+    // Assistant/result persistence must NOT bump, so sessions working in the
+    // background don't reorder the list. Pin a sentinel and let the turn finish.
+    const sentinel = new Date('2021-01-01T00:00:00Z');
+    await testPrisma.session.update({
+      where: { id: sessionId },
+      data: { lastActivityAt: sentinel },
+    });
     fake.emit(assistant('hi there'));
     fake.emit(result());
     await waitFor(async () => (await messagesFor(sessionId)).length >= 3);
 
-    // The bump commits right after each message insert, so poll for it.
-    const lastMessage = (await messagesFor(sessionId)).at(-1)!;
-    await waitFor(async () => {
-      const session = await testPrisma.session.findUniqueOrThrow({ where: { id: sessionId } });
-      return session.lastActivityAt.getTime() === lastMessage.createdAt.getTime();
-    });
-    const session = await testPrisma.session.findUniqueOrThrow({ where: { id: sessionId } });
-    expect(session.lastActivityAt.getTime()).toBeGreaterThan(past.getTime());
+    const afterTurn = await testPrisma.session.findUniqueOrThrow({ where: { id: sessionId } });
+    expect(afterTurn.lastActivityAt.getTime()).toBe(sentinel.getTime());
 
     stopSession(sessionId);
   });

--- a/src/server/services/claude-runner.integration.test.ts
+++ b/src/server/services/claude-runner.integration.test.ts
@@ -232,6 +232,33 @@ describe('claude-runner persistent streaming loop', () => {
     stopSession(sessionId);
   });
 
+  it('bumps session.lastActivityAt when a message is persisted', async () => {
+    const fake = makeFakeQuery();
+    _setQueryFactory(fake.factory);
+    const sessionId = await createRunningSession();
+    const past = new Date('2020-01-01T00:00:00Z');
+    await testPrisma.session.update({
+      where: { id: sessionId },
+      data: { lastActivityAt: past },
+    });
+
+    await sendUserMessage(sessionId, 'hello');
+    fake.emit(assistant('hi there'));
+    fake.emit(result());
+    await waitFor(async () => (await messagesFor(sessionId)).length >= 3);
+
+    // The bump commits right after each message insert, so poll for it.
+    const lastMessage = (await messagesFor(sessionId)).at(-1)!;
+    await waitFor(async () => {
+      const session = await testPrisma.session.findUniqueOrThrow({ where: { id: sessionId } });
+      return session.lastActivityAt.getTime() === lastMessage.createdAt.getTime();
+    });
+    const session = await testPrisma.session.findUniqueOrThrow({ where: { id: sessionId } });
+    expect(session.lastActivityAt.getTime()).toBeGreaterThan(past.getTime());
+
+    stopSession(sessionId);
+  });
+
   it('keeps the query alive across turns and survives a background task past turn end', async () => {
     const fake = makeFakeQuery();
     _setQueryFactory(fake.factory);

--- a/src/server/services/claude-runner.ts
+++ b/src/server/services/claude-runner.ts
@@ -206,19 +206,6 @@ async function insertMessage(params: {
       const message = await prisma.message.create({
         data: { id, sessionId, sequence, type, content: contentJson },
       });
-      // Bump the session's activity timestamp (drives session-list ordering).
-      // Best-effort: an ordering hiccup must never fail message persistence.
-      await prisma.session
-        .update({
-          where: { id: sessionId },
-          data: { lastActivityAt: message.createdAt },
-        })
-        .catch((err: unknown) => {
-          log.warn('Failed to bump session lastActivityAt', {
-            sessionId,
-            error: toError(err).message,
-          });
-        });
       sseEvents.emitNewMessage(sessionId, {
         id,
         sessionId,
@@ -246,6 +233,27 @@ async function insertMessage(params: {
   throw new Error(
     `Failed to insert message ${id} for ${sessionId} after ${SEQUENCE_RETRY_LIMIT} attempts`
   );
+}
+
+/**
+ * Bump the session's activity timestamp (drives session-list ordering). Called
+ * only for genuine user interactions — sending a prompt or answering an
+ * interactive tool call — not for assistant/background traffic, so sessions
+ * working in the background don't shuffle the list while the user is reading
+ * it. Best-effort: an ordering hiccup must never fail the interaction.
+ */
+async function bumpSessionActivity(sessionId: string): Promise<void> {
+  try {
+    await prisma.session.update({
+      where: { id: sessionId },
+      data: { lastActivityAt: new Date() },
+    });
+  } catch (err) {
+    log.warn('Failed to bump session lastActivityAt', {
+      sessionId,
+      error: toError(err).message,
+    });
+  }
 }
 
 /**
@@ -836,6 +844,7 @@ export async function sendUserMessage(sessionId: string, prompt: string): Promis
     type: 'user',
     content: { type: 'user', content: prompt },
   });
+  await bumpSessionActivity(sessionId);
 
   state.input.push({
     type: 'user',
@@ -870,6 +879,7 @@ export async function submitLiveToolResponse(
         toolName: pending.toolName,
       });
       pending.resolve(buildPermissionResult(response, pending.input));
+      await bumpSessionActivity(sessionId);
       return true;
     }
 

--- a/src/server/services/claude-runner.ts
+++ b/src/server/services/claude-runner.ts
@@ -206,6 +206,19 @@ async function insertMessage(params: {
       const message = await prisma.message.create({
         data: { id, sessionId, sequence, type, content: contentJson },
       });
+      // Bump the session's activity timestamp (drives session-list ordering).
+      // Best-effort: an ordering hiccup must never fail message persistence.
+      await prisma.session
+        .update({
+          where: { id: sessionId },
+          data: { lastActivityAt: message.createdAt },
+        })
+        .catch((err: unknown) => {
+          log.warn('Failed to bump session lastActivityAt', {
+            sessionId,
+            error: toError(err).message,
+          });
+        });
       sseEvents.emitNewMessage(sessionId, {
         id,
         sessionId,


### PR DESCRIPTION
## Summary

Answers the question from the session: **no, sending a message did not bubble a session to the top.** The list ordered by `Session.updatedAt`, which only changes when the session *row* is updated — lifecycle changes (stop/start, status, branch detection). Sending a message only inserts `Message` rows, so it never reordered anything, and stopping a session pinned it to the top.

## Changes

- Add `Session.lastActivityAt` (default `now()`), bumped only on **user interactions**: sending a prompt (`sendUserMessage`, which also covers initial prompts and fallback tool answers) and answering a live AskUserQuestion/ExitPlanMode. Assistant/background traffic deliberately does *not* bump, so sessions generating in the background don't shuffle the list while you're using it. The bump is best-effort so an ordering hiccup can never fail the interaction.
- `sessions.list` now orders by `lastActivityAt desc`, and stop/start no longer reorders anything.
- Migration backfills existing sessions from their latest user-typed message's `createdAt` (falling back to `updatedAt`), preserving sensible ordering for existing data.
- Session list item shows "Last activity" from the new field instead of "Last updated".
- Live reordering on the home page comes for free: the existing `claude_running` turn-start/end events on the global session-list stream already trigger a refetch, which picks up the new order.

## Tests

- New integration test: `sessions.list` orders by `lastActivityAt` regardless of status.
- New integration test: a user send bumps `lastActivityAt`; assistant/result persistence does not.
- `pnpm test:run`: 534 passing; the one failure (`getBaseEnv` expecting `CLAUDE_CODE_OAUTH_TOKEN` unset) is pre-existing on a clean tree — this machine's login shell exports the token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)