### PR TITLE
Fix cost double-counting and context-window bugs in token estimation

### DIFF
--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -431,6 +431,17 @@ With one persistent query per session, "is Claude busy?" splits into two **indep
 
 **Ephemeral retry status.** `api_retry` messages (the SDK retrying a rate-limited/overloaded request) are ignored above so they never pollute the transcript, but the _current_ retry state is surfaced live. The runner parses each via `parseRetryState` ([`claude-messages.ts`](../src/lib/claude-messages.ts)), stores it on the in-memory session state, and emits it over the `retry` SSE channel as a latest-value event (`{ attempt, maxRetries, errorStatus?, error? } | null`). Any non-retry message clears it (the request recovered), as does turn end. The client reads it via `claude.getRetryState` (seeded once, updated by the stream, resynced on reconnect) and `ClaudeStatusIndicator` shows "Retrying (overloaded) — attempt n/10…" while it is set. Because it is in-memory only, a server restart loses it — acceptable for a transient indicator.
 
+### Cost & Context Usage Estimation
+
+The `ContextUsageIndicator` (context % + session cost) is computed server-side by the pure `estimateTokenUsage` ([`src/lib/token-estimation.ts`](../src/lib/token-estimation.ts)), served by `claude.getTokenUsage` from the persisted result/system messages plus the latest top-level assistant message. It relies on result-message semantics that were verified empirically against real sessions, because the two families of fields on a `result` have **different scopes**:
+
+- **Top-level `usage`** is **per-turn** — the tokens consumed by the turn that just completed. Summing it across result messages gives correct session token totals.
+- **`total_cost_usd` and `modelUsage`** are **cumulative since the query process started**. With the persistent per-session query one process spans many turns, so every result repeats and extends the totals of the results before it — summing these double-counts (roughly quadratically in turns). The counters reset to zero when the query is re-established (stop→start, server restart); `resume` does **not** carry cost forward.
+
+Session cost is therefore aggregated by segmenting the results into query processes and summing each segment's final cumulative value. Segment boundaries are detected purely from the data: cumulative cost is monotonically non-decreasing within a process, so a **drop marks a reset**. (A reset is masked only if a new process's first turn costs more than the entire previous process — the total is then slightly undercounted by that previous segment; acceptable for an indicator.) `modelUsage` token counts and `costUSD` are never summed; only its `contextWindow` is read.
+
+Context % reflects how full the window currently is, **not** total consumption: it uses the most recent **top-level** assistant message's `input + cache_read + cache_creation + output` tokens (the prompt of the latest API call plus its output, which becomes input next call). Subagent messages (`parent_tool_use_id` set) are skipped — they run in their own, smaller context. The window capacity comes from `modelUsage[mainModel].contextWindow` (a result can report several models — e.g. a haiku utility model alongside a 1M-context main model — so the entry matching the detected main model wins, falling back to the largest, then to 200k).
+
 ## Message Storage & Pagination
 
 Messages are stored with a monotonically increasing sequence number per session (see `Message` model in [`prisma/schema.prisma`](../prisma/schema.prisma)). This enables efficient cursor-based pagination.

