### PR TITLE
Add inline session renaming from the header title

### DIFF
--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -153,6 +153,11 @@ sessions.start({ sessionId: string })
   → { session: Session }
   // Marks session as running (workspace already exists on disk)
 
+sessions.rename({ sessionId: string, name: string })
+  → { session: Session }
+  // Renames a session (updates the display name only). The id, workspace, and
+  // lastActivityAt are untouched — renaming does not reorder the session list.
+
 sessions.stop({ sessionId: string })
   → { session: Session }
   // Stops any running Claude query, marks session as stopped
@@ -654,6 +659,7 @@ Voice mode provides speech-to-text input and text-to-speech output for hands-fre
 - Tool calls rendered with expandable input/output
 - Status indicator (running, waiting, stopped)
 - Session info in header (repo, branch)
+- Editable session title in header: click the name to rename inline (Enter saves, Escape cancels) via `sessions.rename` — see `EditableSessionName`
 
 ## File Structure
 

--- a/src/app/session/[id]/page.tsx
+++ b/src/app/session/[id]/page.tsx
@@ -32,6 +32,7 @@ function SessionView({ sessionId }: { sessionId: string }) {
     start,
     stop,
     archive,
+    rename,
     isStarting,
     isStopping,
     isArchiving,
@@ -256,6 +257,7 @@ function SessionView({ sessionId }: { sessionId: string }) {
           onStart={start}
           onStop={stop}
           onArchive={archive}
+          onRename={rename}
           isStarting={isStarting}
           isStopping={isStopping}
           isArchiving={isArchiving}

--- a/src/components/EditableSessionName.test.tsx
+++ b/src/components/EditableSessionName.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { EditableSessionName } from './EditableSessionName';
+
+describe('EditableSessionName', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the name as a heading by default', () => {
+    render(<EditableSessionName name="My Session" onRename={vi.fn()} />);
+    expect(screen.getByRole('heading', { name: 'My Session' })).toBeInTheDocument();
+  });
+
+  it('switches to an input when the name is clicked', async () => {
+    const user = userEvent.setup();
+    render(<EditableSessionName name="My Session" onRename={vi.fn()} />);
+
+    await user.click(screen.getByRole('heading', { name: 'My Session' }));
+
+    const input = screen.getByRole('textbox', { name: 'Session name' });
+    expect(input).toHaveValue('My Session');
+  });
+
+  it('calls onRename with the trimmed new name on Enter', async () => {
+    const user = userEvent.setup();
+    const onRename = vi.fn();
+    render(<EditableSessionName name="Old" onRename={onRename} />);
+
+    await user.click(screen.getByRole('heading', { name: 'Old' }));
+    const input = screen.getByRole('textbox', { name: 'Session name' });
+    await user.clear(input);
+    await user.type(input, '  New Name  {Enter}');
+
+    expect(onRename).toHaveBeenCalledExactlyOnceWith('New Name');
+    // Exits edit mode; the displayed name is controlled by the parent via the
+    // `name` prop, so it still reads "Old" until the parent updates it.
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Old' })).toBeInTheDocument();
+  });
+
+  it('does not call onRename when the name is unchanged', async () => {
+    const user = userEvent.setup();
+    const onRename = vi.fn();
+    render(<EditableSessionName name="Same" onRename={onRename} />);
+
+    await user.click(screen.getByRole('heading', { name: 'Same' }));
+    await user.type(screen.getByRole('textbox', { name: 'Session name' }), '{Enter}');
+
+    expect(onRename).not.toHaveBeenCalled();
+  });
+
+  it('does not call onRename when the name is emptied', async () => {
+    const user = userEvent.setup();
+    const onRename = vi.fn();
+    render(<EditableSessionName name="Something" onRename={onRename} />);
+
+    await user.click(screen.getByRole('heading', { name: 'Something' }));
+    const input = screen.getByRole('textbox', { name: 'Session name' });
+    await user.clear(input);
+    await user.type(input, '{Enter}');
+
+    expect(onRename).not.toHaveBeenCalled();
+  });
+
+  it('cancels editing on Escape without calling onRename', async () => {
+    const user = userEvent.setup();
+    const onRename = vi.fn();
+    render(<EditableSessionName name="Original" onRename={onRename} />);
+
+    await user.click(screen.getByRole('heading', { name: 'Original' }));
+    const input = screen.getByRole('textbox', { name: 'Session name' });
+    await user.clear(input);
+    await user.type(input, 'Discarded{Escape}');
+
+    expect(onRename).not.toHaveBeenCalled();
+    expect(screen.getByRole('heading', { name: 'Original' })).toBeInTheDocument();
+  });
+
+  it('does not enter edit mode when disabled', async () => {
+    const user = userEvent.setup();
+    render(<EditableSessionName name="Locked" onRename={vi.fn()} disabled />);
+
+    await user.click(screen.getByRole('heading', { name: 'Locked' }));
+
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/EditableSessionName.tsx
+++ b/src/components/EditableSessionName.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { SESSION_NAME_MAX_LENGTH } from '@/lib/types';
+import { cn } from '@/lib/utils';
+
+interface EditableSessionNameProps {
+  name: string;
+  onRename: (name: string) => void;
+  /** Whether editing is allowed (e.g. disabled for archived sessions). */
+  disabled?: boolean;
+  className?: string;
+}
+
+/**
+ * Displays a session name that can be renamed inline: click the title to edit,
+ * Enter to save, Escape to cancel. Renaming never touches the session id.
+ */
+export function EditableSessionName({
+  name,
+  onRename,
+  disabled = false,
+  className,
+}: EditableSessionNameProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [value, setValue] = useState(name);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // `value` is the edit draft, seeded from `name` each time editing begins
+  // (see startEditing), so it needs no effect to stay in sync with the prop.
+  useEffect(() => {
+    if (isEditing) {
+      inputRef.current?.select();
+    }
+  }, [isEditing]);
+
+  const startEditing = () => {
+    if (disabled) return;
+    setValue(name);
+    setIsEditing(true);
+  };
+
+  const commit = () => {
+    setIsEditing(false);
+    const trimmed = value.trim();
+    if (trimmed && trimmed !== name) {
+      onRename(trimmed);
+    }
+  };
+
+  const cancel = () => {
+    setValue(name);
+    setIsEditing(false);
+  };
+
+  if (isEditing) {
+    return (
+      <Input
+        ref={inputRef}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault();
+            commit();
+          } else if (e.key === 'Escape') {
+            e.preventDefault();
+            cancel();
+          }
+        }}
+        maxLength={SESSION_NAME_MAX_LENGTH}
+        aria-label="Session name"
+        className={cn('h-auto py-0.5 font-semibold', className)}
+      />
+    );
+  }
+
+  return (
+    <h1
+      className={cn(
+        'font-semibold break-words',
+        !disabled && 'cursor-text rounded hover:bg-muted/50',
+        className
+      )}
+      onClick={startEditing}
+      title={disabled ? undefined : 'Click to rename'}
+    >
+      {name}
+    </h1>
+  );
+}

