### PR TITLE
Make buildAgentEnv tests hermetic via pure mergeAgentEnv

### DIFF
--- a/src/server/services/claude-runner.test.ts
+++ b/src/server/services/claude-runner.test.ts
@@ -42,7 +42,7 @@ vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
 }));
 
 import {
-  buildAgentEnv,
+  mergeAgentEnv,
   getBaseEnv,
   resetBaseEnvCache,
   mergeSlashCommands,
@@ -96,27 +96,17 @@ describe('claude-runner', () => {
     });
   });
 
-  describe('buildAgentEnv', () => {
-    beforeEach(() => {
-      resetBaseEnvCache();
+  describe('mergeAgentEnv', () => {
+    const baseEnv = { PATH: '/usr/bin:/bin', HOME: '/home/user' };
+
+    it('should include base env vars', () => {
+      const env = mergeAgentEnv(baseEnv, []);
+      expect(env.PATH).toBe('/usr/bin:/bin');
+      expect(env.HOME).toBe('/home/user');
     });
 
-    it('should include base env vars from login shell', async () => {
-      const env = await buildAgentEnv([]);
-      // Should have standard shell vars
-      expect(env.PATH).toBeDefined();
-      expect(env.HOME).toBeDefined();
-    });
-
-    it('should not include server-only env vars', async () => {
-      const env = await buildAgentEnv([]);
-      expect(env.PASSWORD_HASH).toBeUndefined();
-      expect(env.ENCRYPTION_KEY).toBeUndefined();
-      expect(env.DATABASE_URL).toBeUndefined();
-    });
-
-    it('should overlay user-configured env vars', async () => {
-      const env = await buildAgentEnv([
+    it('should overlay user-configured env vars', () => {
+      const env = mergeAgentEnv(baseEnv, [
         { name: 'MY_API_KEY', value: 'key-123' },
         { name: 'MY_SECRET', value: 'decrypted-secret' },
       ]);
@@ -124,30 +114,42 @@ describe('claude-runner', () => {
       expect(env.MY_SECRET).toBe('decrypted-secret');
     });
 
-    it('should allow user env vars to override base env vars', async () => {
-      const env = await buildAgentEnv([{ name: 'HOME', value: '/custom/home' }]);
+    it('should allow user env vars to override base env vars', () => {
+      const env = mergeAgentEnv(baseEnv, [{ name: 'HOME', value: '/custom/home' }]);
       expect(env.HOME).toBe('/custom/home');
     });
 
-    it('should set CLAUDE_CODE_OAUTH_TOKEN when claudeApiKey is provided', async () => {
-      const env = await buildAgentEnv([], 'custom-api-key');
+    it('should set CLAUDE_CODE_OAUTH_TOKEN when claudeApiKey is provided', () => {
+      const env = mergeAgentEnv(baseEnv, [], 'custom-api-key');
       expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe('custom-api-key');
     });
 
-    it('should not set CLAUDE_CODE_OAUTH_TOKEN when claudeApiKey is null', async () => {
-      const env = await buildAgentEnv([], null);
-      // Should not have CLAUDE_CODE_OAUTH_TOKEN from the server process
-      // (it wouldn't be in a clean login shell either)
+    it('should not add CLAUDE_CODE_OAUTH_TOKEN when claudeApiKey is null', () => {
+      const env = mergeAgentEnv(baseEnv, [], null);
       expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
     });
 
-    it('should allow per-repo env var to override claudeApiKey', async () => {
-      const env = await buildAgentEnv(
+    it('should pass through a shell-provided CLAUDE_CODE_OAUTH_TOKEN when claudeApiKey is null', () => {
+      // Configuring the token via the login shell (~/.bashrc) is supported;
+      // the merge must not strip it just because no claudeApiKey is set.
+      const env = mergeAgentEnv({ ...baseEnv, CLAUDE_CODE_OAUTH_TOKEN: 'shell-token' }, [], null);
+      expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe('shell-token');
+    });
+
+    it('should allow per-repo env var to override claudeApiKey', () => {
+      const env = mergeAgentEnv(
+        baseEnv,
         [{ name: 'CLAUDE_CODE_OAUTH_TOKEN', value: 'per-repo-key' }],
         'global-api-key'
       );
       // Per-repo env var should take precedence over global API key
       expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe('per-repo-key');
+    });
+
+    it('should not mutate the base env', () => {
+      const input = { ...baseEnv };
+      mergeAgentEnv(input, [{ name: 'HOME', value: '/custom/home' }], 'key');
+      expect(input).toEqual(baseEnv);
     });
   });
 

--- a/src/server/services/claude-runner.ts
+++ b/src/server/services/claude-runner.ts
@@ -386,16 +386,17 @@ export function _clearPersistedCommands(sessionId: string): void {
 }
 
 /**
- * Build the environment variables to pass to the Claude SDK.
- *
- * Starts with a fresh login shell's environment, then overlays the global Claude
- * API key and finally the user-configured env vars (highest precedence).
+ * Merge the agent environment from its three sources, lowest to highest
+ * precedence: the base (login shell) env, the global Claude API key, and the
+ * user-configured env vars. Never removes vars from the base env — a
+ * CLAUDE_CODE_OAUTH_TOKEN exported by the login shell passes through when no
+ * claudeApiKey is configured.
  */
-export async function buildAgentEnv(
+export function mergeAgentEnv(
+  baseEnv: Record<string, string>,
   userEnvVars: ContainerEnvVar[],
   claudeApiKey?: string | null
-): Promise<Record<string, string | undefined>> {
-  const baseEnv = await getBaseEnv();
+): Record<string, string | undefined> {
   const agentEnv: Record<string, string | undefined> = { ...baseEnv };
 
   if (claudeApiKey) {
@@ -407,6 +408,17 @@ export async function buildAgentEnv(
   }
 
   return agentEnv;
+}
+
+/**
+ * Build the environment variables to pass to the Claude SDK: a fresh login
+ * shell's environment merged with the configured overrides (see mergeAgentEnv).
+ */
+async function buildAgentEnv(
+  userEnvVars: ContainerEnvVar[],
+  claudeApiKey?: string | null
+): Promise<Record<string, string | undefined>> {
+  return mergeAgentEnv(await getBaseEnv(), userEnvVars, claudeApiKey);
 }
 
 /** Convert merged MCP server settings into the SDK's record shape. */


### PR DESCRIPTION
## Summary
- Fixes #373: the `buildAgentEnv` unit tests spawned a real login shell, so they asserted on the host's dotfiles — on a machine whose profile exports `CLAUDE_CODE_OAUTH_TOKEN`, the "not set when claudeApiKey is null" test failed.
- Factors the merge logic into a pure `mergeAgentEnv(baseEnv, userEnvVars, claudeApiKey)` and rewrites the whole test block against a fake base env, so the tests no longer depend on the machine they run on.
- `buildAgentEnv` becomes a private thin wrapper (`mergeAgentEnv(await getBaseEnv(), …)`) — runtime behavior is unchanged.
- Deliberately does **not** take the issue's alternative suggestion of stripping a shell-provided token: configuring env vars via `~/.bashrc` is intentional, and there's now an explicit test that a login-shell `CLAUDE_CODE_OAUTH_TOKEN` passes through when no `claudeApiKey` is configured.

## Test plan
- [x] `pnpm test:run` — 554 tests pass
- [x] `tsc --noEmit` and eslint clean

Closes #373

🤖 Generated with [Claude Code](https://claude.com/claude-code)