--- a/src/components/messages/ResultDisplay.tsx
+++ b/src/components/messages/ResultDisplay.tsx
@@ -119,7 +119,7 @@ export function ResultDisplay({ content }: { content: ResultContent }) {
             {label}
           </Badge>
           <span className="text-muted-foreground text-xs">
-            {formatCost(content.total_cost_usd)} · {content.num_turns} turn
+            {formatCost(content.total_cost_usd)} total · {content.num_turns} turn
             {content.num_turns !== 1 ? 's' : ''} · {formatDuration(content.duration_ms)}
           </span>
           <span className="text-muted-foreground ml-auto">{expanded ? '−' : '+'}</span>
@@ -159,8 +159,10 @@ export function ResultDisplay({ content }: { content: ResultContent }) {
                 <span className="text-muted-foreground">API Duration:</span>
                 <span className="ml-2">{formatDuration(content.duration_api_ms)}</span>
               </div>
+              {/* total_cost_usd is cumulative since the query process started,
+                  not the cost of this turn alone */}
               <div>
-                <span className="text-muted-foreground">Cost:</span>
+                <span className="text-muted-foreground">Session cost:</span>
                 <span className="ml-2">{formatCost(content.total_cost_usd)}</span>
               </div>
               <div>
@@ -227,7 +229,7 @@ export function ResultDisplay({ content }: { content: ResultContent }) {
                         )}
                         {usage.costUSD !== undefined && (
                           <div>
-                            <span className="text-muted-foreground">Cost:</span>
+                            <span className="text-muted-foreground">Session cost:</span>
                             <span className="ml-1">{formatCost(usage.costUSD)}</span>
                           </div>
                         )}

--- a/src/lib/token-estimation.test.ts
+++ b/src/lib/token-estimation.test.ts
@@ -237,14 +237,17 @@ describe('token-estimation', () => {
       expect(result.percentUsed).toBeCloseTo(50.25, 1);
     });
 
-    it('should extract usage from modelUsage in result messages', () => {
+    it('should not sum cumulative modelUsage token counts into totals', () => {
+      // modelUsage token counts are cumulative per query process — summing them
+      // across results would double count. Only per-turn `usage` is summed.
       const messages = [
         {
-          type: 'assistant',
+          type: 'result',
           content: {
-            type: 'assistant',
-            message: {
-              usage: { input_tokens: 3000, output_tokens: 500 },
+            type: 'result',
+            usage: { input_tokens: 100, output_tokens: 50 },
+            modelUsage: {
+              'claude-sonnet-4-20250514': { inputTokens: 100, outputTokens: 50 },
             },
           },
         },
@@ -252,14 +255,10 @@ describe('token-estimation', () => {
           type: 'result',
           content: {
             type: 'result',
+            usage: { input_tokens: 200, output_tokens: 100 },
             modelUsage: {
-              'claude-sonnet-4-20250514': {
-                inputTokens: 3000,
-                outputTokens: 1500,
-                cacheReadInputTokens: 200,
-                cacheCreationInputTokens: 100,
-                contextWindow: 200000,
-              },
+              // Cumulative: includes the first turn's tokens
+              'claude-sonnet-4-20250514': { inputTokens: 300, outputTokens: 150 },
             },
           },
         },
@@ -267,10 +266,8 @@ describe('token-estimation', () => {
 
       const result = estimateTokenUsage(messages);
 
-      expect(result.inputTokens).toBe(3000);
-      expect(result.outputTokens).toBe(1500);
-      expect(result.cacheReadTokens).toBe(200);
-      expect(result.cacheCreationTokens).toBe(100);
+      expect(result.inputTokens).toBe(300);
+      expect(result.outputTokens).toBe(150);
     });
 
     it('should detect model from system init message', () => {
@@ -409,6 +406,134 @@ describe('token-estimation', () => {
       expect(result.contextWindow).toBe(150000);
     });
 
+    it('should use context window from modelUsage even when top-level usage is present', () => {
+      // Real result messages always carry both; the context window (e.g. 1M for
+      // [1m] models) must not be ignored just because usage was parsed.
+      const messages = [
+        {
+          type: 'assistant',
+          content: {
+            type: 'assistant',
+            message: {
+              usage: {
+                input_tokens: 250_000,
+                output_tokens: 1_000,
+                cache_read_input_tokens: 50_000,
+              },
+            },
+          },
+        },
+        {
+          type: 'result',
+          content: {
+            type: 'result',
+            usage: { input_tokens: 250_000, output_tokens: 1_000 },
+            modelUsage: {
+              'claude-opus-4-8[1m]': {
+                inputTokens: 250_000,
+                outputTokens: 1_000,
+                contextWindow: 1_000_000,
+              },
+            },
+          },
+        },
+      ];
+
+      const result = estimateTokenUsage(messages);
+
+      expect(result.contextWindow).toBe(1_000_000);
+      // (250k + 1k + 50k) / 1M ≈ 30.1%, not capped at 100%
+      expect(result.percentUsed).toBeCloseTo(30.1, 1);
+    });
+
+    it('should resolve the context window by the main model when modelUsage has several models', () => {
+      const messages = [
+        {
+          type: 'system',
+          content: { type: 'system', subtype: 'init', model: 'claude-sonnet-4-6' },
+        },
+        {
+          type: 'result',
+          content: {
+            type: 'result',
+            usage: { input_tokens: 1000, output_tokens: 500 },
+            modelUsage: {
+              // The main model's window must win even when another entry
+              // (e.g. an advisor or subagent model) reports a larger one.
+              'claude-opus-4-8[1m]': { contextWindow: 1_000_000 },
+              'claude-sonnet-4-6': { contextWindow: 200_000 },
+            },
+          },
+        },
+      ];
+
+      const result = estimateTokenUsage(messages);
+
+      expect(result.contextWindow).toBe(200_000);
+    });
+
+    it('should include cache_creation_input_tokens in context percentage', () => {
+      const messages = [
+        {
+          type: 'assistant',
+          content: {
+            type: 'assistant',
+            message: {
+              usage: {
+                input_tokens: 1000,
+                output_tokens: 500,
+                cache_read_input_tokens: 40_000,
+                cache_creation_input_tokens: 8_500,
+              },
+            },
+          },
+        },
+      ];
+
+      const result = estimateTokenUsage(messages);
+
+      // (1000 + 40000 + 8500 + 500) / 200000 = 25%
+      expect(result.percentUsed).toBeCloseTo(25, 1);
+    });
+
+    it('should skip subagent assistant messages for context percentage', () => {
+      const messages = [
+        {
+          type: 'assistant',
+          content: {
+            type: 'assistant',
+            parent_tool_use_id: null,
+            message: {
+              usage: { input_tokens: 100_000, output_tokens: 1_000 },
+            },
+          },
+        },
+        {
+          type: 'assistant',
+          content: {
+            type: 'assistant',
+            // A subagent message runs in its own, smaller context
+            parent_tool_use_id: 'toolu_abc123',
+            message: {
+              usage: { input_tokens: 5_000, output_tokens: 200 },
+            },
+          },
+        },
+        {
+          type: 'result',
+          content: {
+            type: 'result',
+            usage: { input_tokens: 105_000, output_tokens: 1_200 },
+          },
+        },
+      ];
+
+      const result = estimateTokenUsage(messages);
+
+      // Context % from the last TOP-LEVEL assistant message: (100k + 1k) / 200k
+      expect(result.percentUsed).toBeCloseTo(50.5, 1);
+    });
+
     it('should fall back to total tokens for % when no assistant messages', () => {
       // This shouldn't happen in practice but tests the fallback
       const messages = [
@@ -459,7 +584,9 @@ describe('token-estimation', () => {
       expect(result.totalCostUsd).toBeCloseTo(0.0523, 4);
     });
 
-    it('should sum total_cost_usd from multiple result messages', () => {
+    it('should treat total_cost_usd as cumulative within one query process', () => {
+      // total_cost_usd is cumulative since the query process started, so the
+      // session total is the LAST value, not the sum of all results.
       const messages = [
         {
           type: 'result',
@@ -473,17 +600,70 @@ describe('token-estimation', () => {
           type: 'result',
           content: {
             type: 'result',
-            total_cost_usd: 0.1,
+            total_cost_usd: 0.15,
             usage: { input_tokens: 2000, output_tokens: 1000 },
+          },
+        },
+        {
+          type: 'result',
+          content: {
+            type: 'result',
+            total_cost_usd: 0.35,
+            usage: { input_tokens: 1500, output_tokens: 800 },
           },
         },
       ];
 
       const result = estimateTokenUsage(messages);
 
-      expect(result.totalCostUsd).toBeCloseTo(0.15, 4);
-      expect(result.inputTokens).toBe(3000);
-      expect(result.outputTokens).toBe(1500);
+      expect(result.totalCostUsd).toBeCloseTo(0.35, 4);
+      // Per-turn usage IS summed
+      expect(result.inputTokens).toBe(4500);
+      expect(result.outputTokens).toBe(2300);
+    });
+
+    it('should detect a query-process reset (cost drop) and sum segment totals', () => {
+      // A stop/start or server restart re-establishes the query and resets the
+      // SDK's cumulative counter to zero. The session total is the sum of each
+      // process segment's final cumulative value: 0.5 + 0.2 = 0.7.
+      const messages = [
+        { type: 'result', content: { type: 'result', total_cost_usd: 0.3, usage: {} } },
+        { type: 'result', content: { type: 'result', total_cost_usd: 0.5, usage: {} } },
+        // Query re-established: counter reset
+        { type: 'result', content: { type: 'result', total_cost_usd: 0.1, usage: {} } },
+        { type: 'result', content: { type: 'result', total_cost_usd: 0.2, usage: {} } },
+      ];
+
+      const result = estimateTokenUsage(messages);
+
+      expect(result.totalCostUsd).toBeCloseTo(0.7, 4);
+    });
+
+    it('should handle multiple query-process resets', () => {
+      const messages = [
+        { type: 'result', content: { type: 'result', total_cost_usd: 1.0, usage: {} } },
+        // Reset 1
+        { type: 'result', content: { type: 'result', total_cost_usd: 0.4, usage: {} } },
+        { type: 'result', content: { type: 'result', total_cost_usd: 0.9, usage: {} } },
+        // Reset 2
+        { type: 'result', content: { type: 'result', total_cost_usd: 0.25, usage: {} } },
+      ];
+
+      const result = estimateTokenUsage(messages);
+
+      // 1.0 + 0.9 + 0.25
+      expect(result.totalCostUsd).toBeCloseTo(2.15, 4);
+    });
+
+    it('should not treat an equal cumulative cost as a reset', () => {
+      const messages = [
+        { type: 'result', content: { type: 'result', total_cost_usd: 0.5, usage: {} } },
+        { type: 'result', content: { type: 'result', total_cost_usd: 0.5, usage: {} } },
+      ];
+
+      const result = estimateTokenUsage(messages);
+
+      expect(result.totalCostUsd).toBeCloseTo(0.5, 4);
     });
 
     it('should deduplicate assistant messages with the same id (parallel tool uses)', () => {

--- a/src/lib/token-estimation.ts
+++ b/src/lib/token-estimation.ts
@@ -1,33 +1,35 @@
 /**
  * Token usage estimation utilities
  *
- * Estimates context window usage from Claude Code messages.
+ * Estimates context window usage and total session cost from Claude Code messages.
  *
- * Key insight: The "context usage %" should reflect how full the context window
- * currently is, NOT the total tokens consumed across all API calls. We use the
- * most recent assistant message's input_tokens + cache_read_input_tokens (the full
- * prompt size) plus output_tokens (which will become input in the next call).
+ * SDK result-message semantics (verified empirically against real sessions):
  *
- * Total consumed tokens (summed from result messages) are tracked separately
- * for cost display purposes.
+ * - The top-level `usage` on a result message is PER-TURN — the tokens consumed
+ *   by the turn that just completed. Summing it across result messages is correct.
+ * - `total_cost_usd` and `modelUsage` are CUMULATIVE since the query process
+ *   started. With the persistent per-session query, one process spans many turns,
+ *   so every result repeats (and extends) the totals of the results before it.
+ *   The counters reset to zero when the query is re-established (stop/start,
+ *   server restart) — `resume` does not carry cost forward.
+ *
+ * Cost is therefore aggregated by segmenting the result messages into query
+ * processes and summing the final cumulative value of each segment. Segment
+ * boundaries are detected by the cumulative cost decreasing: it is monotonically
+ * non-decreasing within a process, so a drop means the counter reset.
+ *
+ * The "context usage %" reflects how full the context window currently is, NOT
+ * the total tokens consumed: it uses the most recent top-level (main-agent)
+ * assistant message's prompt size (input + cache read + cache creation) plus its
+ * output tokens (which become input in the next call). Subagent messages are
+ * skipped — they run in their own, smaller context.
  */
 
 import { z } from 'zod';
 
-// Default context window size (200k tokens for Claude models)
-// Claude Code uses context management, so the effective limit may vary
+// Default context window size, used until a result message reports the real one
+// via modelUsage.contextWindow (e.g. 1M for [1m] models).
 const DEFAULT_CONTEXT_WINDOW = 200_000;
-
-// Model-specific context windows (used when we can detect the model from system init)
-const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
-  'claude-opus-4-5-20251101': 200_000,
-  'claude-sonnet-4-20250514': 200_000,
-  'claude-3-5-sonnet-20241022': 200_000,
-  'claude-3-5-sonnet-20240620': 200_000,
-  'claude-3-opus-20240229': 200_000,
-  'claude-3-sonnet-20240229': 200_000,
-  'claude-3-haiku-20240307': 200_000,
-};
 
 /**
  * Structure representing token usage and context window occupancy
@@ -50,27 +52,16 @@ export interface TokenUsageStats {
   /** Detected model name */
   model?: string;
   /**
-   * Authoritative total cost in USD from result messages.
-   * Per the Anthropic Agent SDK docs, total_cost_usd in the result message
-   * is the authoritative cost figure for billing purposes.
+   * Total session cost in USD, aggregated from the authoritative (cumulative
+   * per query process) total_cost_usd on result messages.
    */
   totalCostUsd: number;
 }
 
 /**
- * Zod schema for message usage in assistant messages
+ * Zod schema for the `usage` object on assistant and result messages
  */
 const MessageUsageSchema = z.object({
-  input_tokens: z.number().optional(),
-  output_tokens: z.number().optional(),
-  cache_read_input_tokens: z.number().optional(),
-  cache_creation_input_tokens: z.number().optional(),
-});
-
-/**
- * Zod schema for result usage in result messages
- */
-const ResultUsageSchema = z.object({
   input_tokens: z.number().optional(),
   output_tokens: z.number().optional(),
   cache_read_input_tokens: z.number().optional(),
@@ -91,6 +82,7 @@ const SystemInitSchema = z.object({
  */
 const AssistantContentSchema = z.object({
   type: z.literal('assistant'),
+  parent_tool_use_id: z.string().nullable().optional(),
   message: z.object({
     id: z.string().optional(),
     usage: MessageUsageSchema.optional(),
@@ -99,24 +91,15 @@ const AssistantContentSchema = z.object({
 });
 
 /**
- * Schema for result message content
+ * Schema for result message content. Only contextWindow is read from
+ * modelUsage — its token counts and costUSD are cumulative per query process,
+ * so they must not be summed across results.
  */
 const ResultContentSchema = z.object({
   type: z.literal('result'),
   total_cost_usd: z.number().optional(),
-  usage: ResultUsageSchema.optional(),
-  modelUsage: z
-    .record(
-      z.string(),
-      z.object({
-        inputTokens: z.number().optional(),
-        outputTokens: z.number().optional(),
-        cacheReadInputTokens: z.number().optional(),
-        cacheCreationInputTokens: z.number().optional(),
-        contextWindow: z.number().optional(),
-      })
-    )
-    .optional(),
+  usage: MessageUsageSchema.optional(),
+  modelUsage: z.record(z.string(), z.object({ contextWindow: z.number().optional() })).optional(),
 });
 
 /**
@@ -128,6 +111,22 @@ interface Message {
   content: unknown;
 }
 
+interface ExtractedUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+}
+
+function extractUsageTokens(usage: z.infer<typeof MessageUsageSchema>): ExtractedUsage {
+  return {
+    inputTokens: usage.input_tokens ?? 0,
+    outputTokens: usage.output_tokens ?? 0,
+    cacheReadTokens: usage.cache_read_input_tokens ?? 0,
+    cacheCreationTokens: usage.cache_creation_input_tokens ?? 0,
+  };
+}
+
 /**
  * Extract usage from an assistant message.
  * Returns the message id for deduplication — per the Anthropic docs, multiple
@@ -136,39 +135,30 @@ interface Message {
  */
 function extractAssistantUsage(content: unknown): {
   messageId?: string;
-  inputTokens: number;
-  outputTokens: number;
-  cacheReadTokens: number;
-  cacheCreationTokens: number;
+  usage: ExtractedUsage;
   model?: string;
+  isTopLevel: boolean;
 } | null {
   const parsed = AssistantContentSchema.safeParse(content);
   if (!parsed.success || !parsed.data.message.usage) {
     return null;
   }
 
-  const usage = parsed.data.message.usage;
   return {
     messageId: parsed.data.message.id,
-    inputTokens: usage.input_tokens ?? 0,
-    outputTokens: usage.output_tokens ?? 0,
-    cacheReadTokens: usage.cache_read_input_tokens ?? 0,
-    cacheCreationTokens: usage.cache_creation_input_tokens ?? 0,
+    usage: extractUsageTokens(parsed.data.message.usage),
     model: parsed.data.message.model,
+    isTopLevel: parsed.data.parent_tool_use_id == null,
   };
 }
 
 /**
- * Extract usage from a result message.
- * Per the Anthropic Agent SDK docs, the result message contains authoritative
- * cumulative usage and total_cost_usd for billing purposes.
+ * Extract per-turn usage, the cumulative cost, and the context window from a
+ * result message.
  */
 function extractResultUsage(content: unknown): {
-  inputTokens: number;
-  outputTokens: number;
-  cacheReadTokens: number;
-  cacheCreationTokens: number;
-  contextWindow?: number;
+  usage: ExtractedUsage | null;
+  contextWindowByModel: Record<string, number>;
   totalCostUsd?: number;
 } | null {
   const parsed = ResultContentSchema.safeParse(content);
@@ -176,61 +166,18 @@ function extractResultUsage(content: unknown): {
     return null;
   }
 
-  const totalCostUsd = parsed.data.total_cost_usd;
-
-  // Try to get usage from top-level usage field
-  const usage = parsed.data.usage;
-  if (usage) {
-    return {
-      inputTokens: usage.input_tokens ?? 0,
-      outputTokens: usage.output_tokens ?? 0,
-      cacheReadTokens: usage.cache_read_input_tokens ?? 0,
-      cacheCreationTokens: usage.cache_creation_input_tokens ?? 0,
-      totalCostUsd,
-    };
-  }
-
-  // Try to get usage from modelUsage (aggregated per-model stats)
-  const modelUsage = parsed.data.modelUsage;
-  if (modelUsage) {
-    let inputTokens = 0;
-    let outputTokens = 0;
-    let cacheReadTokens = 0;
-    let cacheCreationTokens = 0;
-    let contextWindow: number | undefined;
-
-    for (const modelStats of Object.values(modelUsage)) {
-      inputTokens += modelStats.inputTokens ?? 0;
-      outputTokens += modelStats.outputTokens ?? 0;
-      cacheReadTokens += modelStats.cacheReadInputTokens ?? 0;
-      cacheCreationTokens += modelStats.cacheCreationInputTokens ?? 0;
-      if (modelStats.contextWindow) {
-        contextWindow = modelStats.contextWindow;
-      }
+  const contextWindowByModel: Record<string, number> = {};
+  for (const [model, modelStats] of Object.entries(parsed.data.modelUsage ?? {})) {
+    if (modelStats.contextWindow) {
+      contextWindowByModel[model] = modelStats.contextWindow;
     }
-
-    return {
-      inputTokens,
-      outputTokens,
-      cacheReadTokens,
-      cacheCreationTokens,
-      contextWindow,
-      totalCostUsd,
-    };
   }
 
-  // If we have a total_cost_usd but no usage breakdown, still return it
-  if (totalCostUsd !== undefined) {
-    return {
-      inputTokens: 0,
-      outputTokens: 0,
-      cacheReadTokens: 0,
-      cacheCreationTokens: 0,
-      totalCostUsd,
-    };
-  }
-
-  return null;
+  return {
+    usage: parsed.data.usage ? extractUsageTokens(parsed.data.usage) : null,
+    contextWindowByModel,
+    totalCostUsd: parsed.data.total_cost_usd,
+  };
 }
 
 /**
@@ -245,51 +192,21 @@ function extractModelFromInit(content: unknown): string | undefined {
 }
 
 /**
- * Get context window size for a model
- */
-function getContextWindow(model?: string): number {
-  if (!model) return DEFAULT_CONTEXT_WINDOW;
-
-  // Try exact match first
-  if (MODEL_CONTEXT_WINDOWS[model]) {
-    return MODEL_CONTEXT_WINDOWS[model];
-  }
-
-  // Try partial match (for versioned model names)
-  for (const [pattern, window] of Object.entries(MODEL_CONTEXT_WINDOWS)) {
-    if (model.includes(pattern.split('-').slice(0, 3).join('-'))) {
-      return window;
-    }
-  }
-
-  return DEFAULT_CONTEXT_WINDOW;
-}
-
-/**
- * Estimate token usage and context window occupancy from a list of messages.
+ * Estimate token usage, session cost, and context window occupancy from a list
+ * of messages. Messages must be in chronological order (oldest first).
  *
- * Messages should be in chronological order (oldest first).
- *
- * Context percentage is based on the most recent assistant message's input_tokens,
- * which represents the actual size of the prompt/context sent in the latest API call.
- * This is the best proxy for how full the context window currently is.
- *
- * Total consumed tokens (inputTokens, outputTokens in the result) are summed from
- * result messages for cost tracking purposes.
+ * See the module docstring for the SDK semantics this relies on.
  */
 export function estimateTokenUsage(messages: Message[]): TokenUsageStats {
   let totalInputTokens = 0;
   let totalOutputTokens = 0;
   let totalCacheReadTokens = 0;
   let totalCacheCreationTokens = 0;
-  let totalCostUsd = 0;
   let detectedModel: string | undefined;
-  let detectedContextWindow: number | undefined;
-
-  // Track the most recent assistant message's input tokens for context % calculation.
-  // input_tokens represents the full prompt size for that API call, which is our
-  // best proxy for current context window occupancy.
-  let lastAssistantInputTokens = 0;
+  // Latest known context window per model, from result modelUsage. A result can
+  // report several models (the main agent plus utility/subagent models), so the
+  // window is resolved against the main model after model detection.
+  const contextWindowByModel: Record<string, number> = {};
 
   // First pass: look for model info in system init
   for (const msg of messages) {
@@ -302,72 +219,84 @@ export function estimateTokenUsage(messages: Message[]): TokenUsageStats {
     }
   }
 
-  // Sum up total consumed tokens and cost from result messages.
-  // Per the Anthropic Agent SDK docs, result messages contain authoritative
-  // cumulative usage and total_cost_usd for billing purposes.
+  // Sum per-turn usage across result messages, and aggregate the cumulative
+  // total_cost_usd by process segment: within one query process the value is
+  // monotonically non-decreasing, so a drop marks a re-established query whose
+  // counter reset. The session total is the sum of each segment's final value.
   const resultMessages = messages.filter((m) => m.type === 'result');
+  let closedSegmentsCost = 0;
+  let currentSegmentCost = 0;
   for (const resultMsg of resultMessages) {
-    const usage = extractResultUsage(resultMsg.content);
-    if (usage) {
-      totalInputTokens += usage.inputTokens;
-      totalOutputTokens += usage.outputTokens;
-      totalCacheReadTokens += usage.cacheReadTokens;
-      totalCacheCreationTokens += usage.cacheCreationTokens;
-      if (usage.contextWindow) {
-        detectedContextWindow = usage.contextWindow;
+    const extracted = extractResultUsage(resultMsg.content);
+    if (!extracted) {
+      continue;
+    }
+    if (extracted.usage) {
+      totalInputTokens += extracted.usage.inputTokens;
+      totalOutputTokens += extracted.usage.outputTokens;
+      totalCacheReadTokens += extracted.usage.cacheReadTokens;
+      totalCacheCreationTokens += extracted.usage.cacheCreationTokens;
+    }
+    Object.assign(contextWindowByModel, extracted.contextWindowByModel);
+    if (extracted.totalCostUsd !== undefined) {
+      if (extracted.totalCostUsd < currentSegmentCost) {
+        closedSegmentsCost += currentSegmentCost;
       }
-      if (usage.totalCostUsd !== undefined) {
-        totalCostUsd += usage.totalCostUsd;
-      }
+      currentSegmentCost = extracted.totalCostUsd;
     }
   }
+  const totalCostUsd = closedSegmentsCost + currentSegmentCost;
 
-  // Find the most recent assistant message to determine current context occupancy.
-  // We iterate in reverse to find it efficiently.
+  // Find the most recent top-level (main-agent) assistant message to determine
+  // current context occupancy. Subagent messages (parent_tool_use_id set) run
+  // in their own context and would misreport the main conversation's size.
+  let lastAssistantContextTokens = 0;
   for (let i = messages.length - 1; i >= 0; i--) {
     const msg = messages[i];
-    if (msg.type === 'assistant') {
-      const usage = extractAssistantUsage(msg.content);
-      if (usage) {
-        // input_tokens from the Anthropic API represents non-cached input tokens.
-        // cache_read_input_tokens are tokens read from cache.
-        // output_tokens will become part of the input in the next API call.
-        // Together they represent the current context window occupancy.
-        lastAssistantInputTokens = usage.inputTokens + usage.cacheReadTokens + usage.outputTokens;
-        if (usage.model && !detectedModel) {
-          detectedModel = usage.model;
-        }
-        break;
-      }
+    if (msg.type !== 'assistant') {
+      continue;
     }
+    const extracted = extractAssistantUsage(msg.content);
+    if (!extracted || !extracted.isTopLevel) {
+      continue;
+    }
+    // The prompt of the latest API call is input + cache read + cache creation
+    // (newly cached tokens are part of the prompt too); output tokens become
+    // input in the next call. Together they are the current occupancy.
+    const { usage } = extracted;
+    lastAssistantContextTokens =
+      usage.inputTokens + usage.cacheReadTokens + usage.cacheCreationTokens + usage.outputTokens;
+    if (extracted.model && !detectedModel) {
+      detectedModel = extracted.model;
+    }
+    break;
   }
 
-  // If we have no result messages yet, sum assistant messages for total consumed tokens.
-  // Per the Anthropic Agent SDK docs, multiple assistant messages in the same step
-  // share the same message id and identical usage. We deduplicate by message id
-  // to avoid double-counting.
+  // If we have no result messages yet (mid-first-turn), sum assistant messages
+  // for total consumed tokens. Multiple assistant messages in the same step
+  // share the same message id and identical usage, so deduplicate by id.
   if (resultMessages.length === 0) {
     const processedMessageIds = new Set<string>();
     for (const msg of messages) {
-      if (msg.type === 'assistant') {
-        const usage = extractAssistantUsage(msg.content);
-        if (usage) {
-          // Skip if we've already processed this message ID (parallel tool uses
-          // share the same id and usage per Anthropic docs)
-          if (usage.messageId) {
-            if (processedMessageIds.has(usage.messageId)) {
-              continue;
-            }
-            processedMessageIds.add(usage.messageId);
-          }
-          totalInputTokens += usage.inputTokens;
-          totalOutputTokens += usage.outputTokens;
-          totalCacheReadTokens += usage.cacheReadTokens;
-          totalCacheCreationTokens += usage.cacheCreationTokens;
-          if (usage.model && !detectedModel) {
-            detectedModel = usage.model;
-          }
+      if (msg.type !== 'assistant') {
+        continue;
+      }
+      const extracted = extractAssistantUsage(msg.content);
+      if (!extracted) {
+        continue;
+      }
+      if (extracted.messageId) {
+        if (processedMessageIds.has(extracted.messageId)) {
+          continue;
         }
+        processedMessageIds.add(extracted.messageId);
+      }
+      totalInputTokens += extracted.usage.inputTokens;
+      totalOutputTokens += extracted.usage.outputTokens;
+      totalCacheReadTokens += extracted.usage.cacheReadTokens;
+      totalCacheCreationTokens += extracted.usage.cacheCreationTokens;
+      if (extracted.model && !detectedModel) {
+        detectedModel = extracted.model;
       }
     }
   }
@@ -375,14 +304,18 @@ export function estimateTokenUsage(messages: Message[]): TokenUsageStats {
   // Calculate total tokens consumed (for cost/display)
   const totalTokens = totalInputTokens + totalOutputTokens;
 
-  // Determine context window capacity
-  const contextWindow = detectedContextWindow ?? getContextWindow(detectedModel);
+  // Resolve the context window: the main model's reported window, falling back
+  // to the largest reported one (the main model dwarfs the utility models), then
+  // the default.
+  const knownWindows = Object.values(contextWindowByModel);
+  const contextWindow =
+    (detectedModel ? contextWindowByModel[detectedModel] : undefined) ??
+    (knownWindows.length > 0 ? Math.max(...knownWindows) : DEFAULT_CONTEXT_WINDOW);
 
   // Calculate percentage of context window currently used.
-  // Use the most recent assistant message's prompt size as the indicator.
   // Fall back to total tokens if no assistant messages found (shouldn't happen in practice).
   const currentContextTokens =
-    lastAssistantInputTokens > 0 ? lastAssistantInputTokens : totalTokens;
+    lastAssistantContextTokens > 0 ? lastAssistantContextTokens : totalTokens;
   const percentUsed = contextWindow > 0 ? (currentContextTokens / contextWindow) * 100 : 0;
 
   return {

--- a/src/server/routers/claude.ts
+++ b/src/server/routers/claude.ts
@@ -266,30 +266,29 @@ export const claudeRouter = router({
         });
       }
 
-      const [resultAndSystemMessages, lastAssistantMessage] = await Promise.all([
+      // The context-% calculation needs the latest top-level (main-agent)
+      // assistant message; subagent messages (parent_tool_use_id set) run in
+      // their own context and would misreport the main conversation's size.
+      const [resultAndSystemMessages, lastTopLevelAssistant] = await Promise.all([
         prisma.message.findMany({
           where: {
             sessionId: input.sessionId,
             type: { in: ['result', 'system'] },
           },
-          select: { type: true, content: true, sequence: true },
+          select: { type: true, content: true },
           orderBy: { sequence: 'asc' },
         }),
-        prisma.message.findFirst({
-          where: {
-            sessionId: input.sessionId,
-            type: 'assistant',
-          },
-          select: { type: true, content: true, sequence: true },
-          orderBy: { sequence: 'desc' },
-        }),
+        prisma.$queryRaw<{ type: string; content: string }[]>`
+          SELECT type, content FROM Message
+          WHERE sessionId = ${input.sessionId}
+            AND type = 'assistant'
+            AND json_extract(content, '$.parent_tool_use_id') IS NULL
+          ORDER BY sequence DESC
+          LIMIT 1
+        `,
       ]);
 
-      const allMessages = [...resultAndSystemMessages];
-      if (lastAssistantMessage) {
-        allMessages.push(lastAssistantMessage);
-      }
-      allMessages.sort((a, b) => a.sequence - b.sequence);
+      const allMessages = [...resultAndSystemMessages, ...lastTopLevelAssistant];
 
       const parsedMessages = allMessages.map((m) => ({
         type: m.type,


### PR DESCRIPTION
## Problem

`estimateTokenUsage` summed `total_cost_usd` across every result message, but that field is **cumulative since the query process started** — each result repeats and extends the totals of the results before it. Under the persistent-query model one process spans many turns, so the displayed cost overcounted roughly quadratically with turn count. Verified against the production DB: a session that actually cost **\$48.38** displayed as **\$205.16**.

Empirically verified semantics (real sessions + SDK docs):

| Field on `result` | Scope |
|---|---|
| top-level `usage` | per-turn |
| `total_cost_usd`, `modelUsage` | cumulative per query process; resets to 0 on re-establish (stop/start, server restart); `resume` does **not** carry cost forward |

The smoking gun from an old session: a result with per-turn `usage.output_tokens = 1158` whose `modelUsage.outputTokens = 15081` = previous result's 13923 + 1158.

## Fixes

- **Cost**: aggregate by process segment. Cumulative cost is monotonically non-decreasing within a process, so a drop marks a reset; session total = sum of each segment's final value. (Answering "does cost drop to \$0 after stop/start?": the SDK counter resets, but history segments are preserved, so the displayed total keeps prior processes.)
- **modelUsage tokens no longer summed** (also cumulative — same double-count).
- **Context window**: `modelUsage.contextWindow` was dead code behind an early return, so 1M-context sessions (`[1m]` models) were measured against the 200k default and pegged at 100%. Now always read, resolved by the main model when several models appear (haiku utility model alongside the main model), falling back to the largest. Deleted the stale hardcoded model→window table.
- **Context %** now includes `cache_creation_input_tokens` (newly cached tokens are part of the prompt) and skips subagent assistant messages (`parent_tool_use_id` set), which run in their own smaller context — both in the estimator and in the `getTokenUsage` DB query (`json_extract` filter).
- **ResultDisplay** labels the value as session cost since it isn't the turn's own cost.

## Validation on production data

| Session | Old (summed) | Fixed | Context window |
|---|---|---|---|
| f54d3994 | $205.16 | **$48.38** (matches last cumulative, single process) | 200k → **1M**, 100% → 27.3% |
| 1b732d42 | $816.28 | **$551.27** (many process segments) | 200k → **1M** |
| c167cafc | $24.60 | **$15.56** | 200k → **1M** |

Known limitation (documented in DESIGN.md): a reset is masked if a new process's first turn costs more than the entire previous process — the total then undercounts by that previous segment. Acceptable for an indicator; the alternative is persisting per-turn deltas at write time in the runner, which we can do later if this matters.

Tests: 34 unit tests pass (7 new/rewritten). The full suite has one pre-existing, environment-specific failure (`claude-runner.test.ts` asserts `CLAUDE_CODE_OAUTH_TOKEN` is undefined, which fails on machines that export it) — unrelated to this change and failing on `main` in my environment too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)