### PR TITLE
Add attachments to the initial prompt

### DIFF
--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -129,15 +129,26 @@ github.getIssue({ repoFullName: string, issueNumber: number })
 ```typescript
 sessions.create({
   name: string,
-  repoFullName?: string,   // e.g., "brendanlong/math-llm" — omit for no-repo sessions
-  branch?: string,         // omit for no-repo sessions
-  initialPrompt?: string   // Optional prompt to auto-send when session starts
+  repoFullName?: string,          // e.g., "brendanlong/math-llm" — omit for no-repo sessions
+  branch?: string,                // omit for no-repo sessions
+  initialPrompt?: string,         // Optional prompt to auto-send when session starts
+  hasInitialAttachments?: boolean // Set when the client will upload attachments for the
+                                  // initial prompt after create (see setInitialAttachments)
 })
   → { session: Session }
   // Returns immediately with session in "creating" status
   // Cloning continues in background (skipped for no-repo sessions)
   // UI polls session.get() to track progress via statusMessage
-  // If initialPrompt is provided, it is sent automatically server-side when session becomes running
+  // If initialPrompt is provided, it is sent automatically server-side when session becomes running.
+  // If hasInitialAttachments is set, the background setup waits (with a timeout) for the
+  // client's setInitialAttachments call before sending, so the prompt carries the files.
+
+sessions.setInitialAttachments({ sessionId: string, attachments: string[] })
+  → { success: true }
+  // Registers the storedNames of files uploaded (via POST /api/upload) for a session's
+  // initial prompt. Called by the new-session flow right after create + upload; unblocks
+  // the background setup so the initial prompt is prefixed with the attachment paths.
+  // See "Initial Prompt Attachments".
 
 sessions.list({ status?: SessionStatus })
   → { sessions: (Session & { turnActive: boolean })[] }
@@ -240,11 +251,12 @@ claude.getHistory({
 1. User selects repo and branch from UI (or "No Repository" for workspace-only sessions)
 2. Server calls `sessions.create()`
 3. Server creates session record with status `creating` and returns immediately
-4. UI navigates to session page, polls for status updates
-5. **For repo sessions**: Background: Server clones the repository to `/worktrees/{sessionId}/{repoName}`
+4. If files were attached to the initial prompt, the client uploads them to the (still `creating`) session and registers them via `sessions.setInitialAttachments()` (see [Initial Prompt Attachments](#initial-prompt-attachments)), then navigates. Otherwise it navigates immediately.
+5. UI navigates to session page, polls for status updates
+6. **For repo sessions**: Background: Server clones the repository to `/worktrees/{sessionId}/{repoName}`
    **For no-repo sessions**: Background: Server creates an empty directory at `/worktrees/{sessionId}/`
-6. Session status → `running`, statusMessage → null
-7. Background: If an initial prompt was provided, server sends it via `sendUserMessage()` (no client interaction needed)
+7. Session status → `running`, statusMessage → null
+8. Background: If an initial prompt was provided (or files were attached), server sends it via `sendUserMessage()` (no client interaction needed — for attachments it first waits for the client's registration, then prefixes the file paths)
 
 ### Interaction Flow
 
@@ -263,10 +275,21 @@ claude.getHistory({
 
 Users can attach files to a message. Files are stored in an `uploads/` folder inside the session's workspace (`/worktrees/{sessionId}/uploads/`), a **sibling of the repo clone** (`/worktrees/{sessionId}/{repoName}`) rather than inside it — so uploads are readable by Claude (running with the host's tools) but don't pollute the checkout's git status. Living in the workspace makes them durable for the life of the session and cleaned up automatically when the session is archived (the whole workspace is removed by `removeWorkspace`), so no separate reaper is needed.
 
-- **Upload transport**: a dedicated `POST /api/upload` route ([`src/app/api/upload/route.ts`](../src/app/api/upload/route.ts)) accepts `multipart/form-data` (fields `sessionId` + one or more `files`). A route (rather than a tRPC mutation) is used so binary bodies stream through `FormData` instead of being base64-inflated through superjson. It authenticates by reusing the tRPC `createContext` (same Bearer token), validates `sessionId` as a UUID, and only accepts uploads for a **running** session (the workspace exists only then). It returns the saved attachments (`{ name, storedName, path }`). Stored names are prefixed with a short random token so re-uploading the same filename never overwrites an earlier upload (no check-then-set), and file names are sanitized to a safe basename (`sanitizeFileName`), neutralizing path traversal. Implementation: [`src/server/services/uploads.ts`](../src/server/services/uploads.ts) (upload dir via `getSessionUploadDir` → `getSessionWorkspacePath`).
+- **Upload transport**: a dedicated `POST /api/upload` route ([`src/app/api/upload/route.ts`](../src/app/api/upload/route.ts)) accepts `multipart/form-data` (fields `sessionId` + one or more `files`). A route (rather than a tRPC mutation) is used so binary bodies stream through `FormData` instead of being base64-inflated through superjson. It authenticates by reusing the tRPC `createContext` (same Bearer token), validates `sessionId` as a UUID, and accepts uploads for a session that is **running** or **creating** (the latter for the new-session flow's initial-prompt attachments — see [Initial Prompt Attachments](#initial-prompt-attachments); the upload dir is `mkdir`ed on demand and a concurrent clone does not overwrite it since it is a sibling of the repo checkout). It returns the saved attachments (`{ name, storedName, path }`). Stored names are prefixed with a short random token so re-uploading the same filename never overwrites an earlier upload (no check-then-set), and file names are sanitized to a safe basename (`sanitizeFileName`), neutralizing path traversal. Implementation: [`src/server/services/uploads.ts`](../src/server/services/uploads.ts) (upload dir via `getSessionUploadDir` → `getSessionWorkspacePath`).
 - **Size / count limits**: because App Router route handlers have no built-in body-size limit, the route rejects on `Content-Length` before buffering, then enforces a per-file cap (`MAX_UPLOAD_BYTES`, 25 MB), an aggregate cap (`MAX_TOTAL_UPLOAD_BYTES`, 100 MB), and a file-count cap (`MAX_ATTACHMENTS`, 20 — shared with the `claude.send` schema so the two ceilings can't drift). Sizes are checked up front so a batch never writes partially.
 - **Uploads while Claude is working**: the attach control is not gated by `turnActive` — a user can upload files mid-turn. Uploaded files are held **client-side** as pending attachments (chips on the composer, via `useFileUpload`); they are **not** shown in the transcript until the message is sent, matching the requested UX.
 - **Prefixing the next message**: on submit the client passes the pending attachments' `storedName`s to `claude.send`. The server resolves them back to absolute paths (`resolveUploadPaths`, which `basename`s each name to re-neutralize traversal and drops any file no longer on disk), and the pure `buildPromptWithAttachments` ([`src/lib/attachments.ts`](../src/lib/attachments.ts)) prefixes the message with `[User uploaded file(s): /path/a.md, /path/b.png]`. The prefix is part of the persisted/sanitized user message, so the transcript reflects exactly what the model saw. A message may be sent with attachments and no typed text (the prefix is then the whole message). _Known limitation_: a file that has vanished from disk by send time (e.g. the session was archived between upload and send) is silently dropped from the prefix (logged) rather than erroring — durability makes this rare.
+
+### Initial Prompt Attachments
+
+The new-session form can attach files to the **initial prompt** — the same prefixing (`buildPromptWithAttachments`) as a normal message, but with a twist: the initial prompt is sent **server-side** after the background clone finishes (so it survives a client disconnect), while attachments can only be uploaded **after** the session (and its workspace) exists. A small in-memory **rendezvous** ([`src/server/services/initial-attachments.ts`](../src/server/services/initial-attachments.ts)) bridges the gap:
+
+1. The form holds the chosen files **raw** (`File[]`, not uploaded) — there is no workspace to upload to during form-fill. It reuses the shared `useFileUpload` hook (now taking `sessionId` per call, since the id is only known after create) and the shared `AttachmentChip`.
+2. On submit the client calls `sessions.create({ ..., hasInitialAttachments: true })`. Create **reserves** a rendezvous slot (`reserveInitialAttachments`) and passes a `waitForAttachments` flag into the background setup. Create returns immediately (unchanged), so the client navigates without waiting on the clone.
+3. The client uploads the files to the now-`creating` session (`POST /api/upload`, which accepts `creating`), then calls `sessions.setInitialAttachments({ sessionId, attachments: storedNames })` → `resolveInitialAttachments`.
+4. The background setup, after the clone completes and the session is marked `running`, **awaits** the registered stored names (`awaitInitialAttachments`, with a `INITIAL_ATTACHMENTS_TIMEOUT_MS` = 60 s cap), resolves them to absolute paths, and sends the initial prompt with the attachment prefix. It sends when there is prompt text **or** at least one attachment (so an attachments-only initial prompt works).
+
+The common ordering is register-before-await (upload is fast; the clone that gates the await is slow), so the await usually returns immediately. Because the send is server-owned once registered, it still fires even if the client disconnects after step 3. Graceful degradation: if the client abandons the flow after create (never registers), the await times out and the prompt is sent without attachments (or, if there was no prompt text, not at all); the reservation is also dropped if the clone fails (`clearInitialAttachments`). The rendezvous is in-memory only, so a server restart between create and register loses it — but a restart already loses the whole in-flight background setup, so this adds no new failure mode.
 
 ### System Prompt
 
@@ -706,6 +729,7 @@ Both source [`scripts/lib-code-server.sh`](../scripts/lib-code-server.sh) so the
 - Initial prompt (optional) — editable textarea, pre-filled when issue is selected
   - If provided, sent server-side after session setup completes (works even if client disconnects)
   - When omitted, session starts without a prompt (useful for voice mode)
+- Attachments (optional) — attach files to the initial prompt; held client-side until the session is created, then uploaded and prefixed onto the initial prompt (see [Initial Prompt Attachments](#initial-prompt-attachments))
 - Create button
 
 ### Session View (Chat)
@@ -756,6 +780,7 @@ clawed-abode/
 │   │   │   ├── github.ts         # GitHub API service
 │   │   │   ├── mcp-validator.ts  # MCP server config validation
 │   │   │   ├── uploads.ts        # Uploaded-file storage (workspace uploads/ dir) + path resolution
+│   │   │   ├── initial-attachments.ts # In-memory rendezvous for initial-prompt attachments
 │   │   │   └── session-reconciler.ts # Counts running sessions for lazy revive on restart
 │   │   └── trpc.ts
 │   ├── lib/
@@ -786,6 +811,7 @@ clawed-abode/
 │   └── components/
 │       ├── MessageList.tsx
 │       ├── PromptInput.tsx
+│       ├── AttachmentChip.tsx     # Shared pending-attachment chip (composer + new session)
 │       ├── SessionList.tsx
 │       ├── ConnectionStatusIndicator.tsx # "Reconnecting" banner when the SSE stream is down
 │       ├── Header.tsx

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -59,9 +59,12 @@ export async function POST(request: Request): Promise<Response> {
   if (!session) {
     return Response.json({ error: 'Session not found' }, { status: 404 });
   }
-  // Uploads target the session workspace, which only exists while running.
-  if (session.status !== 'running') {
-    return Response.json({ error: 'Session is not running' }, { status: 409 });
+  // Uploads target the session workspace. It exists once the session is running,
+  // and also during `creating` for the new-session flow's initial-prompt
+  // attachments — the upload dir is a sibling of the repo clone (created on
+  // demand) that the concurrent clone does not overwrite.
+  if (session.status !== 'running' && session.status !== 'creating') {
+    return Response.json({ error: 'Session is not accepting uploads' }, { status: 409 });
   }
 
   const files = formData.getAll('files').filter((f): f is File => f instanceof File);

--- a/src/app/new/page.tsx
+++ b/src/app/new/page.tsx
@@ -99,7 +99,10 @@ function NewSessionForm() {
 
   const handleRepoSelect = useCallback(
     (repo: Repo) => {
+      // selectRepo resets the rest of the form (name, prompt); clear the
+      // separately-held attachments too so nothing carries across the reset.
       dispatch({ type: 'selectRepo', repo });
+      setFiles([]);
     },
     [dispatch]
   );

--- a/src/app/new/page.tsx
+++ b/src/app/new/page.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useState, useCallback, useReducer } from 'react';
+import { useState, useCallback, useReducer, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
+import { Paperclip } from 'lucide-react';
 import { AuthGuard } from '@/components/AuthGuard';
 import { Header } from '@/components/Header';
 import { trpc } from '@/lib/trpc';
@@ -16,9 +17,12 @@ import { Spinner } from '@/components/ui/spinner';
 import { RepoSelector, NO_REPO_SENTINEL } from '@/components/RepoSelector';
 import { BranchSelector } from '@/components/BranchSelector';
 import { IssueSelector } from '@/components/IssueSelector';
+import { AttachmentChip } from '@/components/AttachmentChip';
+import { useFileUpload } from '@/hooks/useFileUpload';
 import type { Repo } from '@/components/RepoSelector';
 import type { Issue } from '@/lib/types';
 import { SESSION_NAME_MAX_LENGTH } from '@/lib/types';
+import { MAX_ATTACHMENTS } from '@/lib/attachments';
 import { formReducer, initialFormState } from './form-reducer';
 
 function generateIssuePrompt(issue: Issue, repoFullName: string): string {
@@ -50,18 +54,37 @@ function NewSessionForm() {
   const router = useRouter();
   const [form, dispatch] = useReducer(formReducer, initialFormState);
   const [error, setError] = useState('');
+  // Files chosen for the initial prompt. Held raw (not uploaded) until submit,
+  // since there is no session workspace to upload to until the session exists.
+  const [files, setFiles] = useState<File[]>([]);
+  // Covers the whole create → upload → register sequence (createMutation.isPending
+  // only spans the create call).
+  const [submitting, setSubmitting] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const isNoRepo = form.selectedRepo?.fullName === NO_REPO_SENTINEL;
   const hasRepo = form.selectedRepo && !isNoRepo;
 
-  const createMutation = trpc.sessions.create.useMutation({
-    onSuccess: (data) => {
-      router.replace(`/session/${data.session.id}`);
-    },
-    onError: (err) => {
-      setError(err.message);
-    },
-  });
+  const { upload } = useFileUpload();
+  const createMutation = trpc.sessions.create.useMutation();
+  const setInitialAttachmentsMutation = trpc.sessions.setInitialAttachments.useMutation();
+
+  const handleFilesSelected = useCallback((fileList: FileList | null) => {
+    if (!fileList || fileList.length === 0) return;
+    setError('');
+    setFiles((prev) => {
+      const combined = [...prev, ...Array.from(fileList)];
+      if (combined.length > MAX_ATTACHMENTS) {
+        setError(`You can attach at most ${MAX_ATTACHMENTS} files`);
+        return combined.slice(0, MAX_ATTACHMENTS);
+      }
+      return combined;
+    });
+  }, []);
+
+  const removeFile = useCallback((index: number) => {
+    setFiles((prev) => prev.filter((_, i) => i !== index));
+  }, []);
 
   const handleIssueSelect = useCallback(
     (issue: Issue | null) => {
@@ -102,7 +125,7 @@ function NewSessionForm() {
     [dispatch]
   );
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
 
@@ -120,18 +143,38 @@ function NewSessionForm() {
       isNoRepo ? 'Workspace' : `${form.selectedRepo.name} - ${form.selectedBranch}`
     ).slice(0, SESSION_NAME_MAX_LENGTH);
 
-    createMutation.mutate({
-      name: form.sessionName || defaultName,
-      repoFullName: isNoRepo ? undefined : form.selectedRepo.fullName,
-      branch: isNoRepo ? undefined : form.selectedBranch,
-      initialPrompt: form.initialPrompt.trim() || undefined,
-    });
+    setSubmitting(true);
+    try {
+      const { session } = await createMutation.mutateAsync({
+        name: form.sessionName || defaultName,
+        repoFullName: isNoRepo ? undefined : form.selectedRepo.fullName,
+        branch: isNoRepo ? undefined : form.selectedBranch,
+        initialPrompt: form.initialPrompt.trim() || undefined,
+        hasInitialAttachments: files.length > 0,
+      });
+
+      // Upload the initial prompt's files to the now-created session, then
+      // register their stored names so the background setup can prefix them
+      // onto the initial prompt once the workspace is ready.
+      if (files.length > 0) {
+        const uploaded = await upload(session.id, files);
+        await setInitialAttachmentsMutation.mutateAsync({
+          sessionId: session.id,
+          attachments: uploaded.map((a) => a.storedName),
+        });
+      }
+
+      router.replace(`/session/${session.id}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create session');
+      setSubmitting(false);
+    }
   };
 
   const canSubmit = isNoRepo || (hasRepo && !!form.selectedBranch);
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-6">
+    <form onSubmit={(e) => void handleSubmit(e)} className="space-y-6">
       {error && (
         <Alert variant="destructive">
           <AlertDescription>{error}</AlertDescription>
@@ -187,6 +230,43 @@ function NewSessionForm() {
               If provided, this prompt will be sent to Claude automatically when the session starts.
             </p>
           </div>
+
+          <div className="space-y-2">
+            <Label>Attachments (optional)</Label>
+            <input
+              ref={fileInputRef}
+              type="file"
+              multiple
+              className="hidden"
+              onChange={(e) => {
+                handleFilesSelected(e.currentTarget.files);
+                // Reset so selecting the same file again re-triggers onChange.
+                e.currentTarget.value = '';
+              }}
+            />
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={submitting || files.length >= MAX_ATTACHMENTS}
+              >
+                <Paperclip className="mr-1.5 h-4 w-4" />
+                Attach files
+              </Button>
+              {files.map((file, index) => (
+                <AttachmentChip
+                  key={`${file.name}-${index}`}
+                  name={file.name}
+                  onRemove={submitting ? undefined : () => removeFile(index)}
+                />
+              ))}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Files are uploaded when the session is created and referenced in the initial prompt.
+            </p>
+          </div>
         </>
       )}
 
@@ -194,8 +274,8 @@ function NewSessionForm() {
         <Button variant="outline" asChild>
           <Link href="/">Cancel</Link>
         </Button>
-        <Button type="submit" disabled={!canSubmit || createMutation.isPending}>
-          {createMutation.isPending ? (
+        <Button type="submit" disabled={!canSubmit || submitting}>
+          {submitting ? (
             <span className="flex items-center gap-2">
               <Spinner size="sm" className="text-primary-foreground" />
               Creating...

--- a/src/components/AttachmentChip.tsx
+++ b/src/components/AttachmentChip.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { Paperclip, X } from 'lucide-react';
+
+interface AttachmentChipProps {
+  /** File name to display. */
+  name: string;
+  /** Remove handler; the ✕ button is hidden when omitted. */
+  onRemove?: () => void;
+}
+
+/**
+ * A single pending-attachment chip (paperclip + truncated file name + optional
+ * remove button). Shared by the session composer and the new-session form so
+ * their attachment lists render identically.
+ */
+export function AttachmentChip({ name, onRemove }: AttachmentChipProps) {
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-md border bg-muted px-2 py-1 text-xs">
+      <Paperclip className="h-3 w-3 shrink-0 text-muted-foreground" />
+      <span className="max-w-[12rem] truncate" title={name}>
+        {name}
+      </span>
+      {onRemove && (
+        <button
+          type="button"
+          onClick={onRemove}
+          className="text-muted-foreground hover:text-foreground"
+          aria-label={`Remove ${name}`}
+        >
+          <X className="h-3 w-3" />
+        </button>
+      )}
+    </span>
+  );
+}

--- a/src/components/PromptInput.tsx
+++ b/src/components/PromptInput.tsx
@@ -7,6 +7,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { VoiceMicButton } from '@/components/voice/VoiceMicButton';
 import { useVoiceRecording } from '@/hooks/useVoiceRecording';
 import { useFileUpload } from '@/hooks/useFileUpload';
+import { AttachmentChip } from '@/components/AttachmentChip';
 import type { UploadedAttachment } from '@/lib/attachments';
 
 export interface SlashCommand {
@@ -48,7 +49,7 @@ export function PromptInput({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const commandsRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const { upload, uploading, error: uploadError, clearError } = useFileUpload(sessionId);
+  const { upload, uploading, error: uploadError, clearError } = useFileUpload();
 
   const {
     isRecording,
@@ -118,13 +119,13 @@ export function PromptInput({
       if (!fileList || fileList.length === 0) return;
       const files = Array.from(fileList);
       try {
-        const uploaded = await upload(files);
+        const uploaded = await upload(sessionId, files);
         setAttachments((prev) => [...prev, ...uploaded]);
       } catch {
         // Error is surfaced via uploadError; nothing else to do here.
       }
     },
-    [upload]
+    [upload, sessionId]
   );
 
   const removeAttachment = useCallback((storedName: string) => {
@@ -249,23 +250,11 @@ export function PromptInput({
         {(attachments.length > 0 || uploadError) && (
           <div className="mb-2 flex flex-wrap items-center gap-2">
             {attachments.map((att) => (
-              <span
+              <AttachmentChip
                 key={att.storedName}
-                className="inline-flex items-center gap-1.5 rounded-md border bg-muted px-2 py-1 text-xs"
-              >
-                <Paperclip className="h-3 w-3 shrink-0 text-muted-foreground" />
-                <span className="max-w-[12rem] truncate" title={att.name}>
-                  {att.name}
-                </span>
-                <button
-                  type="button"
-                  onClick={() => removeAttachment(att.storedName)}
-                  className="text-muted-foreground hover:text-foreground"
-                  aria-label={`Remove ${att.name}`}
-                >
-                  <X className="h-3 w-3" />
-                </button>
-              </span>
+                name={att.name}
+                onRemove={() => removeAttachment(att.storedName)}
+              />
             ))}
             {uploadError && (
               <span className="inline-flex items-center gap-1.5 text-xs text-destructive">

--- a/src/hooks/useFileUpload.ts
+++ b/src/hooks/useFileUpload.ts
@@ -9,16 +9,20 @@ interface UploadResponse {
 }
 
 /**
- * Uploads files to the session's upload directory via the `/api/upload` route.
+ * Uploads files to a session's upload directory via the `/api/upload` route.
  * Returns the saved attachments (name + stored name + absolute path) so the
  * caller can hold them as pending attachments until the next message is sent.
+ *
+ * `sessionId` is passed per call rather than bound to the hook so the same hook
+ * serves both the composer (known session) and the new-session flow (session id
+ * only known after create).
  */
-export function useFileUpload(sessionId: string) {
+export function useFileUpload() {
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const upload = useCallback(
-    async (files: File[]): Promise<UploadedAttachment[]> => {
+    async (sessionId: string, files: File[]): Promise<UploadedAttachment[]> => {
       if (files.length === 0) return [];
 
       setUploading(true);
@@ -52,7 +56,7 @@ export function useFileUpload(sessionId: string) {
         setUploading(false);
       }
     },
-    [sessionId]
+    []
   );
 
   return { upload, uploading, error, clearError: useCallback(() => setError(null), []) };

--- a/src/server/routers/sessions.ts
+++ b/src/server/routers/sessions.ts
@@ -15,12 +15,28 @@ import {
   cleanupSession,
   isClaudeRunning,
 } from '../services/claude-runner';
+import { resolveUploadPaths } from '../services/uploads';
+import {
+  reserveInitialAttachments,
+  resolveInitialAttachments,
+  awaitInitialAttachments,
+  clearInitialAttachments,
+} from '../services/initial-attachments';
 import { sseEvents } from '../services/events';
 import { createLogger, toError } from '@/lib/logger';
 import { env } from '@/lib/env';
 import { SESSION_NAME_MAX_LENGTH } from '@/lib/types';
+import { MAX_ATTACHMENTS } from '@/lib/attachments';
 
 const log = createLogger('sessions');
+
+/**
+ * How long the background setup waits for the client to register the initial
+ * prompt's uploaded attachments before sending the prompt without them. The
+ * client registers right after uploading (typically while the clone is still
+ * running), so this only bites when the client abandons the flow after create.
+ */
+const INITIAL_ATTACHMENTS_TIMEOUT_MS = 60_000;
 
 const sessionStatusSchema = z.enum(['creating', 'running', 'stopped', 'error', 'archived']);
 
@@ -30,9 +46,10 @@ async function setupSessionBackground(
   repoFullName: string | null,
   branch: string | null,
   initialPrompt: string | undefined,
+  waitForAttachments: boolean,
   githubToken?: string
 ): Promise<void> {
-  log.info('Starting session setup', { sessionId, repoFullName, branch });
+  log.info('Starting session setup', { sessionId, repoFullName, branch, waitForAttachments });
 
   const updateStatus = async (message: string) => {
     const session = await prisma.session.update({
@@ -75,15 +92,30 @@ async function setupSessionBackground(
 
     log.info('Session setup complete', { sessionId });
 
-    // Send the initial prompt if provided. sendUserMessage establishes the
-    // streaming query (loading settings internally) and pushes the prompt.
-    if (initialPrompt?.trim()) {
-      log.info('Sending initial prompt', { sessionId });
-      sendUserMessage(sessionId, initialPrompt.trim()).catch((err) => {
+    // If the initial prompt carries attachments, wait for the client to register
+    // the uploaded files (it does so right after create, usually while cloning
+    // was still running) before building the prompt. The workspace now exists, so
+    // resolve the stored names to absolute paths for the attachment prefix.
+    let attachmentPaths: string[] = [];
+    if (waitForAttachments) {
+      const storedNames = await awaitInitialAttachments(sessionId, INITIAL_ATTACHMENTS_TIMEOUT_MS);
+      attachmentPaths = await resolveUploadPaths(sessionId, storedNames);
+      log.info('Resolved initial attachments', { sessionId, count: attachmentPaths.length });
+    }
+
+    // Send the initial prompt if there is text or at least one attachment.
+    // sendUserMessage establishes the streaming query (loading settings
+    // internally), prefixes the attachment paths, and pushes the prompt.
+    const trimmedPrompt = initialPrompt?.trim() ?? '';
+    if (trimmedPrompt || attachmentPaths.length > 0) {
+      log.info('Sending initial prompt', { sessionId, attachments: attachmentPaths.length });
+      sendUserMessage(sessionId, trimmedPrompt, attachmentPaths).catch((err) => {
         log.error('Initial prompt failed', toError(err), { sessionId });
       });
     }
   } catch (error) {
+    // Drop any reserved rendezvous slot so a late register call doesn't leak.
+    clearInitialAttachments(sessionId);
     log.error('Session setup failed', toError(error), { sessionId, repoFullName, branch });
 
     const errorMessage = error instanceof Error ? error.message : 'Failed to create session';
@@ -109,11 +141,16 @@ export const sessionsRouter = router({
           .optional(),
         branch: z.string().min(1).optional(),
         initialPrompt: z.string().max(100000).optional(),
+        // Set when the client will upload attachments for the initial prompt
+        // after this call (see `setInitialAttachments`). The background setup
+        // then waits for those files before sending the initial prompt.
+        hasInitialAttachments: z.boolean().optional(),
       })
     )
     .mutation(async ({ input }) => {
       const githubToken = env.GITHUB_TOKEN;
       const hasRepo = !!input.repoFullName && !!input.branch;
+      const waitForAttachments = input.hasInitialAttachments ?? false;
 
       const session = await prisma.session.create({
         data: {
@@ -127,18 +164,50 @@ export const sessionsRouter = router({
         },
       });
 
+      // Reserve the rendezvous slot before starting setup so the background
+      // await and the client's register call meet on the same reservation
+      // regardless of which lands first.
+      if (waitForAttachments) {
+        reserveInitialAttachments(session.id);
+      }
+
       // Start setup in background
       setupSessionBackground(
         session.id,
         input.repoFullName ?? null,
         input.branch ?? null,
         input.initialPrompt,
+        waitForAttachments,
         githubToken
       ).catch((error) => {
         log.error('Unhandled error in session setup', toError(error), { sessionId: session.id });
       });
 
       return { session };
+    }),
+
+  // Register the uploaded attachments for a session's initial prompt. Called by
+  // the new-session flow right after uploading files (via /api/upload) to the
+  // freshly created session, so the background setup can prefix them onto the
+  // initial prompt once the workspace is ready.
+  setInitialAttachments: protectedProcedure
+    .input(
+      z.object({
+        sessionId: z.string().uuid(),
+        attachments: z.array(z.string().min(1).max(255)).min(1).max(MAX_ATTACHMENTS),
+      })
+    )
+    .mutation(async ({ input }) => {
+      const session = await prisma.session.findUnique({
+        where: { id: input.sessionId },
+        select: { id: true },
+      });
+      if (!session) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Session not found' });
+      }
+
+      resolveInitialAttachments(input.sessionId, input.attachments);
+      return { success: true };
     }),
 
   list: protectedProcedure

--- a/src/server/services/initial-attachments.test.ts
+++ b/src/server/services/initial-attachments.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import {
+  reserveInitialAttachments,
+  resolveInitialAttachments,
+  awaitInitialAttachments,
+  clearInitialAttachments,
+} from './initial-attachments';
+
+// Each test uses a distinct session id so the module-level map doesn't leak
+// state between cases.
+describe('initial-attachments rendezvous', () => {
+  it('returns stored names when resolved before the await (common case)', async () => {
+    const id = 'session-resolve-first';
+    reserveInitialAttachments(id);
+    resolveInitialAttachments(id, ['a.png', 'b.md']);
+
+    const result = await awaitInitialAttachments(id, 1000);
+    expect(result).toEqual(['a.png', 'b.md']);
+  });
+
+  it('returns stored names when resolved after the await starts', async () => {
+    const id = 'session-await-first';
+    reserveInitialAttachments(id);
+
+    const pending = awaitInitialAttachments(id, 1000);
+    resolveInitialAttachments(id, ['late.txt']);
+
+    expect(await pending).toEqual(['late.txt']);
+  });
+
+  it('returns an empty array when the timeout elapses first', async () => {
+    const id = 'session-timeout';
+    reserveInitialAttachments(id);
+
+    const result = await awaitInitialAttachments(id, 5);
+    expect(result).toEqual([]);
+  });
+
+  it('returns an empty array when no slot was reserved', async () => {
+    const result = await awaitInitialAttachments('session-never-reserved', 1000);
+    expect(result).toEqual([]);
+  });
+
+  it('resolve is a no-op when no slot was reserved', async () => {
+    // Should not throw; a later await still returns [] because the slot is gone.
+    resolveInitialAttachments('session-no-reserve', ['x']);
+    const result = await awaitInitialAttachments('session-no-reserve', 5);
+    expect(result).toEqual([]);
+  });
+
+  it('clear drops the reservation so a later await returns []', async () => {
+    const id = 'session-cleared';
+    reserveInitialAttachments(id);
+    clearInitialAttachments(id);
+
+    const result = await awaitInitialAttachments(id, 5);
+    expect(result).toEqual([]);
+  });
+
+  it('consumes the slot so a second await returns []', async () => {
+    const id = 'session-consumed';
+    reserveInitialAttachments(id);
+    resolveInitialAttachments(id, ['once.png']);
+
+    expect(await awaitInitialAttachments(id, 1000)).toEqual(['once.png']);
+    expect(await awaitInitialAttachments(id, 5)).toEqual([]);
+  });
+});

--- a/src/server/services/initial-attachments.ts
+++ b/src/server/services/initial-attachments.ts
@@ -1,0 +1,81 @@
+/**
+ * In-memory rendezvous for attachments on a session's initial prompt.
+ *
+ * A new session's workspace only exists after `sessions.create` starts cloning
+ * in the background, so the client can only upload the initial prompt's files
+ * *after* the session row exists. But the initial prompt is sent server-side
+ * once the clone completes (so it survives a client disconnect). This module
+ * bridges the two: `create` reserves a slot, the client registers the uploaded
+ * stored names once available, and the background setup awaits them (with a
+ * timeout) before sending the prompt with attachment paths.
+ *
+ * The common ordering is register-before-await (upload is fast; the clone that
+ * gates the await is slow), so `resolve` almost always lands first and the
+ * background's `await` returns immediately. The timeout covers the rare case
+ * where the client abandons the flow after `create` — the prompt is then sent
+ * without attachments rather than hanging forever.
+ */
+
+interface Reservation {
+  promise: Promise<string[]>;
+  resolve: (storedNames: string[]) => void;
+}
+
+const reservations = new Map<string, Reservation>();
+
+/**
+ * Reserve a rendezvous slot for a session whose initial prompt will carry
+ * attachments. Called from `create` before the background setup starts, so the
+ * slot exists whether the client registers or the background awaits first.
+ * Idempotent: re-reserving keeps the existing (possibly already-resolved) slot.
+ */
+export function reserveInitialAttachments(sessionId: string): void {
+  if (reservations.has(sessionId)) return;
+  let resolve!: (storedNames: string[]) => void;
+  const promise = new Promise<string[]>((r) => {
+    resolve = r;
+  });
+  reservations.set(sessionId, { promise, resolve });
+}
+
+/**
+ * Register the uploaded attachment stored names for a session's initial prompt,
+ * unblocking the background setup's `await`. A no-op if no slot was reserved
+ * (e.g. the session had no initial attachments) or it was already resolved.
+ */
+export function resolveInitialAttachments(sessionId: string, storedNames: string[]): void {
+  reservations.get(sessionId)?.resolve(storedNames);
+}
+
+/**
+ * Await the registered attachment stored names for a session, up to `timeoutMs`.
+ * Returns the stored names once registered, or an empty array if the timeout
+ * elapses first (the client never registered). Consumes the slot.
+ */
+export async function awaitInitialAttachments(
+  sessionId: string,
+  timeoutMs: number
+): Promise<string[]> {
+  const reservation = reservations.get(sessionId);
+  if (!reservation) return [];
+
+  let timer: NodeJS.Timeout | undefined;
+  const timeout = new Promise<string[]>((resolve) => {
+    timer = setTimeout(() => resolve([]), timeoutMs);
+  });
+
+  try {
+    return await Promise.race([reservation.promise, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+    reservations.delete(sessionId);
+  }
+}
+
+/**
+ * Drop a session's reservation without awaiting it. Used to clean up when the
+ * background setup fails before it reaches the await (e.g. the clone throws).
+ */
+export function clearInitialAttachments(sessionId: string): void {
+  reservations.delete(sessionId);
+}


### PR DESCRIPTION
## Summary

Adds the ability to attach files to the **initial prompt** when creating a new session — previously attachments were only possible on messages in a running session's composer.

### The problem

Uploads target a session's workspace (`~/worktrees/{sessionId}/uploads/`), which only exists once `sessions.create` has started cloning. But the initial prompt is sent **server-side** after the clone finishes (so it survives a client disconnect). So the client can only upload attachments *after* the session exists, yet the server owns the send — the two need to meet.

### The approach

A small in-memory **rendezvous** (`src/server/services/initial-attachments.ts`) bridges the gap:

1. The new-session form holds the chosen files **raw** (`File[]`) until submit — there's no workspace to upload to during form-fill.
2. On submit the client calls `sessions.create({ ..., hasInitialAttachments: true })`, which **reserves** a rendezvous slot and returns immediately.
3. The client uploads the files to the now-`creating` session (`POST /api/upload` now accepts `creating`), then registers the stored names via the new `sessions.setInitialAttachments`.
4. The background setup, after the clone + marking `running`, **awaits** the registered names (60s timeout), resolves them to paths, and sends the initial prompt with the `[User uploaded file(s): ...]` prefix.

The common ordering is register-before-await (upload is fast; the clone that gates the await is slow), so the await usually returns instantly. It degrades gracefully: if the client abandons the flow, the await times out and the prompt sends without attachments; a failed clone drops the reservation.

### Changes

- `initial-attachments.ts` — the rendezvous (reserve / resolve / await / clear) + unit tests
- `sessions.create` gains `hasInitialAttachments`; new `sessions.setInitialAttachments` mutation; background setup waits + prefixes
- `/api/upload` accepts `creating` sessions (uploads dir is a sibling of the clone, `mkdir`ed on demand, not overwritten by the concurrent clone)
- `useFileUpload` takes `sessionId` per call so it serves both the composer and the new-session flow
- extracted a shared `AttachmentChip` used by both the composer and the form
- `DESIGN.md` updated (new "Initial Prompt Attachments" section, API, flows, file structure)

### Testing

- `pnpm test:run` — 619 passing (7 new for the rendezvous)
- `pnpm tsc --noEmit` and `pnpm lint` clean (one pre-existing unrelated warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)