### PR TITLE
Render server tool calls (advisor) in the transcript

### DIFF
--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -400,6 +400,12 @@ When extended thinking is active, assistant messages include `thinking` (and, wh
 
 During redacted thinking the SDK also emits frequent `{ type: 'system', subtype: 'thinking_tokens' }` progress messages carrying only live token-count estimates. These are dropped (not persisted or shown) via `isIgnoredSystemMessage` in [`src/lib/claude-messages.ts`](../src/lib/claude-messages.ts) — one of several ignored system subtypes (see [System Message Subtypes](#system-message-subtypes)) — so they don't render as a stream of empty "System" bubbles.
 
+### Server Tool Blocks (Advisor)
+
+Some tools (notably the **advisor** tool) execute inside the Anthropic API rather than in the SDK. They never pass through `canUseTool`, and they appear in assistant messages as distinct content-block types: `server_tool_use` (the call) and `advisor_tool_result` (the response). The advisor's response content is encrypted (`advisor_redacted_result`) — only the model can read it, so the transcript has nothing human-readable to show for it.
+
+Persistence needs no special handling (classification keys off the top-level message type). Rendering does: `server_tool_use` counts as renderable content and displays as a one-line indicator ("Consulted the advisor…", `ServerToolUseDisplay`), while a message whose only block is an `advisor_tool_result` is deliberately hidden (`hasRenderableAssistantContent` returns false) since the indicator on the call block already marks the event and the result is unreadable.
+
 ### Message Classification
 
 Every message yielded by the SDK is routed through `classifyMessage(message)` in [`src/lib/claude-messages.ts`](../src/lib/claude-messages.ts), which returns one of `{ kind: 'stream_event' | 'skip' | 'persist' }` (with the DB column type for `persist`). It `switch`es over the SDK's `SDKMessage` discriminated union and ends in `assertNeverFallback`, a compile-time exhaustiveness guard: if a future SDK release adds a top-level message `type`, the build fails until it is handled here. At runtime an unrecognized type degrades to generic system persistence rather than throwing, so an unexpected frame never crashes the query loop.

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -94,7 +94,7 @@ function buildToolResultMap(messages: Message[]): {
       for (const block of resultBlocks) {
         if (block.tool_use_id && toolUseIds.has(block.tool_use_id)) {
           resultMap.set(block.tool_use_id, {
-            content: block.content,
+            content: typeof block.content === 'string' ? block.content : undefined,
             is_error: block.is_error,
           });
         } else {

--- a/src/components/messages/ContentRenderer.tsx
+++ b/src/components/messages/ContentRenderer.tsx
@@ -20,6 +20,7 @@ import { ExitPlanModeDisplay } from './ExitPlanModeDisplay';
 import { TodoWriteDisplay } from './TodoWriteDisplay';
 import { AskUserQuestionDisplay } from './AskUserQuestionDisplay';
 import { ThinkingDisplay } from './ThinkingDisplay';
+import { ServerToolUseDisplay } from './ServerToolUseDisplay';
 
 /**
  * Map of tool names to their specialized display components.
@@ -47,6 +48,7 @@ function renderContentBlocks(blocks: ContentBlock[], toolResults?: ToolResultMap
   const thinkingParts: string[] = [];
   const textBlocks: string[] = [];
   const toolUseBlocks: ContentBlock[] = [];
+  const serverToolUseBlocks: ContentBlock[] = [];
   let hasRedactedThinking = false;
 
   for (const block of blocks) {
@@ -58,6 +60,8 @@ function renderContentBlocks(blocks: ContentBlock[], toolResults?: ToolResultMap
       hasRedactedThinking = true;
     } else if (block.type === 'tool_use') {
       toolUseBlocks.push(block);
+    } else if (block.type === 'server_tool_use') {
+      serverToolUseBlocks.push(block);
     }
   }
 
@@ -71,6 +75,13 @@ function renderContentBlocks(blocks: ContentBlock[], toolResults?: ToolResultMap
       {thinking.length > 0 && <ThinkingDisplay thinking={thinking} />}
       {hasRedactedThinking && <ThinkingDisplay thinking="" redacted />}
       {textBlocks.length > 0 && <MarkdownContent content={textBlocks.join('\n')} />}
+      {serverToolUseBlocks.length > 0 && (
+        <div className="mt-2 space-y-1">
+          {serverToolUseBlocks.map((block) => (
+            <ServerToolUseDisplay key={block.id} name={block.name ?? 'unknown'} />
+          ))}
+        </div>
+      )}
       {toolUseBlocks.length > 0 && (
         <div className="mt-2 space-y-2">
           {toolUseBlocks.map((block) => {

--- a/src/components/messages/MessageBubble.test.tsx
+++ b/src/components/messages/MessageBubble.test.tsx
@@ -495,6 +495,59 @@ describe('MessageBubble', () => {
     });
   });
 
+  describe('server tool use (advisor)', () => {
+    it('renders an indicator for an advisor server_tool_use block', () => {
+      const message = {
+        type: 'assistant',
+        content: {
+          message: {
+            content: [{ type: 'server_tool_use', id: 'srvtoolu_1', name: 'advisor', input: {} }],
+          },
+        } as MessageContent,
+      };
+
+      render(<MessageBubble message={message} />);
+
+      expect(screen.getByText(/Consulted the advisor/)).toBeInTheDocument();
+    });
+
+    it('renders a generic indicator for other server tools', () => {
+      const message = {
+        type: 'assistant',
+        content: {
+          message: {
+            content: [{ type: 'server_tool_use', id: 'srvtoolu_2', name: 'web_search', input: {} }],
+          },
+        } as MessageContent,
+      };
+
+      render(<MessageBubble message={message} />);
+
+      expect(screen.getByText(/Used server tool: web_search/)).toBeInTheDocument();
+    });
+
+    it('renders nothing for a message containing only an advisor_tool_result', () => {
+      const message = {
+        type: 'assistant',
+        content: {
+          message: {
+            content: [
+              {
+                type: 'advisor_tool_result',
+                tool_use_id: 'srvtoolu_1',
+                content: { type: 'advisor_redacted_result', encrypted_content: 'abc' },
+              },
+            ],
+          },
+        } as MessageContent,
+      };
+
+      const { container } = render(<MessageBubble message={message} />);
+
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
   describe('styling', () => {
     it('applies user message styling', () => {
       const message = {

--- a/src/components/messages/ServerToolUseDisplay.tsx
+++ b/src/components/messages/ServerToolUseDisplay.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Lightbulb, Server } from 'lucide-react';
+
+/**
+ * Indicator for a server-side tool call (`server_tool_use` block) — a tool
+ * executed inside the Anthropic API, like the advisor tool. There is no
+ * expandable input/output: the advisor's response comes back encrypted
+ * (`advisor_tool_result` / `advisor_redacted_result`) and is only readable by
+ * the model, so all we can show is that the call happened.
+ */
+export function ServerToolUseDisplay({ name }: { name: string }) {
+  const isAdvisor = name === 'advisor';
+  const Icon = isAdvisor ? Lightbulb : Server;
+  return (
+    <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+      <Icon className="h-3.5 w-3.5 shrink-0" />
+      <span className="italic">
+        {isAdvisor
+          ? 'Consulted the advisor (the response is only visible to Claude)'
+          : `Used server tool: ${name}`}
+      </span>
+    </div>
+  );
+}

--- a/src/components/messages/messageHelpers.test.ts
+++ b/src/components/messages/messageHelpers.test.ts
@@ -444,6 +444,32 @@ describe('hasRenderableAssistantContent', () => {
     ).toBe(true);
   });
 
+  it('returns true for a server_tool_use block (e.g. the advisor tool)', () => {
+    expect(
+      hasRenderableAssistantContent({
+        message: {
+          content: [{ type: 'server_tool_use', id: 'srvtoolu_1', name: 'advisor', input: {} }],
+        },
+      })
+    ).toBe(true);
+  });
+
+  it('returns false when the only block is an advisor_tool_result (encrypted, nothing to show)', () => {
+    expect(
+      hasRenderableAssistantContent({
+        message: {
+          content: [
+            {
+              type: 'advisor_tool_result',
+              tool_use_id: 'srvtoolu_1',
+              content: { type: 'advisor_redacted_result', encrypted_content: 'abc' },
+            },
+          ],
+        },
+      })
+    ).toBe(false);
+  });
+
   it('returns true for non-array content (handled elsewhere)', () => {
     expect(hasRenderableAssistantContent({ content: 'plain' })).toBe(true);
   });

--- a/src/components/messages/messageHelpers.ts
+++ b/src/components/messages/messageHelpers.ts
@@ -96,7 +96,10 @@ export function hasRenderableAssistantContent(content: MessageContent): boolean 
         return typeof block.thinking === 'string' && block.thinking.trim().length > 0;
       case 'tool_use':
       case 'redacted_thinking':
+      case 'server_tool_use':
         return true;
+      // advisor_tool_result is deliberately not renderable: its content is
+      // encrypted, so the server_tool_use block is the visible indicator.
       default:
         return false;
     }

--- a/src/components/messages/types.ts
+++ b/src/components/messages/types.ts
@@ -12,7 +12,14 @@ export interface ToolCall {
 }
 
 export interface ContentBlock {
-  type: 'text' | 'thinking' | 'redacted_thinking' | 'tool_use' | 'tool_result';
+  type:
+    | 'text'
+    | 'thinking'
+    | 'redacted_thinking'
+    | 'tool_use'
+    | 'tool_result'
+    | 'server_tool_use'
+    | 'advisor_tool_result';
   text?: string;
   /** For thinking blocks */
   thinking?: string;
@@ -22,7 +29,8 @@ export interface ContentBlock {
   name?: string;
   input?: unknown;
   tool_use_id?: string;
-  content?: string;
+  /** String for tool_result; advisor_tool_result carries an encrypted object */
+  content?: string | { type?: string; encrypted_content?: string };
   is_error?: boolean;
 }
 

--- a/src/lib/claude-messages.test.ts
+++ b/src/lib/claude-messages.test.ts
@@ -118,6 +118,25 @@ describe('claude-messages', () => {
         expect(result.success).toBe(true);
       });
 
+      it('should parse server_tool_use block (advisor)', () => {
+        const result = ContentBlockSchema.safeParse({
+          type: 'server_tool_use',
+          id: 'srvtoolu_014mCNVrW6NLM6TiYm3bX4Ue',
+          name: 'advisor',
+          input: {},
+        });
+        expect(result.success).toBe(true);
+      });
+
+      it('should parse advisor_tool_result block with encrypted content', () => {
+        const result = ContentBlockSchema.safeParse({
+          type: 'advisor_tool_result',
+          tool_use_id: 'srvtoolu_014mCNVrW6NLM6TiYm3bX4Ue',
+          content: { type: 'advisor_redacted_result', encrypted_content: 'Eu8NCioI...' },
+        });
+        expect(result.success).toBe(true);
+      });
+
       it('should reject unknown block type', () => {
         const result = ContentBlockSchema.safeParse({ type: 'unknown', data: 'test' });
         expect(result.success).toBe(false);

--- a/src/lib/claude-messages.ts
+++ b/src/lib/claude-messages.ts
@@ -65,6 +65,32 @@ export const ToolResultBlockSchema = z.object({
 export type ToolResultBlock = z.infer<typeof ToolResultBlockSchema>;
 
 /**
+ * Server tool use content block - a tool executed server-side by the Anthropic
+ * API (e.g. the advisor tool). Unlike `tool_use` it never goes through
+ * canUseTool, and its result arrives as a dedicated block type rather than a
+ * `tool_result` in a user message.
+ */
+export const ServerToolUseBlockSchema = z.object({
+  type: z.literal('server_tool_use'),
+  id: z.string(),
+  name: z.string(),
+  input: z.record(z.string(), z.unknown()),
+});
+export type ServerToolUseBlock = z.infer<typeof ServerToolUseBlockSchema>;
+
+/**
+ * Advisor tool result block - the advisor's response to a `server_tool_use`
+ * advisor call. The content is encrypted (`advisor_redacted_result`) and only
+ * readable by the model, so it carries nothing renderable.
+ */
+export const AdvisorToolResultBlockSchema = z.object({
+  type: z.literal('advisor_tool_result'),
+  tool_use_id: z.string(),
+  content: z.unknown().optional(),
+});
+export type AdvisorToolResultBlock = z.infer<typeof AdvisorToolResultBlockSchema>;
+
+/**
  * Union of all content block types
  */
 export const ContentBlockSchema = z.discriminatedUnion('type', [
@@ -73,6 +99,8 @@ export const ContentBlockSchema = z.discriminatedUnion('type', [
   RedactedThinkingBlockSchema,
   ToolUseBlockSchema,
   ToolResultBlockSchema,
+  ServerToolUseBlockSchema,
+  AdvisorToolResultBlockSchema,
 ]);
 export type ContentBlock = z.infer<typeof ContentBlockSchema>;
 


### PR DESCRIPTION
## Problem

Calling the advisor tool left no trace in the web UI, even though the call succeeded and was persisted. The advisor is a **server-side tool** — it executes inside the Anthropic API, never passes through `canUseTool`, and arrives as new content-block types (`server_tool_use` / `advisor_tool_result`) instead of the ordinary `tool_use` / `tool_result` pair. The client had no display path for these:

1. `hasRenderableAssistantContent` treated unknown block types as non-renderable, so a message containing only a `server_tool_use` block rendered as `null` (the empty-bubble suppression hiding a real event)
2. `renderContentBlocks` silently skipped unrecognized block types
3. `ContentBlockSchema` didn't include either block type

## Fix

- Add `ServerToolUseBlockSchema` / `AdvisorToolResultBlockSchema` to `ContentBlockSchema` and the loose component `ContentBlock` type
- Treat `server_tool_use` as renderable content; render it via a new `ServerToolUseDisplay` — a one-line indicator ("💡 Consulted the advisor (the response is only visible to Claude)", generic label for other server tools)
- Keep `advisor_tool_result`-only messages hidden: the result content is encrypted (`advisor_redacted_result`), so there is nothing readable to show — the call indicator is the visible event
- Document server tool blocks in DESIGN.md

## Testing

- New unit tests for the schemas, `hasRenderableAssistantContent`, and `MessageBubble` rendering (indicator shown for advisor + generic server tools; result-only message renders nothing)
- `pnpm test:run`: 538 passed; the one failure (`claude-runner.test.ts` login-shell `CLAUDE_CODE_OAUTH_TOKEN` check) is pre-existing on clean HEAD in this environment and unrelated
- Verified against the real persisted advisor messages from session `ae225152` (sequences 6–7 in prod.db)

🤖 Generated with [Claude Code](https://claude.com/claude-code)