### PR TITLE
Add Dependabot config with 7-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    # Wait 7 days for other people to find security problems
+    # https://daniakash.com/posts/simplest-supply-chain-defense/
+    cooldown:
+      default-days: 7
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Enables weekly Dependabot version updates for the two ecosystems this repo uses — **npm** and **github-actions** — each with a **7-day `cooldown`**.

The cooldown waits a week before proposing a new release, so someone else has a chance to surface supply-chain issues first ([rationale](https://daniakash.com/posts/simplest-supply-chain-defense/)). This matches the policy already used in `lion-reader` and `brendanlong.com`.

No Docker ecosystem — this repo has no Dockerfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)