### PR TITLE
chore(deps): bump agent-input-sanitizer 1.4.10 → 1.34.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@trpc/next": "^11.17.0",
     "@trpc/react-query": "^11.17.0",
     "@trpc/server": "^11.17.0",
-    "agent-input-sanitizer": "1.4.10",
+    "agent-input-sanitizer": "1.34.0",
     "ansi-to-html": "^0.7.2",
     "argon2": "^0.43.1",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,8 +81,8 @@ importers:
         specifier: ^11.17.0
         version: 11.17.0(typescript@5.9.3)
       agent-input-sanitizer:
-        specifier: 1.4.10
-        version: 1.4.10
+        specifier: 1.34.0
+        version: 1.34.0
       ansi-to-html:
         specifier: ^0.7.2
         version: 0.7.2
@@ -2413,8 +2413,8 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
-  agent-input-sanitizer@1.4.10:
-    resolution: {integrity: sha512-Z4DeMxsHQD7VsqjEGwD+D59jWqLthvZJkNjojo6rHmSCar2TVH6nEKlf1YBHo3ZqPyT6L1blxVO2McgEBPqlWQ==}
+  agent-input-sanitizer@1.34.0:
+    resolution: {integrity: sha512-7DfWU+xTZ4Cq47foF85sfR8mgi1Ed0X20OamDCKbzQ6IrSc3CUlKIaupwh3BrFt1uYiNJlPJhkKu/gBYT4TCJA==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -4004,10 +4004,6 @@ packages:
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
-    engines: {node: '>=12'}
-
-  picomatch@4.0.5:
-    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
   pkce-challenge@5.0.1:
@@ -6593,7 +6589,7 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  agent-input-sanitizer@1.4.10:
+  agent-input-sanitizer@1.34.0:
     dependencies:
       rehype-parse: 9.0.1
       remark-gfm: 4.0.1
@@ -7483,10 +7479,6 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
-
-  fdir@6.5.0(picomatch@4.0.5):
-    optionalDependencies:
-      picomatch: 4.0.5
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -8567,8 +8559,6 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  picomatch@4.0.5: {}
-
   pkce-challenge@5.0.1: {}
 
   possible-typed-array-names@1.1.0: {}
@@ -9323,8 +9313,8 @@ snapshots:
   vite@7.3.1(@types/node@26.0.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
-      fdir: 6.5.0(picomatch@4.0.5)
-      picomatch: 4.0.5
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
       postcss: 8.5.16
       rollup: 4.62.2
       tinyglobby: 0.2.17


### PR DESCRIPTION
## What

Bumps the pinned `agent-input-sanitizer` dependency from **1.4.10** → **1.34.0** (current npm latest).

## Why

The pinned `1.4.10` stripped **legitimate emoji presentation selectors** (VS16, `U+FE0F`) as a `variation-selectors` payload. So an ordinary glyph like `⚠️` (`U+26A0 U+FE0F`) appearing in tool output — e.g. a repo's `SECURITY.md` version table — got flagged and rewritten by the `PostToolUse` sanitizer hook, and the agent saw a spurious *"Hidden or invisible content was automatically removed…"* note.

`1.34.0` includes the lone-presentation-selector carve-out: a VS16 following an `Extended_Pictographic` base (or a keycap base) is preserved.

### Verified against both versions

```
1.4.10:  sanitize('| 1.1.x | ⚠️ Best-effort |', { html: true })
         → found: ["variation-selectors"], VS16 dropped, text rewritten
1.34.0:  sanitize('| 1.1.x | ⚠️ Best-effort |', { html: true })
         → found: [], VS16 preserved, text unchanged
```

(This is the same false positive I hit while reviewing an unrelated plugin — see [agent-input-sanitizer#2](https://github.com/brendanlong/agent-input-sanitizer/issues/2).)

## Compatibility

- **No API changes.** `sanitize(text, { html: true })` still returns `{ cleaned, found, warnings }`, and the `found` category codes (`cf-format`, `variation-selectors`, `blank-fillers`, `ansi`, `lone-surrogates`, …) are identical across the two versions. `input-sanitizer.ts` / `sanitization.ts` need no changes.
- **No breaking changes** in the CHANGELOG across the `1.4.10 → 1.34.0` range (the only `BREAKING` entry — machine-readable `found` codes — predates `1.4.10`).
- Node engine requirement is unchanged (`>=22`).
- Lockfile diff is the bump plus a transitive `picomatch`/`fdir` dedup.

## Testing

- All 31 sanitizer-related tests pass: `input-sanitizer.test.ts`, `sanitization.test.ts`, `message-sanitization.test.ts`.
- End-to-end check through the installed package confirms `⚠️` now passes through untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)