### PR TITLE
Add unit tests for the SSE createEventQueue helper (salvaged from #359)

### DIFF
--- a/src/server/routers/sse.test.ts
+++ b/src/server/routers/sse.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createEventQueue } from './sse';
+
+/**
+ * Wire up a createEventQueue with a controllable fake subscription. Returns the
+ * queue handle plus the captured `push` and an `unsubscribed` flag so tests can
+ * assert the cleanup invariants.
+ */
+function harness<T>() {
+  let push: ((event: T) => void) | null = null;
+  let unsubscribed = false;
+  const handle = createEventQueue<T>((p) => {
+    push = p;
+    return () => {
+      unsubscribed = true;
+    };
+  });
+  return {
+    ...handle,
+    push: (event: T) => push!(event),
+    get unsubscribed() {
+      return unsubscribed;
+    },
+  };
+}
+
+describe('createEventQueue', () => {
+  it('subscribes synchronously so events pushed before any wait are buffered in order', () => {
+    const h = harness<number>();
+    h.push(1);
+    h.push(2);
+    h.push(3);
+    expect(h.queue).toEqual([1, 2, 3]);
+  });
+
+  it('resolves waitForEvent when an event arrives', async () => {
+    const h = harness<string>();
+    const wait = h.waitForEvent(undefined);
+    h.push('hello');
+    await expect(wait).resolves.toBeUndefined();
+    expect(h.queue).toEqual(['hello']);
+  });
+
+  it('resolves waitForEvent when the signal aborts, leaving the queue empty', async () => {
+    const h = harness<number>();
+    const controller = new AbortController();
+    const wait = h.waitForEvent(controller.signal);
+    controller.abort();
+    await expect(wait).resolves.toBeUndefined();
+    expect(h.queue).toEqual([]);
+  });
+
+  it('resolves waitForEvent synchronously when the signal is already aborted', async () => {
+    // Regression guard: the 'abort' event has already fired and will not fire
+    // again, so waiting on it would hang the subscription generator forever.
+    const h = harness<number>();
+    const controller = new AbortController();
+    controller.abort();
+    await expect(h.waitForEvent(controller.signal)).resolves.toBeUndefined();
+  });
+
+  it('removes the abort listener when an event (not the abort) ends the wait', async () => {
+    const h = harness<number>();
+    const controller = new AbortController();
+    const removeSpy = vi.spyOn(controller.signal, 'removeEventListener');
+    const wait = h.waitForEvent(controller.signal);
+    h.push(42);
+    await wait;
+    expect(removeSpy).toHaveBeenCalledWith('abort', expect.any(Function));
+  });
+
+  it('supports repeated waits, resolving each on its own event', async () => {
+    const h = harness<number>();
+
+    const first = h.waitForEvent(undefined);
+    h.push(1);
+    await first;
+    expect(h.queue.shift()).toBe(1);
+
+    const second = h.waitForEvent(undefined);
+    h.push(2);
+    await second;
+    expect(h.queue.shift()).toBe(2);
+  });
+
+  it('unsubscribe invokes the underlying subscription cleanup', () => {
+    const h = harness<number>();
+    expect(h.unsubscribed).toBe(false);
+    h.unsubscribe();
+    expect(h.unsubscribed).toBe(true);
+  });
+});

--- a/src/server/routers/sse.ts
+++ b/src/server/routers/sse.ts
@@ -30,7 +30,7 @@ function toSessionListStreamEvent(event: SessionListEvent) {
  * synchronously (rather than on the first generator `next()`) ensures events that
  * arrive while we replay history are not missed.
  */
-function createEventQueue<T>(subscribe: (push: (event: T) => void) => () => void) {
+export function createEventQueue<T>(subscribe: (push: (event: T) => void) => () => void) {
   const queue: T[] = [];
   let resolveWait: (() => void) | null = null;
   const unsubscribe = subscribe((event) => {


### PR DESCRIPTION
## Summary

While rebasing #359 it turned out every functional change in that PR had already been independently re-implemented on main (details in the review comment on #359). The one artifact main lacked was test coverage for the SSE subscription plumbing — #359 added tests for its `eventStream` helper, but main has since replaced that with `createEventQueue`, which had no coverage at all.

This ports the test ideas to `createEventQueue`:

- Synchronous subscription: events pushed before any wait are buffered, in order (the "don't miss events during history replay" invariant)
- `waitForEvent` resolves on event arrival and on signal abort
- The already-aborted signal resolves synchronously (regression guard for the hang the code comments call out)
- The abort listener is removed when an event, not the abort, ends the wait
- Repeated waits each resolve on their own event
- `unsubscribe` invokes the underlying subscription cleanup

`createEventQueue` is now exported from `sse.ts` so the co-located test can import it.

## Test plan

- `pnpm vitest run src/server/routers/sse.test.ts` — 7/7 pass
- Full `pnpm test:run`: 545 pass, 1 pre-existing environment-dependent failure unrelated to this change (`buildAgentEnv` picks up `CLAUDE_CODE_OAUTH_TOKEN` from this machine's login shell — filed as #373)
- `tsc --noEmit` and eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)