--- a/src/components/SessionHeader.tsx
+++ b/src/components/SessionHeader.tsx
@@ -5,6 +5,7 @@ import { Mic } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { SessionStatusToggle } from '@/components/SessionStatusToggle';
 import { SessionActionButton } from '@/components/SessionActionButton';
+import { EditableSessionName } from '@/components/EditableSessionName';
 import { VoiceAutoReadToggle } from '@/components/voice/VoiceAutoReadToggle';
 
 interface SessionHeaderProps {
@@ -20,6 +21,7 @@ interface SessionHeaderProps {
   onStart: () => void;
   onStop: () => void;
   onArchive?: () => void;
+  onRename?: (name: string) => void;
   isStarting: boolean;
   isStopping: boolean;
   isArchiving?: boolean;
@@ -35,6 +37,7 @@ export function SessionHeader({
   onStart,
   onStop,
   onArchive,
+  onRename,
   isStarting,
   isStopping,
   isArchiving = false,
@@ -65,7 +68,11 @@ export function SessionHeader({
             </Link>
           </Button>
           <div className="min-w-0">
-            <h1 className="font-semibold break-words">{session.name}</h1>
+            {onRename ? (
+              <EditableSessionName name={session.name} onRename={onRename} />
+            ) : (
+              <h1 className="font-semibold break-words">{session.name}</h1>
+            )}
             {repoName && <p className="text-sm text-muted-foreground truncate">{repoName}</p>}
           </div>
         </div>

--- a/src/hooks/useSessionState.ts
+++ b/src/hooks/useSessionState.ts
@@ -31,6 +31,12 @@ export function useSessionState(sessionId: string) {
     },
   });
 
+  const renameMutation = trpc.sessions.rename.useMutation({
+    onSuccess: (data) => {
+      utils.sessions.get.setData({ sessionId }, { session: data.session });
+    },
+  });
+
   // The API endpoint is "delete" but it now archives instead of permanently deleting
   const archiveMutation = trpc.sessions.delete.useMutation({
     onSuccess: () => {
@@ -51,12 +57,20 @@ export function useSessionState(sessionId: string) {
     archiveMutation.mutate({ sessionId });
   }, [sessionId, archiveMutation]);
 
+  const rename = useCallback(
+    (name: string) => {
+      renameMutation.mutate({ sessionId, name });
+    },
+    [sessionId, renameMutation]
+  );
+
   return {
     session: sessionData?.session,
     isLoading,
     start,
     stop,
     archive,
+    rename,
     isStarting: startMutation.isPending,
     isStopping: stopMutation.isPending,
     isArchiving: archiveMutation.isPending,

--- a/src/server/routers/sessions.integration.test.ts
+++ b/src/server/routers/sessions.integration.test.ts
@@ -510,6 +510,104 @@ describe('sessionsRouter integration', () => {
     });
   });
 
+  describe('rename', () => {
+    it('should update the session name without changing the id', async () => {
+      const session = await testPrisma.session.create({
+        data: {
+          name: 'Old Name',
+          repoUrl: 'https://github.com/owner/repo.git',
+          branch: 'main',
+          workspacePath: '/workspace/test',
+          status: 'running',
+        },
+      });
+
+      const caller = createCaller('auth-session-id');
+      const result = await caller.sessions.rename({ sessionId: session.id, name: 'New Name' });
+
+      expect(result.session.id).toBe(session.id);
+      expect(result.session.name).toBe('New Name');
+
+      const dbSession = await testPrisma.session.findUnique({ where: { id: session.id } });
+      expect(dbSession!.name).toBe('New Name');
+      expect(dbSession!.id).toBe(session.id);
+    });
+
+    it('should trim whitespace from the new name', async () => {
+      const session = await testPrisma.session.create({
+        data: {
+          name: 'Old Name',
+          workspacePath: '/workspace/test',
+          status: 'running',
+        },
+      });
+
+      const caller = createCaller('auth-session-id');
+      const result = await caller.sessions.rename({
+        sessionId: session.id,
+        name: '  Trimmed Name  ',
+      });
+
+      expect(result.session.name).toBe('Trimmed Name');
+    });
+
+    it('should reject an empty name', async () => {
+      const session = await testPrisma.session.create({
+        data: {
+          name: 'Old Name',
+          workspacePath: '/workspace/test',
+          status: 'running',
+        },
+      });
+
+      const caller = createCaller('auth-session-id');
+      await expect(
+        caller.sessions.rename({ sessionId: session.id, name: '   ' })
+      ).rejects.toThrow();
+    });
+
+    it('should emit a session update event', async () => {
+      const session = await testPrisma.session.create({
+        data: {
+          name: 'Old Name',
+          workspacePath: '/workspace/test',
+          status: 'running',
+        },
+      });
+
+      mockSseEvents.emitSessionUpdate.mockClear();
+      const caller = createCaller('auth-session-id');
+      await caller.sessions.rename({ sessionId: session.id, name: 'New Name' });
+
+      expect(mockSseEvents.emitSessionUpdate).toHaveBeenCalledWith(
+        session.id,
+        expect.objectContaining({ name: 'New Name' })
+      );
+    });
+
+    it('should throw NOT_FOUND for non-existent session', async () => {
+      const caller = createCaller('auth-session-id');
+
+      await expect(
+        caller.sessions.rename({
+          sessionId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+          name: 'New Name',
+        })
+      ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    });
+
+    it('should require authentication', async () => {
+      const caller = createCaller(null);
+
+      await expect(
+        caller.sessions.rename({
+          sessionId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+          name: 'New Name',
+        })
+      ).rejects.toThrow();
+    });
+  });
+
   describe('delete (archive)', () => {
     it('should archive a session and clean up resources but keep messages', async () => {
       const session = await testPrisma.session.create({

--- a/src/server/routers/sessions.ts
+++ b/src/server/routers/sessions.ts
@@ -221,6 +221,37 @@ export const sessionsRouter = router({
       return { session: updatedSession };
     }),
 
+  rename: protectedProcedure
+    .input(
+      z.object({
+        sessionId: z.string().uuid(),
+        name: z.string().trim().min(1).max(SESSION_NAME_MAX_LENGTH),
+      })
+    )
+    .mutation(async ({ input }) => {
+      const session = await prisma.session.findUnique({
+        where: { id: input.sessionId },
+      });
+
+      if (!session) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Session not found',
+        });
+      }
+
+      // Renaming only changes the display name; the session id and workspace
+      // are untouched. lastActivityAt is deliberately not bumped so renaming
+      // doesn't reorder the session list.
+      const updatedSession = await prisma.session.update({
+        where: { id: session.id },
+        data: { name: input.name },
+      });
+
+      sseEvents.emitSessionUpdate(input.sessionId, updatedSession);
+      return { session: updatedSession };
+    }),
+
   stop: protectedProcedure
     .input(z.object({ sessionId: z.string().uuid() }))
     .mutation(async ({ input }) => {


### PR DESCRIPTION
Closes #63

## What

Adds the ability to rename a session by clicking its title in the session header, typing a new name, and pressing Enter. The session id (and workspace) are never touched.

## Behavior

- Click the title → it becomes an inline input, pre-filled and text-selected
- **Enter** (or blur) saves; **Escape** cancels
- Empty/whitespace-only or unchanged names are ignored (no-op)
- Renaming updates only the display name — `lastActivityAt` is deliberately **not** bumped, so renaming doesn't reorder the session list
- The change streams live to the home list and the session page via the existing `emitSessionUpdate` SSE fan-out

## Changes

- **`sessions.rename` tRPC mutation** — Zod-validated (`trim().min(1).max(SESSION_NAME_MAX_LENGTH)`), updates the DB, emits a session update event
- **`EditableSessionName`** — reusable inline-edit component, wired into `SessionHeader` (read-only headers for archived/creating sessions don't receive `onRename`)
- **`rename()`** exposed from `useSessionState`, optimistically updating the `sessions.get` cache
- Updated `doc/DESIGN.md` (API + Session View)

## Tests

- Integration tests for the `rename` mutation (updates name / preserves id, trims, rejects empty, emits event, NOT_FOUND, auth)
- Component tests for `EditableSessionName` (click-to-edit, Enter/Escape, no-op on unchanged/empty, disabled)

All unit, component, and integration suites pass; lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)