### PR TITLE
Assign message sequence numbers atomically (fixes #356)

### DIFF
--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -446,6 +446,12 @@ Context % reflects how full the window currently is, **not** total consumption: 
 
 Messages are stored with a monotonically increasing sequence number per session (see `Message` model in [`prisma/schema.prisma`](../prisma/schema.prisma)). This enables efficient cursor-based pagination.
 
+### Atomic Sequence Assignment
+
+Every insert site funnels through the single `insertMessage` helper in [`claude-runner.ts`](../src/server/services/claude-runner.ts), which assigns `sequence` **atomically** rather than with a race-prone read-then-insert. Each `Session` carries a `messageSequence` counter (the next sequence to assign); `insertMessage` reserves a value with one autocommit statement — `UPDATE "Session" SET "messageSequence" = "messageSequence" + 1 ... RETURNING "messageSequence"` — then inserts the message at `messageSequence - 1`. Because it is a single statement, SQLite serializes it on the write lock, so two concurrent inserts for the same session (e.g. two browser tabs, or an answer racing a `send` — both `runClaudeCommand` paths fire un-awaited) always get distinct sequences and can never collide on `@@unique([sessionId, sequence])`. There is no retry loop and no interactive transaction (on SQLite's single-writer model, many concurrent interactive transactions contend on the write lock and deadlock/time out; a single statement cannot).
+
+A duplicate `id` (the same message inserted twice — e.g. an idempotent synthetic `tool_result`, whose id is deterministic) makes the `message.create` fail on the primary key; `insertMessage` treats that as a no-op (`inserted: false`). The reserved sequence is then skipped, leaving a harmless gap — pagination orders by `sequence` and never assumes contiguity.
+
 ### Pagination Queries
 
 **Load recent (initial view):**

--- a/prisma/migrations/20260705000000_add_message_sequence_to_session/migration.sql
+++ b/prisma/migrations/20260705000000_add_message_sequence_to_session/migration.sql
@@ -1,0 +1,10 @@
+-- AlterTable: per-session monotonic counter for atomic message sequence assignment.
+-- Holds the NEXT sequence number to assign; incremented in the same transaction as
+-- each message insert so concurrent inserts can never collide on (sessionId, sequence).
+ALTER TABLE "Session" ADD COLUMN "messageSequence" INTEGER NOT NULL DEFAULT 0;
+
+-- Backfill existing sessions so the next assigned sequence is MAX(sequence)+1.
+UPDATE "Session" SET "messageSequence" = COALESCE(
+    (SELECT MAX(m."sequence") + 1 FROM "Message" m WHERE m."sessionId" = "Session"."id"),
+    0
+);

--- a/prisma/migrations/20260705000000_add_message_sequence_to_session/migration.sql
+++ b/prisma/migrations/20260705000000_add_message_sequence_to_session/migration.sql
@@ -1,6 +1,8 @@
 -- AlterTable: per-session monotonic counter for atomic message sequence assignment.
--- Holds the NEXT sequence number to assign; incremented in the same transaction as
--- each message insert so concurrent inserts can never collide on (sessionId, sequence).
+-- Holds the NEXT sequence number to assign. insertMessage reserves a value with a
+-- single autocommit `UPDATE ... SET messageSequence = messageSequence + 1 RETURNING`
+-- statement, which SQLite serializes on the write lock, so concurrent inserts can
+-- never collide on (sessionId, sequence).
 ALTER TABLE "Session" ADD COLUMN "messageSequence" INTEGER NOT NULL DEFAULT 0;
 
 -- Backfill existing sessions so the next assigned sequence is MAX(sequence)+1.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,21 +22,22 @@ model AuthSession {
 }
 
 model Session {
-  id            String    @id @default(uuid())
-  name          String
-  repoUrl       String?   // null for no-repo sessions
-  branch        String?   // null for no-repo sessions
-  workspacePath String    @default("") // Path to workspace directory (e.g., ~/worktrees/{sessionId})
-  repoPath      String    @default("") // Path to repo relative to workspace (e.g., "my-repo")
-  status        String    @default("creating") // creating, running, stopped, error, archived
-  statusMessage String?   // Human-readable progress message during creation
-  initialPrompt  String?   // Optional prompt to send when session starts (e.g., from GitHub issue)
-  currentBranch  String?   // Current git branch (detected after each query)
-  createdAt      DateTime  @default(now())
-  updatedAt     DateTime  @updatedAt
-  lastActivityAt DateTime @default(now()) // Bumped when a message is persisted; drives session-list ordering
-  archivedAt    DateTime? // When the session was archived (null if not archived)
-  messages      Message[]
+  id              String    @id @default(uuid())
+  name            String
+  repoUrl         String? // null for no-repo sessions
+  branch          String? // null for no-repo sessions
+  workspacePath   String    @default("") // Path to workspace directory (e.g., ~/worktrees/{sessionId})
+  repoPath        String    @default("") // Path to repo relative to workspace (e.g., "my-repo")
+  status          String    @default("creating") // creating, running, stopped, error, archived
+  statusMessage   String? // Human-readable progress message during creation
+  initialPrompt   String? // Optional prompt to send when session starts (e.g., from GitHub issue)
+  currentBranch   String? // Current git branch (detected after each query)
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+  lastActivityAt  DateTime  @default(now()) // Bumped when a message is persisted; drives session-list ordering
+  archivedAt      DateTime? // When the session was archived (null if not archived)
+  messageSequence Int       @default(0) // Monotonic counter for atomic message sequence assignment (next sequence to assign)
+  messages        Message[]
 
   @@index([status])
 }
@@ -45,11 +46,11 @@ model Message {
   id        String   @id @default(uuid())
   sessionId String
   sequence  Int
-  type      String   // system, user, assistant, result
-  content   String   // JSON stored as string
+  type      String // system, user, assistant, result
+  content   String // JSON stored as string
   createdAt DateTime @default(now())
 
-  session   Session  @relation(fields: [sessionId], references: [id], onDelete: Cascade)
+  session Session @relation(fields: [sessionId], references: [id], onDelete: Cascade)
 
   @@unique([sessionId, sequence])
   @@index([sessionId, sequence])
@@ -61,8 +62,8 @@ model RepoSettings {
   repoFullName       String   @unique // e.g., "owner/repo"
   isFavorite         Boolean  @default(false)
   displayOrder       Int      @default(0) // For custom ordering within favorites
-  customSystemPrompt String?  // Optional prompt appended to the default system prompt
-  claudeModel        String?  // If set, overrides the global/env Claude model for this repo's sessions
+  customSystemPrompt String? // Optional prompt appended to the default system prompt
+  claudeModel        String? // If set, overrides the global/env Claude model for this repo's sessions
   createdAt          DateTime @default(now())
   updatedAt          DateTime @updatedAt
 
@@ -110,18 +111,18 @@ model McpServer {
 
 // Global application settings (singleton - only one row)
 model GlobalSettings {
-  id                        String   @id @default("global") // Singleton pattern
-  systemPromptOverride      String?  // If set, replaces the default system prompt
-  systemPromptOverrideEnabled Boolean @default(false) // Whether to use the override
-  systemPromptAppend        String?  // Additional content appended after default/override prompt
-  claudeModel               String?  // If set, overrides CLAUDE_MODEL env var
-  advisorModel              String?  // Model for the server-side advisor tool. Null (the default) disables the advisor tool.
-  claudeApiKey              String?  // If set (encrypted), overrides CLAUDE_CODE_OAUTH_TOKEN env var
-  ttsSpeed                  Float?   // TTS playback speed (0.25-4.0, default 1.0)
-  voiceAutoSend             Boolean  @default(true) // Auto-send after speech-to-text transcription
-  settingSourceUser         Boolean  @default(false) // Load Claude settings from the user scope (~/.claude): skills, CLAUDE.md, hooks
-  settingSourceProject      Boolean  @default(true)  // Load Claude settings from the project scope (<cwd>/.claude)
-  settingSourceLocal        Boolean  @default(false) // Load Claude settings from the local scope (<cwd>/.claude/settings.local.json)
-  createdAt                 DateTime @default(now())
-  updatedAt                 DateTime @updatedAt
+  id                          String   @id @default("global") // Singleton pattern
+  systemPromptOverride        String? // If set, replaces the default system prompt
+  systemPromptOverrideEnabled Boolean  @default(false) // Whether to use the override
+  systemPromptAppend          String? // Additional content appended after default/override prompt
+  claudeModel                 String? // If set, overrides CLAUDE_MODEL env var
+  advisorModel                String? // Model for the server-side advisor tool. Null (the default) disables the advisor tool.
+  claudeApiKey                String? // If set (encrypted), overrides CLAUDE_CODE_OAUTH_TOKEN env var
+  ttsSpeed                    Float? // TTS playback speed (0.25-4.0, default 1.0)
+  voiceAutoSend               Boolean  @default(true) // Auto-send after speech-to-text transcription
+  settingSourceUser           Boolean  @default(false) // Load Claude settings from the user scope (~/.claude): skills, CLAUDE.md, hooks
+  settingSourceProject        Boolean  @default(true) // Load Claude settings from the project scope (<cwd>/.claude)
+  settingSourceLocal          Boolean  @default(false) // Load Claude settings from the local scope (<cwd>/.claude/settings.local.json)
+  createdAt                   DateTime @default(now())
+  updatedAt                   DateTime @updatedAt
 }

--- a/src/server/services/claude-runner.integration.test.ts
+++ b/src/server/services/claude-runner.integration.test.ts
@@ -74,6 +74,7 @@ let stopSession: typeof import('./claude-runner').stopSession;
 let isClaudeRunning: typeof import('./claude-runner').isClaudeRunning;
 let getSessionBackgroundTasks: typeof import('./claude-runner').getSessionBackgroundTasks;
 let stopBackgroundTask: typeof import('./claude-runner').stopBackgroundTask;
+let insertMessage: typeof import('./claude-runner').insertMessage;
 let _setQueryFactory: typeof import('./claude-runner')._setQueryFactory;
 let mockLoadSettings: ReturnType<
   typeof vi.mocked<typeof import('./settings-merger').loadMergedSessionSettings>
@@ -192,6 +193,7 @@ describe('claude-runner persistent streaming loop', () => {
     isClaudeRunning = mod.isClaudeRunning;
     getSessionBackgroundTasks = mod.getSessionBackgroundTasks;
     stopBackgroundTask = mod.stopBackgroundTask;
+    insertMessage = mod.insertMessage;
     _setQueryFactory = mod._setQueryFactory;
     const sm = await import('./settings-merger');
     mockLoadSettings = vi.mocked(sm.loadMergedSessionSettings);
@@ -564,5 +566,72 @@ describe('claude-runner persistent streaming loop', () => {
     expect(factoryCalls).toBe(0); // no query was ever created
     expect(isClaudeRunning(sessionId)).toBe(false);
     expect(getSessionBackgroundTasks(sessionId)).toEqual([]);
+  });
+
+  it('assigns unique contiguous sequences under concurrent inserts (no collision)', async () => {
+    const sessionId = await createRunningSession();
+    const N = 50;
+
+    // Fire N inserts for the SAME session concurrently. With a read-then-insert
+    // this races on @@unique([sessionId, sequence]); the atomic counter must give
+    // each a distinct sequence.
+    const results = await Promise.all(
+      Array.from({ length: N }, (_, i) =>
+        insertMessage({
+          sessionId,
+          id: `msg-${i}`,
+          type: 'assistant',
+          content: { type: 'assistant', i },
+        })
+      )
+    );
+
+    // Every insert succeeded and got a sequence.
+    expect(results.every((r) => r.inserted)).toBe(true);
+    const sequences = results.map((r) => r.sequence!).sort((a, b) => a - b);
+    expect(sequences).toEqual([...Array(N).keys()]);
+
+    // The DB agrees: N rows with contiguous sequences 0..N-1.
+    const rows = await messagesFor(sessionId);
+    expect(rows.map((m) => m.sequence)).toEqual([...Array(N).keys()]);
+
+    // The counter points at the next sequence.
+    const session = await testPrisma.session.findUniqueOrThrow({ where: { id: sessionId } });
+    expect(session.messageSequence).toBe(N);
+  });
+
+  it('is idempotent on a duplicate id (no-op, no second row)', async () => {
+    const sessionId = await createRunningSession();
+
+    const first = await insertMessage({
+      sessionId,
+      id: 'dup',
+      type: 'user',
+      content: { type: 'user', content: 'hi' },
+    });
+    expect(first).toEqual({ inserted: true, sequence: 0 });
+
+    // Same id again: the create fails on the primary key and it is a no-op.
+    const second = await insertMessage({
+      sessionId,
+      id: 'dup',
+      type: 'user',
+      content: { type: 'user', content: 'hi' },
+    });
+    expect(second).toEqual({ inserted: false });
+
+    // The reserved sequence (1) is skipped — the next distinct insert lands at 2.
+    // A gap is harmless: pagination orders by sequence and never assumes contiguity.
+    const third = await insertMessage({
+      sessionId,
+      id: 'next',
+      type: 'assistant',
+      content: { type: 'assistant' },
+    });
+    expect(third).toEqual({ inserted: true, sequence: 2 });
+
+    // Only the two real rows exist (the duplicate never created one).
+    const rows = await messagesFor(sessionId);
+    expect(rows.map((m) => m.sequence)).toEqual([0, 2]);
   });
 });

--- a/src/server/services/claude-runner.ts
+++ b/src/server/services/claude-runner.ts
@@ -80,9 +80,6 @@ export function mergeSlashCommands(
 // Namespace UUID for generating deterministic IDs from content.
 const ERROR_LINE_NAMESPACE = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
 
-/** Number of times to retry sequence assignment when a concurrent insert wins the race. */
-const SEQUENCE_RETRY_LIMIT = 5;
-
 /**
  * `turnActive` is derived ENTIRELY from the message stream by `reduceSessionMessage`
  * ([`session-status.ts`](../../lib/session-status.ts)) — a top-level
@@ -180,13 +177,24 @@ export function _setQueryFactory(factory: QueryFactory | null): void {
 }
 
 /**
- * Insert a message with the next per-session sequence, retrying on sequence
- * collision. Distinguishes a true duplicate (same `id` already present → returns
- * `inserted: false`) from a `(sessionId, sequence)` race against a concurrent
- * insert (recompute and retry, so a real message is never silently dropped).
- * Emits the `new_message` SSE event on success.
+ * Insert a message, assigning its per-session `sequence` ATOMICALLY. The sequence
+ * is drawn from the `Session.messageSequence` counter via a single
+ * `UPDATE ... SET messageSequence = messageSequence + 1 ... RETURNING` statement.
+ * Because it is one autocommit statement, SQLite serializes it on the write lock,
+ * so concurrent inserts for the same session each get a distinct value and can
+ * never collide on `@@unique([sessionId, sequence])` — no read-then-insert, no
+ * retry. (An interactive transaction is deliberately avoided: on SQLite's
+ * single-writer model, many concurrent interactive transactions contend on the
+ * write lock and deadlock/time out; a single statement cannot.)
+ *
+ * A duplicate `id` (same message inserted twice — e.g. an idempotent synthetic
+ * tool_result) makes the `message.create` fail with P2002; the call is a no-op
+ * returning `inserted: false`. The counter was already advanced, so that
+ * `sequence` is skipped — a harmless gap, since pagination orders by `sequence`
+ * and never assumes contiguity. Emits the `new_message` SSE event on a real
+ * insert.
  */
-async function insertMessage(params: {
+export async function insertMessage(params: {
   sessionId: string;
   id: string;
   type: 'system' | 'user' | 'assistant' | 'result';
@@ -195,45 +203,38 @@ async function insertMessage(params: {
   const { sessionId, id, type, content } = params;
   const contentJson = JSON.stringify(content);
 
-  for (let attempt = 0; attempt < SEQUENCE_RETRY_LIMIT; attempt++) {
-    const last = await prisma.message.findFirst({
-      where: { sessionId },
-      orderBy: { sequence: 'desc' },
-      select: { sequence: true },
-    });
-    const sequence = (last?.sequence ?? -1) + 1;
+  // Atomically reserve this insert's exclusive sequence. RETURNING gives back the
+  // post-increment counter; the reserved sequence is one less.
+  const rows = await prisma.$queryRaw<{ messageSequence: number | bigint }[]>`
+    UPDATE "Session"
+    SET "messageSequence" = "messageSequence" + 1
+    WHERE "id" = ${sessionId}
+    RETURNING "messageSequence"
+  `;
+  if (rows.length === 0) {
+    throw new Error(`insertMessage: session ${sessionId} not found`);
+  }
+  const sequence = Number(rows[0].messageSequence) - 1;
 
-    try {
-      const message = await prisma.message.create({
-        data: { id, sessionId, sequence, type, content: contentJson },
-      });
-      sseEvents.emitNewMessage(sessionId, {
-        id,
-        sessionId,
-        sequence,
-        type,
-        content,
-        createdAt: message.createdAt,
-      });
-      return { inserted: true, sequence };
-    } catch (err) {
-      if (!(err && typeof err === 'object' && 'code' in err && err.code === 'P2002')) {
-        throw err;
-      }
-      // Unique violation: distinguish a duplicate id (idempotent no-op) from a
-      // sequence race (different id collided) — only the latter should retry.
-      const existing = await prisma.message.findUnique({ where: { id }, select: { id: true } });
-      if (existing) {
-        log.debug('insertMessage: duplicate id, skipping', { sessionId, id });
-        return { inserted: false };
-      }
-      log.debug('insertMessage: sequence collision, retrying', { sessionId, attempt });
+  let createdAt: Date;
+  try {
+    const message = await prisma.message.create({
+      data: { id, sessionId, sequence, type, content: contentJson },
+    });
+    createdAt = message.createdAt;
+  } catch (err) {
+    // The only unique key left to violate is the primary-key `id` (the sequence
+    // is race-free): a duplicate message. Idempotent no-op; the reserved sequence
+    // is skipped (a harmless gap).
+    if (err && typeof err === 'object' && 'code' in err && err.code === 'P2002') {
+      log.debug('insertMessage: duplicate id, skipping', { sessionId, id });
+      return { inserted: false };
     }
+    throw err;
   }
 
-  throw new Error(
-    `Failed to insert message ${id} for ${sessionId} after ${SEQUENCE_RETRY_LIMIT} attempts`
-  );
+  sseEvents.emitNewMessage(sessionId, { id, sessionId, sequence, type, content, createdAt });
+  return { inserted: true, sequence };
 }
 
 /**

--- a/src/server/services/claude-runner.ts
+++ b/src/server/services/claude-runner.ts
@@ -193,6 +193,9 @@ export function _setQueryFactory(factory: QueryFactory | null): void {
  * `sequence` is skipped — a harmless gap, since pagination orders by `sequence`
  * and never assumes contiguity. Emits the `new_message` SSE event on a real
  * insert.
+ *
+ * @internal Exported only for the integration test; the sole intended callers are
+ * the persist sites in this module. Throws if the session does not exist.
  */
 export async function insertMessage(params: {
   sessionId: string;


### PR DESCRIPTION
## Problem

Fixes #356. Message `sequence` numbers were assigned with an unguarded read-then-insert (`findFirst` for `MAX(sequence)`, then `create` at `+1`). Two concurrent inserts for the same session could read the same max and collide on `@@unique([sessionId, sequence])`. This is reachable in practice: both `runClaudeCommand` paths fire **un-awaited** and `isRunning` is only set *inside* the call, so two near-simultaneous requests (two browser tabs, or an answer racing a `send`) can both pass the guard and start inserting. The previous mitigation was a P2002 retry loop — fragile, and it contradicts the project guideline to avoid check-then-set.

## Fix

Assign `sequence` **atomically** via a per-session counter:

- Add `Session.messageSequence` (the next sequence to assign) + a backfill migration (`MAX(sequence)+1` for existing sessions).
- `insertMessage` reserves a value with a **single autocommit statement** — `UPDATE "Session" SET "messageSequence" = "messageSequence" + 1 ... RETURNING` — which SQLite serializes on the write lock, then inserts at `messageSequence - 1`. Concurrent inserts always get distinct sequences. No retry loop.
- Deliberately **not** an interactive transaction: on SQLite's single-writer model, many concurrent interactive transactions contend on the write lock and deadlock/time out (verified — a 25-way concurrent test hung even at a 20s timeout). A single statement cannot.
- A duplicate `id` (idempotent synthetic `tool_result`) still no-ops via the primary-key P2002; the reserved sequence is skipped, a harmless gap since pagination orders by `sequence` and never assumes contiguity.

## Tests

- 50 concurrent `insertMessage` calls for one session → all inserted, unique contiguous sequences `0..49`, counter at 50 (this fails hard with the old read-then-insert).
- Duplicate `id` → no-op, no second row, next insert lands past the skipped sequence.
- Full suite: 581 passing, typecheck + lint clean.

Also documented atomic sequence assignment in `doc/DESIGN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)