### PR TITLE
Add "Open in VS Code" deep link to session worktrees (code-server)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,10 @@ PASSWORD_HASH="JGFyZ29uMmlkJHY9MTkkbT02NTUzNix0PTMscD00JHlvdXJfc2FsdF9oZXJlJHlvd
 # 32+ character key for encrypting secrets (env vars, MCP API keys)
 # Generate with: openssl rand -base64 32
 # ENCRYPTION_KEY=
+
+# Base URL of a self-hosted code-server (browser VS Code) instance for viewing
+# and editing session worktrees remotely. When set, each session shows an
+# "Open in VS Code" button that deep-links into its worktree folder.
+# Run scripts/setup-code-server.sh to install and expose code-server, which
+# prints the URL to use here. Leave unset to hide the button.
+# CODE_SERVER_URL="https://your-host.tailnet.ts.net:8443"

--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,7 @@ PASSWORD_HASH="JGFyZ29uMmlkJHY9MTkkbT02NTUzNix0PTMscD00JHlvdXJfc2FsdF9oZXJlJHlvd
 # Base URL of a self-hosted code-server (browser VS Code) instance for viewing
 # and editing session worktrees remotely. When set, each session shows an
 # "Open in VS Code" button that deep-links into its worktree folder.
-# Run scripts/setup-code-server.sh to install and expose code-server, which
-# prints the URL to use here. Leave unset to hide the button.
+# Run scripts/setup-code-server.sh to install/run code-server, then
+# scripts/expose-code-server-tailscale.sh (needs Tailscale access) to expose it
+# and print the URL to use here. Leave unset to hide the button.
 # CODE_SERVER_URL="https://your-host.tailnet.ts.net:8443"

--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -659,7 +659,12 @@ To view and edit the files an agent is working on — without building a bespoke
 - The link is built server-side by the pure `buildEditorUrl` ([`src/lib/editor-url.ts`](../src/lib/editor-url.ts)) and served by `sessions.getEditorUrl`, which resolves the session's absolute working dir with `getSessionWorkingDir` (the same path logic the runner uses) — the client never needs to know the host's home directory or worktrees root.
 - The feature is **opt-in**: `getEditorUrl` returns `{ url: null }` when `CODE_SERVER_URL` is unset (or the session is `archived`, since its workspace is removed from disk), and `OpenInEditorButton` ([`src/components/OpenInEditorButton.tsx`](../src/components/OpenInEditorButton.tsx)) renders nothing for a null url. As with [Answering Interactive Tools](#answering-interactive-tools), the server is authoritative and the UI stays dumb.
 
-**Deployment.** [`scripts/setup-code-server.sh`](../scripts/setup-code-server.sh) installs code-server, points it at `~/worktrees`, gives it its own generated password, exposes it over **Tailscale Serve** on a dedicated HTTPS port (keeping it on the tailnet — the same trust boundary as the app), and prints the `CODE_SERVER_URL` to set. Because it runs as a normal host process with filesystem access to the worktrees, edits made in code-server land directly in the session's clone, ready for the agent (or the user) to commit and push.
+**Deployment.** Setup is split into two scripts so the Tailscale step (which usually needs privileges the app's account lacks) is separable from the app-side install:
+
+1. [`scripts/setup-code-server.sh`](../scripts/setup-code-server.sh) — installs code-server, gives it its own generated password (config written mode `600`), points it at `~/worktrees`, and runs it as a service on loopback. **No Tailscale involvement**, so it can be run by the account that runs the app.
+2. [`scripts/expose-code-server-tailscale.sh`](../scripts/expose-code-server-tailscale.sh) — exposes the loopback code-server over **Tailscale Serve** on a dedicated HTTPS port (keeping it on the tailnet — the same trust boundary as the app, never `funnel`) and prints the `CODE_SERVER_URL` to set. Run by someone with Tailscale access.
+
+Both source [`scripts/lib-code-server.sh`](../scripts/lib-code-server.sh) so the loopback/HTTPS ports stay in sync. Because code-server runs as a normal host process with filesystem access to the worktrees, edits made in it land directly in the session's clone, ready for the agent (or the user) to commit and push.
 
 ## UI Screens
 
@@ -713,7 +718,9 @@ clawed-abode/
 │   └── agent-types.ts          # Shared types (PartialAssistantMessage)
 ├── scripts/
 │   ├── hash-password.ts        # Password hashing utility
-│   ├── setup-code-server.sh    # Install/expose code-server for remote file editing
+│   ├── lib-code-server.sh      # Shared config sourced by the code-server scripts
+│   ├── setup-code-server.sh    # Install + run code-server (app-side, no Tailscale)
+│   ├── expose-code-server-tailscale.sh # Expose code-server over Tailscale Serve
 │   └── update.sh               # Production update: pull, install, migrate, build, restart
 ├── src/
 │   ├── server/

--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -165,6 +165,12 @@ sessions.stop({ sessionId: string })
 sessions.delete({ sessionId: string })
   → { success: true }
   // Stops query, removes workspace, archives session
+
+sessions.getEditorUrl({ sessionId: string })
+  → { url: string | null }
+  // Deep link into a self-hosted code-server (browser VS Code) opened on this
+  // session's worktree folder. null when CODE_SERVER_URL is unset or the
+  // session is archived (workspace removed). See "Remote File Editing".
 ```
 
 ### Claude Interaction
@@ -644,6 +650,17 @@ Voice mode provides speech-to-text input and text-to-speech output for hands-fre
 
 **Implementation**: See [`src/hooks/useVoiceRecording.ts`](../src/hooks/useVoiceRecording.ts), [`src/hooks/useVoicePlayback.ts`](../src/hooks/useVoicePlayback.ts), [`src/hooks/useVoiceConfig.ts`](../src/hooks/useVoiceConfig.ts), and [`src/components/voice/`](../src/components/voice/) for UI components.
 
+### Remote File Editing
+
+To view and edit the files an agent is working on — without building a bespoke file browser/editor — the app integrates with a **self-hosted [code-server](https://github.com/coder/code-server)** (browser VS Code) running alongside it on the host. This is deliberately a thin integration: code-server owns the entire editor (file tree, multi-file edit, integrated terminal, search, extensions); the app only contributes a deep link.
+
+**How it works.** Each session's worktree lives at a stable absolute path (`~/worktrees/{sessionId}/{repoName}`, or `~/worktrees/{sessionId}` for no-repo sessions — see [Workspace Structure](#workspace-structure)). code-server opens any folder via a `?folder=<absolute-path>` query param, so the "Open in VS Code" button in the session header is just a link to `${CODE_SERVER_URL}/?folder=<workingDir>`.
+
+- The link is built server-side by the pure `buildEditorUrl` ([`src/lib/editor-url.ts`](../src/lib/editor-url.ts)) and served by `sessions.getEditorUrl`, which resolves the session's absolute working dir with `getSessionWorkingDir` (the same path logic the runner uses) — the client never needs to know the host's home directory or worktrees root.
+- The feature is **opt-in**: `getEditorUrl` returns `{ url: null }` when `CODE_SERVER_URL` is unset (or the session is `archived`, since its workspace is removed from disk), and `OpenInEditorButton` ([`src/components/OpenInEditorButton.tsx`](../src/components/OpenInEditorButton.tsx)) renders nothing for a null url. As with [Answering Interactive Tools](#answering-interactive-tools), the server is authoritative and the UI stays dumb.
+
+**Deployment.** [`scripts/setup-code-server.sh`](../scripts/setup-code-server.sh) installs code-server, points it at `~/worktrees`, gives it its own generated password, exposes it over **Tailscale Serve** on a dedicated HTTPS port (keeping it on the tailnet — the same trust boundary as the app), and prints the `CODE_SERVER_URL` to set. Because it runs as a normal host process with filesystem access to the worktrees, edits made in code-server land directly in the session's clone, ready for the agent (or the user) to commit and push.
+
 ## UI Screens
 
 ### Session List (Home)
@@ -686,6 +703,7 @@ Voice mode provides speech-to-text input and text-to-speech output for hands-fre
 - Status indicator (running, waiting, stopped)
 - Session info in header (repo, branch)
 - Editable session title in header: click the name to rename inline (Enter saves, Escape cancels) via `sessions.rename` — see `EditableSessionName`
+- "Open in VS Code" button in the header (only when `CODE_SERVER_URL` is configured) that deep-links into the session's worktree in code-server — see [Remote File Editing](#remote-file-editing)
 
 ## File Structure
 
@@ -695,6 +713,7 @@ clawed-abode/
 │   └── agent-types.ts          # Shared types (PartialAssistantMessage)
 ├── scripts/
 │   ├── hash-password.ts        # Password hashing utility
+│   ├── setup-code-server.sh    # Install/expose code-server for remote file editing
 │   └── update.sh               # Production update: pull, install, migrate, build, restart
 ├── src/
 │   ├── server/

--- a/scripts/expose-code-server-tailscale.sh
+++ b/scripts/expose-code-server-tailscale.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Expose a running code-server to the tailnet via Tailscale Serve and print the
+# CODE_SERVER_URL to put in the app's .env.
+#
+# This is the Tailscale half of the setup, split out because managing Tailscale
+# usually needs privileges the app's account does not have (the operator/root, or
+# membership in the tailscale group). Run setup-code-server.sh first (installs and
+# starts code-server on loopback); then run this as a user with Tailscale access.
+#
+# Keeps code-server off the public internet: it uses `tailscale serve` (tailnet
+# only), not `tailscale funnel`. Idempotent: safe to re-run. Requires an existing
+# Tailscale login on this host, and jq or python3 to read the host's DNS name.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib-code-server.sh
+source "$SCRIPT_DIR/lib-code-server.sh"
+
+if ! command -v tailscale >/dev/null 2>&1; then
+  echo "Error: tailscale is not installed or not on PATH." >&2
+  exit 1
+fi
+
+echo "==> Exposing code-server over Tailscale Serve on port ${CODE_SERVER_HTTPS_PORT}"
+tailscale serve --bg --https "${CODE_SERVER_HTTPS_PORT}" "http://127.0.0.1:${CODE_SERVER_PORT}"
+
+# Resolve *this host's* MagicDNS name. Parse the Self object explicitly rather
+# than grabbing the first DNSName in the JSON (which could be a peer).
+if command -v jq >/dev/null 2>&1; then
+  HOSTNAME_FQDN="$(tailscale status --json | jq -r '.Self.DNSName')"
+elif command -v python3 >/dev/null 2>&1; then
+  HOSTNAME_FQDN="$(tailscale status --json |
+    python3 -c 'import sys,json; print(json.load(sys.stdin)["Self"]["DNSName"])')"
+else
+  echo "Error: need jq or python3 to read this host's Tailscale name." >&2
+  exit 1
+fi
+HOSTNAME_FQDN="${HOSTNAME_FQDN%.}" # strip the trailing dot MagicDNS returns
+
+if [ -z "$HOSTNAME_FQDN" ] || [ "$HOSTNAME_FQDN" = "null" ]; then
+  echo "Error: could not determine this host's Tailscale DNS name." >&2
+  echo "Is Tailscale logged in? Try: tailscale status" >&2
+  exit 1
+fi
+
+URL="https://${HOSTNAME_FQDN}:${CODE_SERVER_HTTPS_PORT}"
+
+echo
+echo "==> Done."
+echo
+echo "  code-server is reachable at:  ${URL}"
+cat <<EOF
+
+  Add this to your .env and restart the app:
+
+    CODE_SERVER_URL="${URL}"
+
+  The "Open in VS Code" button in each session will then deep-link into that
+  session's worktree folder.
+EOF

--- a/scripts/lib-code-server.sh
+++ b/scripts/lib-code-server.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Shared configuration for the code-server setup scripts. This file is *sourced*
+# by setup-code-server.sh and expose-code-server-tailscale.sh, not executed
+# directly, so the loopback/HTTPS ports stay in sync between the two steps
+# (Tailscale Serve maps the HTTPS port to the loopback port code-server binds).
+#
+# Override any of these by exporting them before running either script.
+
+# Port code-server binds on loopback (never exposed directly).
+CODE_SERVER_PORT="${CODE_SERVER_PORT:-8080}"
+# HTTPS port Tailscale Serve exposes on the tailnet, proxied to CODE_SERVER_PORT.
+CODE_SERVER_HTTPS_PORT="${CODE_SERVER_HTTPS_PORT:-8443}"
+# Root directory that holds all session worktrees.
+WORKTREES_DIR="${WORKTREES_DIR:-$HOME/worktrees}"
+# code-server config file (holds the generated password).
+CODE_SERVER_CONFIG_DIR="$HOME/.config/code-server"
+CODE_SERVER_CONFIG_FILE="$CODE_SERVER_CONFIG_DIR/config.yaml"

--- a/scripts/setup-code-server.sh
+++ b/scripts/setup-code-server.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Set up code-server (browser VS Code) so the "Open in VS Code" button can view
+# and edit session worktrees remotely.
+#
+# This installs code-server, points it at ~/worktrees, and exposes it over the
+# tailnet via Tailscale Serve on a dedicated HTTPS port. code-server keeps its
+# own password (set below), and Tailscale keeps it off the public internet — the
+# same trust boundary the app itself uses.
+#
+# After running, set CODE_SERVER_URL in your .env to the printed URL and restart
+# the app so the button appears.
+#
+# Idempotent: safe to re-run. Requires an existing Tailscale login on this host.
+set -euo pipefail
+
+# Port code-server listens on locally (loopback only) and the HTTPS port
+# Tailscale Serve maps to it. Override via env if they collide with something.
+CODE_SERVER_PORT="${CODE_SERVER_PORT:-8080}"
+CODE_SERVER_HTTPS_PORT="${CODE_SERVER_HTTPS_PORT:-8443}"
+WORKTREES_DIR="${WORKTREES_DIR:-$HOME/worktrees}"
+
+echo "==> Installing code-server (if not already present)"
+if ! command -v code-server >/dev/null 2>&1; then
+  curl -fsSL https://code-server.dev/install.sh | sh
+else
+  echo "    code-server already installed: $(command -v code-server)"
+fi
+
+echo "==> Writing code-server config"
+CONFIG_DIR="$HOME/.config/code-server"
+CONFIG_FILE="$CONFIG_DIR/config.yaml"
+mkdir -p "$CONFIG_DIR"
+
+if [ -f "$CONFIG_FILE" ] && grep -q '^password:' "$CONFIG_FILE"; then
+  echo "    Keeping existing password in $CONFIG_FILE"
+  PASSWORD="$(grep '^password:' "$CONFIG_FILE" | awk '{print $2}')"
+else
+  PASSWORD="$(openssl rand -base64 24)"
+fi
+
+cat >"$CONFIG_FILE" <<EOF
+bind-addr: 127.0.0.1:${CODE_SERVER_PORT}
+auth: password
+password: ${PASSWORD}
+cert: false
+EOF
+echo "    Wrote $CONFIG_FILE"
+
+echo "==> Enabling code-server as a user service"
+# Open the worktrees dir by default; individual sessions are deep-linked with ?folder=.
+mkdir -p "$WORKTREES_DIR"
+systemctl --user enable --now "code-server@$USER" 2>/dev/null ||
+  systemctl --user enable --now code-server 2>/dev/null || {
+    echo "    Could not manage the user service automatically."
+    echo "    Start it manually with: code-server"
+  }
+
+echo "==> Exposing code-server over Tailscale Serve on port ${CODE_SERVER_HTTPS_PORT}"
+tailscale serve --bg --https "${CODE_SERVER_HTTPS_PORT}" "http://127.0.0.1:${CODE_SERVER_PORT}"
+
+HOSTNAME_FQDN="$(tailscale status --json | grep -o '"DNSName":"[^"]*"' | head -1 | sed 's/"DNSName":"//;s/\.$//;s/"//')"
+URL="https://${HOSTNAME_FQDN}:${CODE_SERVER_HTTPS_PORT}"
+
+cat <<EOF
+
+==> Done.
+
+  code-server is reachable at:  ${URL}
+  code-server password:         ${PASSWORD}
+
+  Add this to your .env and restart the app:
+
+    CODE_SERVER_URL="${URL}"
+
+  The "Open in VS Code" button in each session will then deep-link into that
+  session's worktree folder.
+EOF

--- a/scripts/setup-code-server.sh
+++ b/scripts/setup-code-server.sh
@@ -2,22 +2,18 @@
 # Set up code-server (browser VS Code) so the "Open in VS Code" button can view
 # and edit session worktrees remotely.
 #
-# This installs code-server, points it at ~/worktrees, and exposes it over the
-# tailnet via Tailscale Serve on a dedicated HTTPS port. code-server keeps its
-# own password (set below), and Tailscale keeps it off the public internet — the
-# same trust boundary the app itself uses.
+# This is the app-side half of the setup: install code-server, point it at
+# ~/worktrees, and run it as a service. It does NOT touch Tailscale, so it can be
+# run by the account that runs the app (which may not have permission to manage
+# Tailscale). Expose it to the tailnet separately with
+# expose-code-server-tailscale.sh (run by someone with Tailscale access).
 #
-# After running, set CODE_SERVER_URL in your .env to the printed URL and restart
-# the app so the button appears.
-#
-# Idempotent: safe to re-run. Requires an existing Tailscale login on this host.
+# Idempotent: safe to re-run.
 set -euo pipefail
 
-# Port code-server listens on locally (loopback only) and the HTTPS port
-# Tailscale Serve maps to it. Override via env if they collide with something.
-CODE_SERVER_PORT="${CODE_SERVER_PORT:-8080}"
-CODE_SERVER_HTTPS_PORT="${CODE_SERVER_HTTPS_PORT:-8443}"
-WORKTREES_DIR="${WORKTREES_DIR:-$HOME/worktrees}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib-code-server.sh
+source "$SCRIPT_DIR/lib-code-server.sh"
 
 echo "==> Installing code-server (if not already present)"
 if ! command -v code-server >/dev/null 2>&1; then
@@ -27,37 +23,35 @@ else
 fi
 
 echo "==> Writing code-server config"
-CONFIG_DIR="$HOME/.config/code-server"
-CONFIG_FILE="$CONFIG_DIR/config.yaml"
-mkdir -p "$CONFIG_DIR"
-chmod 700 "$CONFIG_DIR"
+mkdir -p "$CODE_SERVER_CONFIG_DIR"
+chmod 700 "$CODE_SERVER_CONFIG_DIR"
 
 # Reuse an existing password on re-run; otherwise generate one. Track which case
 # we hit so we only print a *freshly generated* secret (never re-echo an existing
 # one on idempotent re-runs).
 PASSWORD_IS_NEW=false
-if [ -f "$CONFIG_FILE" ] && grep -q '^password:' "$CONFIG_FILE"; then
+if [ -f "$CODE_SERVER_CONFIG_FILE" ] && grep -q '^password:' "$CODE_SERVER_CONFIG_FILE"; then
   # Strip the "password:" key, surrounding whitespace, and optional quotes so
   # hand-edited/quoted passwords (incl. those with spaces) survive intact.
-  PASSWORD="$(sed -n 's/^password:[[:space:]]*//p' "$CONFIG_FILE" | head -1)"
+  PASSWORD="$(sed -n 's/^password:[[:space:]]*//p' "$CODE_SERVER_CONFIG_FILE" | head -1)"
   PASSWORD="${PASSWORD%\"}"
   PASSWORD="${PASSWORD#\"}"
-  echo "    Keeping existing password in $CONFIG_FILE"
+  echo "    Keeping existing password in $CODE_SERVER_CONFIG_FILE"
 else
   PASSWORD="$(openssl rand -base64 24)"
   PASSWORD_IS_NEW=true
 fi
 
 # Write the config with restrictive permissions *before* the secret lands in it.
-touch "$CONFIG_FILE"
-chmod 600 "$CONFIG_FILE"
-cat >"$CONFIG_FILE" <<EOF
+touch "$CODE_SERVER_CONFIG_FILE"
+chmod 600 "$CODE_SERVER_CONFIG_FILE"
+cat >"$CODE_SERVER_CONFIG_FILE" <<EOF
 bind-addr: 127.0.0.1:${CODE_SERVER_PORT}
 auth: password
 password: ${PASSWORD}
 cert: false
 EOF
-echo "    Wrote $CONFIG_FILE (mode 600)"
+echo "    Wrote $CODE_SERVER_CONFIG_FILE (mode 600)"
 
 echo "==> Enabling code-server as a systemd service"
 # Open the worktrees dir by default; individual sessions are deep-linked with ?folder=.
@@ -72,46 +66,20 @@ else
   echo "    Start it manually with:  code-server   (or: sudo systemctl enable --now code-server@$USER)"
 fi
 
-echo "==> Exposing code-server over Tailscale Serve on port ${CODE_SERVER_HTTPS_PORT}"
-tailscale serve --bg --https "${CODE_SERVER_HTTPS_PORT}" "http://127.0.0.1:${CODE_SERVER_PORT}"
-
-# Resolve *this host's* MagicDNS name. Parse the Self object explicitly rather
-# than grabbing the first DNSName in the JSON (which could be a peer).
-if command -v jq >/dev/null 2>&1; then
-  HOSTNAME_FQDN="$(tailscale status --json | jq -r '.Self.DNSName')"
-elif command -v python3 >/dev/null 2>&1; then
-  HOSTNAME_FQDN="$(tailscale status --json |
-    python3 -c 'import sys,json; print(json.load(sys.stdin)["Self"]["DNSName"])')"
-else
-  echo "Error: need jq or python3 to read this host's Tailscale name." >&2
-  exit 1
-fi
-HOSTNAME_FQDN="${HOSTNAME_FQDN%.}" # strip the trailing dot MagicDNS returns
-
-if [ -z "$HOSTNAME_FQDN" ] || [ "$HOSTNAME_FQDN" = "null" ]; then
-  echo "Error: could not determine this host's Tailscale DNS name." >&2
-  echo "Is Tailscale logged in? Try: tailscale status" >&2
-  exit 1
-fi
-
-URL="https://${HOSTNAME_FQDN}:${CODE_SERVER_HTTPS_PORT}"
-
 echo
-echo "==> Done."
-echo
-echo "  code-server is reachable at:  ${URL}"
+echo "==> code-server is set up (listening on 127.0.0.1:${CODE_SERVER_PORT})."
 if [ "$PASSWORD_IS_NEW" = true ]; then
-  echo "  code-server password:         ${PASSWORD}"
-  echo "  (also stored in ${CONFIG_FILE})"
+  echo "    code-server password:  ${PASSWORD}"
+  echo "    (also stored in ${CODE_SERVER_CONFIG_FILE})"
 else
-  echo "  code-server password:         (unchanged; see ${CONFIG_FILE})"
+  echo "    code-server password:  (unchanged; see ${CODE_SERVER_CONFIG_FILE})"
 fi
 cat <<EOF
 
-  Add this to your .env and restart the app:
+  Next: expose it to your tailnet and get the CODE_SERVER_URL by running (as a
+  user with Tailscale access):
 
-    CODE_SERVER_URL="${URL}"
+    scripts/expose-code-server-tailscale.sh
 
-  The "Open in VS Code" button in each session will then deep-link into that
-  session's worktree folder.
+  Then set the printed CODE_SERVER_URL in your .env and restart the app.
 EOF

--- a/scripts/setup-code-server.sh
+++ b/scripts/setup-code-server.sh
@@ -30,43 +30,83 @@ echo "==> Writing code-server config"
 CONFIG_DIR="$HOME/.config/code-server"
 CONFIG_FILE="$CONFIG_DIR/config.yaml"
 mkdir -p "$CONFIG_DIR"
+chmod 700 "$CONFIG_DIR"
 
+# Reuse an existing password on re-run; otherwise generate one. Track which case
+# we hit so we only print a *freshly generated* secret (never re-echo an existing
+# one on idempotent re-runs).
+PASSWORD_IS_NEW=false
 if [ -f "$CONFIG_FILE" ] && grep -q '^password:' "$CONFIG_FILE"; then
+  # Strip the "password:" key, surrounding whitespace, and optional quotes so
+  # hand-edited/quoted passwords (incl. those with spaces) survive intact.
+  PASSWORD="$(sed -n 's/^password:[[:space:]]*//p' "$CONFIG_FILE" | head -1)"
+  PASSWORD="${PASSWORD%\"}"
+  PASSWORD="${PASSWORD#\"}"
   echo "    Keeping existing password in $CONFIG_FILE"
-  PASSWORD="$(grep '^password:' "$CONFIG_FILE" | awk '{print $2}')"
 else
   PASSWORD="$(openssl rand -base64 24)"
+  PASSWORD_IS_NEW=true
 fi
 
+# Write the config with restrictive permissions *before* the secret lands in it.
+touch "$CONFIG_FILE"
+chmod 600 "$CONFIG_FILE"
 cat >"$CONFIG_FILE" <<EOF
 bind-addr: 127.0.0.1:${CODE_SERVER_PORT}
 auth: password
 password: ${PASSWORD}
 cert: false
 EOF
-echo "    Wrote $CONFIG_FILE"
+echo "    Wrote $CONFIG_FILE (mode 600)"
 
-echo "==> Enabling code-server as a user service"
+echo "==> Enabling code-server as a systemd service"
 # Open the worktrees dir by default; individual sessions are deep-linked with ?folder=.
 mkdir -p "$WORKTREES_DIR"
-systemctl --user enable --now "code-server@$USER" 2>/dev/null ||
-  systemctl --user enable --now code-server 2>/dev/null || {
-    echo "    Could not manage the user service automatically."
-    echo "    Start it manually with: code-server"
-  }
+# The code-server installer ships a system-scope template unit run as the target
+# user: `sudo systemctl enable --now code-server@$USER` (its own post-install note).
+if command -v systemctl >/dev/null 2>&1 &&
+  sudo systemctl enable --now "code-server@$USER"; then
+  echo "    Enabled code-server@$USER"
+else
+  echo "    Could not enable the service automatically."
+  echo "    Start it manually with:  code-server   (or: sudo systemctl enable --now code-server@$USER)"
+fi
 
 echo "==> Exposing code-server over Tailscale Serve on port ${CODE_SERVER_HTTPS_PORT}"
 tailscale serve --bg --https "${CODE_SERVER_HTTPS_PORT}" "http://127.0.0.1:${CODE_SERVER_PORT}"
 
-HOSTNAME_FQDN="$(tailscale status --json | grep -o '"DNSName":"[^"]*"' | head -1 | sed 's/"DNSName":"//;s/\.$//;s/"//')"
+# Resolve *this host's* MagicDNS name. Parse the Self object explicitly rather
+# than grabbing the first DNSName in the JSON (which could be a peer).
+if command -v jq >/dev/null 2>&1; then
+  HOSTNAME_FQDN="$(tailscale status --json | jq -r '.Self.DNSName')"
+elif command -v python3 >/dev/null 2>&1; then
+  HOSTNAME_FQDN="$(tailscale status --json |
+    python3 -c 'import sys,json; print(json.load(sys.stdin)["Self"]["DNSName"])')"
+else
+  echo "Error: need jq or python3 to read this host's Tailscale name." >&2
+  exit 1
+fi
+HOSTNAME_FQDN="${HOSTNAME_FQDN%.}" # strip the trailing dot MagicDNS returns
+
+if [ -z "$HOSTNAME_FQDN" ] || [ "$HOSTNAME_FQDN" = "null" ]; then
+  echo "Error: could not determine this host's Tailscale DNS name." >&2
+  echo "Is Tailscale logged in? Try: tailscale status" >&2
+  exit 1
+fi
+
 URL="https://${HOSTNAME_FQDN}:${CODE_SERVER_HTTPS_PORT}"
 
+echo
+echo "==> Done."
+echo
+echo "  code-server is reachable at:  ${URL}"
+if [ "$PASSWORD_IS_NEW" = true ]; then
+  echo "  code-server password:         ${PASSWORD}"
+  echo "  (also stored in ${CONFIG_FILE})"
+else
+  echo "  code-server password:         (unchanged; see ${CONFIG_FILE})"
+fi
 cat <<EOF
-
-==> Done.
-
-  code-server is reachable at:  ${URL}
-  code-server password:         ${PASSWORD}
 
   Add this to your .env and restart the app:
 

--- a/src/components/OpenInEditorButton.tsx
+++ b/src/components/OpenInEditorButton.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { Code } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { trpc } from '@/lib/trpc';
+
+interface OpenInEditorButtonProps {
+  sessionId: string;
+}
+
+/**
+ * Opens the session's worktree folder in a self-hosted code-server (browser
+ * VS Code) instance in a new tab. Renders nothing when the editor is not
+ * configured (CODE_SERVER_URL unset) or the session has no workspace on disk —
+ * the server decides via sessions.getEditorUrl, so the UI stays dumb.
+ */
+export function OpenInEditorButton({ sessionId }: OpenInEditorButtonProps) {
+  const { data } = trpc.sessions.getEditorUrl.useQuery({ sessionId });
+
+  if (!data?.url) {
+    return null;
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      asChild
+      title="Open worktree in VS Code"
+      className="shrink-0 h-8 w-8"
+    >
+      <a href={data.url} target="_blank" rel="noopener noreferrer">
+        <Code className="h-4 w-4" />
+      </a>
+    </Button>
+  );
+}

--- a/src/components/SessionHeader.tsx
+++ b/src/components/SessionHeader.tsx
@@ -7,6 +7,7 @@ import { SessionStatusToggle } from '@/components/SessionStatusToggle';
 import { SessionActionButton } from '@/components/SessionActionButton';
 import { EditableSessionName } from '@/components/EditableSessionName';
 import { VoiceAutoReadToggle } from '@/components/voice/VoiceAutoReadToggle';
+import { OpenInEditorButton } from '@/components/OpenInEditorButton';
 
 interface SessionHeaderProps {
   session: {
@@ -79,6 +80,7 @@ export function SessionHeader({
 
         <div className="flex flex-col items-end gap-1 shrink-0">
           <div className="flex items-center gap-1">
+            <OpenInEditorButton sessionId={session.id} />
             {voiceEnabled && onToggleVoiceMode && (
               <Button
                 variant={voiceModeActive ? 'secondary' : 'ghost'}

--- a/src/lib/editor-url.test.ts
+++ b/src/lib/editor-url.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { buildEditorUrl } from './editor-url';
+
+describe('buildEditorUrl', () => {
+  it('returns null when no base URL is configured', () => {
+    expect(buildEditorUrl(undefined, '/home/user/worktrees/abc/repo')).toBeNull();
+    expect(buildEditorUrl(null, '/home/user/worktrees/abc/repo')).toBeNull();
+    expect(buildEditorUrl('', '/home/user/worktrees/abc/repo')).toBeNull();
+    expect(buildEditorUrl('   ', '/home/user/worktrees/abc/repo')).toBeNull();
+  });
+
+  it('builds a folder deep link', () => {
+    expect(buildEditorUrl('https://host.ts.net:8443', '/home/user/worktrees/abc/repo')).toBe(
+      'https://host.ts.net:8443/?folder=%2Fhome%2Fuser%2Fworktrees%2Fabc%2Frepo'
+    );
+  });
+
+  it('strips trailing slashes from the base URL', () => {
+    expect(buildEditorUrl('https://host.ts.net:8443///', '/tmp/x')).toBe(
+      'https://host.ts.net:8443/?folder=%2Ftmp%2Fx'
+    );
+  });
+
+  it('supports a relative base path', () => {
+    expect(buildEditorUrl('/editor', '/tmp/x')).toBe('/editor/?folder=%2Ftmp%2Fx');
+  });
+
+  it('percent-encodes spaces and special characters in the path', () => {
+    expect(buildEditorUrl('https://host', '/tmp/my repo/a&b')).toBe(
+      'https://host/?folder=%2Ftmp%2Fmy%20repo%2Fa%26b'
+    );
+  });
+});

--- a/src/lib/editor-url.ts
+++ b/src/lib/editor-url.ts
@@ -1,0 +1,32 @@
+/**
+ * Builds deep links into a self-hosted code-server (browser VS Code) instance
+ * so the operator can view/edit a session's worktree files remotely.
+ *
+ * code-server opens a folder via the `?folder=<absolute-path>` query param, so
+ * the link is just the configured base URL plus the session's absolute working
+ * directory. Kept pure and dependency-free so it is trivially unit-testable and
+ * shared by the router.
+ */
+
+/**
+ * Build a code-server deep link that opens `folderPath` in the editor.
+ *
+ * @param baseUrl  Base URL where code-server is reachable (e.g.
+ *   `https://host.tailnet.ts.net:8443`). When empty/undefined the feature is
+ *   considered disabled and `null` is returned.
+ * @param folderPath  Absolute path to the folder to open.
+ * @returns The deep link, or `null` when the editor is not configured.
+ */
+export function buildEditorUrl(
+  baseUrl: string | undefined | null,
+  folderPath: string
+): string | null {
+  if (!baseUrl) {
+    return null;
+  }
+  const trimmed = baseUrl.trim().replace(/\/+$/, '');
+  if (!trimmed) {
+    return null;
+  }
+  return `${trimmed}/?folder=${encodeURIComponent(folderPath)}`;
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -26,6 +26,10 @@ const envSchema = z.object({
   // 32+ character key for encrypting secrets (env vars, MCP API keys)
   // Generate with: openssl rand -base64 32
   ENCRYPTION_KEY: z.string().min(32).optional(),
+  // Base URL of a self-hosted code-server (browser VS Code) instance used to
+  // view/edit session worktrees remotely (e.g. https://host.tailnet.ts.net:8443).
+  // When unset, the "Open in VS Code" button is hidden. See scripts/setup-code-server.sh.
+  CODE_SERVER_URL: z.string().optional(),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -29,6 +29,8 @@ const envSchema = z.object({
   // Base URL of a self-hosted code-server (browser VS Code) instance used to
   // view/edit session worktrees remotely (e.g. https://host.tailnet.ts.net:8443).
   // When unset, the "Open in VS Code" button is hidden. See scripts/setup-code-server.sh.
+  // Intentionally free-form (not z.string().url()): it is operator-controlled and
+  // may legitimately be a relative reverse-proxy path like "/editor".
   CODE_SERVER_URL: z.string().optional(),
 });
 

--- a/src/server/routers/sessions.integration.test.ts
+++ b/src/server/routers/sessions.integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
 import { setupTestDb, teardownTestDb, testPrisma, clearTestDb } from '@/test/setup-test-db';
 
 // Mock external services that have real dependencies (git clone)
@@ -409,6 +409,80 @@ describe('sessionsRouter integration', () => {
       const caller = createCaller(null);
       await expect(
         caller.sessions.get({ sessionId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11' })
+      ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+    });
+  });
+
+  describe('getEditorUrl', () => {
+    afterEach(() => {
+      delete process.env.CODE_SERVER_URL;
+    });
+
+    it('returns a deep link into the session worktree when configured', async () => {
+      process.env.CODE_SERVER_URL = 'https://host.ts.net:8443';
+      const session = await testPrisma.session.create({
+        data: {
+          name: 'Test Session',
+          repoUrl: 'https://github.com/owner/repo.git',
+          branch: 'main',
+          workspacePath: '/workspace/test',
+          repoPath: 'repo',
+          status: 'running',
+        },
+      });
+
+      const caller = createCaller('auth-session-id');
+      const result = await caller.sessions.getEditorUrl({ sessionId: session.id });
+
+      expect(result.url).toBe(
+        `https://host.ts.net:8443/?folder=${encodeURIComponent(`/worktrees/${session.id}/repo`)}`
+      );
+    });
+
+    it('returns null when CODE_SERVER_URL is not configured', async () => {
+      const session = await testPrisma.session.create({
+        data: {
+          name: 'Test Session',
+          workspacePath: '/workspace/test',
+          repoPath: 'repo',
+          status: 'running',
+        },
+      });
+
+      const caller = createCaller('auth-session-id');
+      const result = await caller.sessions.getEditorUrl({ sessionId: session.id });
+
+      expect(result.url).toBeNull();
+    });
+
+    it('returns null for an archived session even when configured', async () => {
+      process.env.CODE_SERVER_URL = 'https://host.ts.net:8443';
+      const session = await testPrisma.session.create({
+        data: {
+          name: 'Archived Session',
+          workspacePath: '/workspace/test',
+          repoPath: 'repo',
+          status: 'archived',
+        },
+      });
+
+      const caller = createCaller('auth-session-id');
+      const result = await caller.sessions.getEditorUrl({ sessionId: session.id });
+
+      expect(result.url).toBeNull();
+    });
+
+    it('throws NOT_FOUND for a non-existent session', async () => {
+      const caller = createCaller('auth-session-id');
+      await expect(
+        caller.sessions.getEditorUrl({ sessionId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11' })
+      ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    });
+
+    it('requires authentication', async () => {
+      const caller = createCaller(null);
+      await expect(
+        caller.sessions.getEditorUrl({ sessionId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11' })
       ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
     });
   });

--- a/src/server/routers/sessions.ts
+++ b/src/server/routers/sessions.ts
@@ -2,7 +2,13 @@ import { z } from 'zod';
 import { router, protectedProcedure } from '../trpc';
 import { prisma } from '@/lib/prisma';
 import { TRPCError } from '@trpc/server';
-import { cloneRepo, createEmptyWorkspace, removeWorkspace } from '../services/worktree-manager';
+import {
+  cloneRepo,
+  createEmptyWorkspace,
+  removeWorkspace,
+  getSessionWorkingDir,
+} from '../services/worktree-manager';
+import { buildEditorUrl } from '@/lib/editor-url';
 import {
   sendUserMessage,
   stopSession,
@@ -180,6 +186,33 @@ export const sessionsRouter = router({
       }
 
       return { session };
+    }),
+
+  // Deep link into a self-hosted code-server (browser VS Code) instance opened
+  // on this session's worktree folder. Returns { url: null } when the editor is
+  // not configured (CODE_SERVER_URL unset) or the session has no workspace on
+  // disk (archived), so the UI can hide the button.
+  getEditorUrl: protectedProcedure
+    .input(z.object({ sessionId: z.string().uuid() }))
+    .query(async ({ input }) => {
+      const session = await prisma.session.findUnique({
+        where: { id: input.sessionId },
+      });
+
+      if (!session) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Session not found',
+        });
+      }
+
+      // Archived sessions have their workspace removed from disk.
+      if (session.status === 'archived') {
+        return { url: null };
+      }
+
+      const workingDir = getSessionWorkingDir(session.id, session.repoPath);
+      return { url: buildEditorUrl(env.CODE_SERVER_URL, workingDir) };
     }),
 
   start: protectedProcedure


### PR DESCRIPTION
## What

Adds a low-maintenance way to **view and edit the files agents are working on**, by integrating a self-hosted [code-server](https://github.com/coder/code-server) (browser VS Code) rather than building a bespoke file browser/editor from scratch.

Each session's header gets an **"Open in VS Code"** button that deep-links straight into that session's worktree folder. code-server owns the entire editor experience (file tree, multi-file edit, integrated terminal, search, extensions); the app only contributes a single deep link.

## Why this approach

Chosen over building an in-app file browser (much more ongoing surface: path-traversal safety, editor state, save/diff UX, large files) and over VS Code Remote Tunnels (external Microsoft relay + separate GitHub/MS auth). code-server is fully self-hosted, matches the app's ethos, and stays on the tailnet — the same trust boundary as the app itself.

## How it works

- Each session's worktree is at a stable absolute path (`~/worktrees/{sessionId}/{repoName}`). code-server opens any folder via `?folder=<abs-path>`, so the button is just a link to `${CODE_SERVER_URL}/?folder=<workingDir>`.
- The link is built server-side by the pure `buildEditorUrl` and served by `sessions.getEditorUrl`, which resolves the absolute working dir with the same `getSessionWorkingDir` the runner uses — the client never needs the host's home dir.
- **Opt-in**: returns `{ url: null }` when `CODE_SERVER_URL` is unset (or the session is archived, workspace removed), and the button renders nothing. Server authoritative, UI dumb.

## Deployment

`scripts/setup-code-server.sh` installs code-server, points it at `~/worktrees`, gives it its own generated password, exposes it over **Tailscale Serve** on a dedicated HTTPS port, and prints the `CODE_SERVER_URL` to set. Edits made in code-server land directly in the session's clone, ready to commit/push.

## Changes

- `CODE_SERVER_URL` env config (`src/lib/env.ts`, `.env.example`)
- Pure `buildEditorUrl()` + unit tests (`src/lib/editor-url.ts`)
- `sessions.getEditorUrl` tRPC query
- `OpenInEditorButton` wired into `SessionHeader`
- `scripts/setup-code-server.sh`
- `doc/DESIGN.md` "Remote File Editing" section

## Testing

- `pnpm test:run src/lib/editor-url.test.ts` — 5 passing
- `pnpm exec tsc --noEmit` + eslint clean

Note: the host-side setup script (installing/exposing code-server) has **not** been run on the server — that's a deployment step for you to run and approve, since it stands up a new tailnet-exposed service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)