### PR TITLE
Add per-session Claude model override

### DIFF
--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -42,7 +42,7 @@ The system runs **directly on the host** without containers:
 
 The database schema is defined in [`prisma/schema.prisma`](../prisma/schema.prisma). Key models:
 
-- **Session**: Claude Code sessions tied to git clones or standalone workspaces. `repoUrl` and `branch` are nullable — when null, the session has no repository (workspace-only). `lastActivityAt` drives session-list ordering and is bumped only on **user interactions** (sending a prompt, answering an AskUserQuestion / ExitPlanMode) — not on assistant/background traffic or lifecycle changes like stop/start — so the list orders by where the user last acted and doesn't shuffle while other sessions generate.
+- **Session**: Claude Code sessions tied to git clones or standalone workspaces. `repoUrl` and `branch` are nullable — when null, the session has no repository (workspace-only). `lastActivityAt` drives session-list ordering and is bumped only on **user interactions** (sending a prompt, answering an AskUserQuestion / ExitPlanMode) — not on assistant/background traffic or lifecycle changes like stop/start — so the list orders by where the user last acted and doesn't shuffle while other sessions generate. `claudeModel` is a nullable **per-session model override** — when set it takes precedence over the repo/global/env model (the highest-precedence layer of `resolveClaudeModel`); null (the default) means the session uses the repo/global/env default. It can be set at creation and changed later via `sessions.setModel`.
 - **Message**: Chat messages with sequence numbers for cursor-based pagination
 - **AuthSession**: Login sessions with tokens and audit info
 - **GlobalSettings**: Global application settings (system prompt override and append, Claude model, advisor model, Claude API key, TTS speed, voice auto-send)
@@ -133,7 +133,8 @@ sessions.create({
   name: string,
   repoFullName?: string,   // e.g., "brendanlong/math-llm" — omit for no-repo sessions
   branch?: string,         // omit for no-repo sessions
-  initialPrompt?: string   // Optional prompt to auto-send when session starts
+  initialPrompt?: string,  // Optional prompt to auto-send when session starts
+  claudeModel?: string     // Optional per-session model override (persisted on the session)
 })
   → { session: Session }
   // Returns immediately with session in "creating" status
@@ -161,6 +162,13 @@ sessions.rename({ sessionId: string, name: string })
   → { session: Session }
   // Renames a session (updates the display name only). The id, workspace, and
   // lastActivityAt are untouched — renaming does not reorder the session list.
+
+sessions.setModel({ sessionId: string, claudeModel: string | null })
+  → { session: Session }
+  // Sets (or clears, with null/empty) the per-session Claude model override. This is
+  // the highest-precedence layer of resolveClaudeModel (session → repo → global → env).
+  // Persisted on the session row, so it survives restarts; applied live to a running
+  // query on the next turn (refreshSessionSettings applies it immediately when idle).
 
 sessions.stop({ sessionId: string })
   → { session: Session }
@@ -682,7 +690,7 @@ Users can configure per-repository settings that are automatically applied when 
 
 - **Favorites**: Mark repositories (or "No Repository") as favorites so they appear at the top of the repo selector
 - **Custom System Prompt**: Additional instructions appended to the default system prompt for all sessions using this repository
-- **Claude Model**: Override the model for all sessions using this repository. Takes precedence over the global model and the `CLAUDE_MODEL` env var. Falls back to those when not set.
+- **Claude Model**: Override the model for all sessions using this repository. Takes precedence over the global model and the `CLAUDE_MODEL` env var, but is itself overridden by a per-session model (see [Per-Session Model Override](#per-session-model-override)). Falls back to those when not set.
 - **Environment Variables**: Custom env vars set for Claude sessions (e.g., API keys, config values)
 - **MCP Servers**: Configure [MCP servers](https://modelcontextprotocol.io/) for Claude to use, supporting three transport types:
   - **Stdio**: Traditional command-based servers (e.g., `npx @anthropic/mcp-server-memory`)
@@ -707,7 +715,7 @@ Users can configure per-repository settings that are automatically applied when 
 
 Users can configure global settings that apply to all sessions:
 
-- **Claude Model**: Override the `CLAUDE_MODEL` environment variable. Free-text field accepting model names like `opus`, `sonnet`, or full IDs like `claude-opus-4-6`. A per-repo model override (if set) takes precedence over this; otherwise this is used, falling back to the env var default when neither is set. Resolution order is `repo model → global model → CLAUDE_MODEL env var` (see `resolveClaudeModel` in `settings-merger.ts`).
+- **Claude Model**: Override the `CLAUDE_MODEL` environment variable. Free-text field accepting model names like `opus`, `sonnet`, or full IDs like `claude-opus-4-6`. A per-session or per-repo model override (if set) takes precedence over this; otherwise this is used, falling back to the env var default when neither is set. Resolution order is `session model → repo model → global model → CLAUDE_MODEL env var` (see `resolveClaudeModel` in `settings-merger.ts`).
 - **Advisor Model**: The model used by the server-side advisor tool (which Claude can consult for a second opinion mid-session). Uses the same free-text model selector as Claude Model. This is a global-only setting with **no env-var or per-repo layer**: the effective value is `global advisor model → null`, resolved by `resolveAdvisorModel` in `settings-merger.ts`. The advisor tool is **opt-in and disabled by default** — when no model is set the value resolves to null and the tool is not wired into requests at all; setting a model enables it (and picks which model it uses), and clearing it (Disable) turns the tool back off. `SUGGESTED_ADVISOR_MODEL` (`claude-fable-5`, in the dependency-free [`src/lib/advisor.ts`](../src/lib/advisor.ts) so both the server router and the client settings UI share one source of truth) is the model an empty **Enable → Save** adopts and the input placeholder — not a resolution fallback; the only way to reach the disabled state is the **Disable** button. The advisor model is a settings-schema field with no dedicated SDK option, so when set it is passed to the Claude Agent SDK as an ad-hoc `--settings` source via `Options.extraArgs` (`{ advisorModel }`) — the `settings` arg is omitted entirely when the advisor is disabled; see `buildSdkOptions` in `claude-runner.ts`. This only takes effect on a CLI/SDK version that actually implements the advisor tool: it wires the `advisor_20260301` server tool into each request (the `advisor-tool-2026-03-01` beta header is already sent unconditionally by the CLI). The dependency is pinned to an exact version (`@anthropic-ai/claude-agent-sdk` `0.3.196`) because earlier versions (e.g. `0.3.173`) ignore `advisorModel` entirely and `0.3.198` ships a dangling `SDKConversationResetMessage` type that degrades `SDKMessage` to `any` and breaks the `classifyMessage` exhaustiveness guard. To re-verify after a bump, capture the CLI's outgoing `/v1/messages` request (e.g. a logging proxy set via `ANTHROPIC_BASE_URL`) and check the `tools` array for `advisor_20260301`.
 - **Claude API Key**: Override the `CLAUDE_CODE_OAUTH_TOKEN` environment variable. Stored encrypted at rest. The actual value is never exposed to the UI — only a "configured" status is shown. Falls back to the env var when not set.
 - **Setting Sources**: Which Claude Code [scopes](https://code.claude.com/docs/en/settings#available-scopes) the SDK loads filesystem config (CLAUDE.md, **skills**, hooks, permissions) from, as three independent toggles — `user` (`~/.claude/`), `project` (`<cwd>/.claude/`), and `local` (`<cwd>/.claude/settings.local.json`). This is a **global-only** setting (no env-var or per-repo layer) with defaults matching the historical hardcoded behavior: only `project` on. Enabling `user` is what surfaces personal skills / a global CLAUDE.md / user hooks from the home directory of the account running the app; a repo can still ship skills via a committed `.claude/skills/` whenever `project` is on. Stored as three booleans on `GlobalSettings`; the pure `resolveSettingSources` ([`src/lib/setting-sources.ts`](../src/lib/setting-sources.ts), dependency-free so the router and settings UI share one source of truth) turns the flags into the SDK's ordered `settingSources` array (all-off yields `[]`, disabling all filesystem config). Because these scopes also load **hooks** (which execute) and permissions, widening them is a trust decision — `project` already carries the same property for a checked-out repo's `.claude/settings.json`. A settings-file `PostToolUse` hook **merges with** (does not displace) the app's programmatic tool-output sanitizer hook, so enabling a scope never silently disables sanitization — verified in both `user` and `project` scopes by `scripts/spike-hook-merge.ts`.
@@ -728,9 +736,17 @@ Users can configure global settings that apply to all sessions:
 
 - **Environment Variables**: Global env vars are included in all sessions. If a per-repo env var has the same name as a global one, the per-repo value takes precedence.
 - **MCP Servers**: Global MCP servers are included in all sessions. If a per-repo MCP server has the same name as a global one, the per-repo configuration takes precedence.
-- **Claude Model**: Resolved in precedence order `per-repo model → global model → CLAUDE_MODEL env var`.
+- **Claude Model**: Resolved in precedence order `per-session model → per-repo model → global model → CLAUDE_MODEL env var`.
 
-**Live vs. restart-bound settings.** Because a session's query is long-lived, settings are bound when the query is established. **Model and MCP servers** are re-applied live on the next `send` when they differ from what the query was built with (`query.setModel` / `query.setMcpServers`, gated by `mcpServersEqual`). **Environment variables, the system prompt, the advisor model, and the setting sources** are bound at construction and only take effect after a Stop→Start (which rebuilds the query with fresh settings) — the SDK exposes no live setter for these.
+### Per-Session Model Override
+
+Each session can pin its own Claude model, stored on the `Session.claudeModel` column and taking precedence over every other layer — it is the first argument of `resolveClaudeModel` (`session → repo → global → env`). The override is null by default, so a session runs with the repo/global/env default unless explicitly changed.
+
+- **Set at creation**: the New Session form has an optional model field (reusing `ModelOverrideField`); the value flows through `sessions.create` onto the new row.
+- **Changed later**: a per-session **gear button** in the session header (`SessionModelButton`, next to the "Open in VS Code" link) opens a panel to view/change/clear the override via `sessions.setModel`.
+- **Threading**: `establishSessionQuery` selects `claudeModel` and passes it to `loadMergedSessionSettings(settingsKey, sessionModel)`, which forwards it to `resolveClaudeModel`. Because the model is a **live-applicable** SDK setting (`query.setModel`), `applyLiveSettings` re-reads the session's `claudeModel` on each send, so changing it takes effect on the next turn without a Stop→Start. `sessions.setModel` additionally calls `refreshSessionSettings` to apply it immediately to an idle live query.
+
+**Live vs. restart-bound settings.** Because a session's query is long-lived, settings are bound when the query is established. **Model and MCP servers** are re-applied live on the next `send` when they differ from what the query was built with (`query.setModel` / `query.setMcpServers`, gated by `mcpServersEqual`) — this covers a change to the per-session, per-repo, or global model. **Environment variables, the system prompt, the advisor model, and the setting sources** are bound at construction and only take effect after a Stop→Start (which rebuilds the query with fresh settings) — the SDK exposes no live setter for these.
 
 **Configuration**: Go to Settings → System Prompt to manage prompt and model settings. Go to Settings → Audio to manage voice/audio settings (TTS speed, voice auto-send).
 
@@ -830,6 +846,7 @@ Both source [`scripts/lib-code-server.sh`](../scripts/lib-code-server.sh) so the
 - Initial prompt (optional) — editable textarea, pre-filled when issue is selected
   - If provided, sent server-side after session setup completes (works even if client disconnects)
   - When omitted, session starts without a prompt (useful for voice mode)
+- Claude model (optional) — a `ModelOverrideField` to pin a [per-session model](#per-session-model-override); defaults to the repo/global/env model and can be changed later from the session header
 - Create button
 
 ### Session View (Chat)
@@ -844,6 +861,7 @@ Both source [`scripts/lib-code-server.sh`](../scripts/lib-code-server.sh) so the
 - Session info in header (repo, branch)
 - Editable session title in header: click the name to rename inline (Enter saves, Escape cancels) via `sessions.rename` — see `EditableSessionName`
 - "Open in VS Code" button in the header (only when `CODE_SERVER_URL` is configured) that deep-links into the session's worktree in code-server — see [Remote File Editing](#remote-file-editing)
+- Per-session **gear** button in the header (`SessionModelButton`, next to the VS Code link, hidden for archived sessions) that opens a panel to view/change the [per-session Claude model override](#per-session-model-override) via `sessions.setModel`
 
 ## File Structure
 

--- a/prisma/migrations/20260714000000_add_session_claude_model/migration.sql
+++ b/prisma/migrations/20260714000000_add_session_claude_model/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Session" ADD COLUMN "claudeModel" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,6 +38,7 @@ model Session {
   archivedAt      DateTime? // When the session was archived (null if not archived)
   messageSequence Int       @default(0) // Monotonic counter for atomic message sequence assignment (next sequence to assign)
   sessionScope    String? // systemd user scope unit this session's CLI runs in; recorded so a crash-restart can reap the exact orphaned scope (null when not scoped / after clean teardown)
+  claudeModel     String? // If set, overrides the repo/global/env Claude model for this session only (highest precedence)
   messages        Message[]
 
   @@index([status])

--- a/src/app/new/form-reducer.test.ts
+++ b/src/app/new/form-reducer.test.ts
@@ -49,6 +49,7 @@ describe('formReducer', () => {
         nameManuallyEdited: true,
         initialPrompt: 'some prompt',
         promptManuallyEdited: true,
+        claudeModel: 'sonnet',
       };
 
       const result = formReducer(state, { type: 'selectRepo', repo: mockRepo2 });
@@ -61,6 +62,7 @@ describe('formReducer', () => {
         nameManuallyEdited: false,
         initialPrompt: '',
         promptManuallyEdited: false,
+        claudeModel: null,
       });
     });
 
@@ -99,6 +101,7 @@ describe('formReducer', () => {
         nameManuallyEdited: true,
         initialPrompt: 'my prompt',
         promptManuallyEdited: true,
+        claudeModel: null,
       };
 
       const result = formReducer(state, { type: 'selectBranch', branch: 'develop' });
@@ -312,6 +315,24 @@ describe('formReducer', () => {
 
       expect(result.initialPrompt).toBe('');
       expect(result.promptManuallyEdited).toBe(true);
+    });
+  });
+
+  describe('editModel', () => {
+    it('sets the per-session model override', () => {
+      const state: FormState = { ...initialFormState, selectedRepo: mockRepo };
+
+      const result = formReducer(state, { type: 'editModel', claudeModel: 'sonnet' });
+
+      expect(result.claudeModel).toBe('sonnet');
+    });
+
+    it('clears the override when set to null', () => {
+      const state: FormState = { ...initialFormState, claudeModel: 'sonnet' };
+
+      const result = formReducer(state, { type: 'editModel', claudeModel: null });
+
+      expect(result.claudeModel).toBeNull();
     });
   });
 

--- a/src/app/new/form-reducer.ts
+++ b/src/app/new/form-reducer.ts
@@ -9,6 +9,8 @@ export interface FormState {
   nameManuallyEdited: boolean;
   initialPrompt: string;
   promptManuallyEdited: boolean;
+  /** Per-session model override, or null to use the repo/global/env default. */
+  claudeModel: string | null;
 }
 
 export type FormAction =
@@ -16,7 +18,8 @@ export type FormAction =
   | { type: 'selectBranch'; branch: string }
   | { type: 'selectIssue'; issue: Issue | null; generatedPrompt?: string }
   | { type: 'editName'; name: string }
-  | { type: 'editPrompt'; prompt: string };
+  | { type: 'editPrompt'; prompt: string }
+  | { type: 'editModel'; claudeModel: string | null };
 
 export const initialFormState: FormState = {
   selectedRepo: null,
@@ -26,6 +29,7 @@ export const initialFormState: FormState = {
   nameManuallyEdited: false,
   initialPrompt: '',
   promptManuallyEdited: false,
+  claudeModel: null,
 };
 
 export function formReducer(state: FormState, action: FormAction): FormState {
@@ -62,5 +66,7 @@ export function formReducer(state: FormState, action: FormAction): FormState {
         initialPrompt: action.prompt,
         promptManuallyEdited: true,
       };
+    case 'editModel':
+      return { ...state, claudeModel: action.claudeModel };
   }
 }

--- a/src/app/new/page.tsx
+++ b/src/app/new/page.tsx
@@ -16,6 +16,8 @@ import { Spinner } from '@/components/ui/spinner';
 import { RepoSelector, NO_REPO_SENTINEL } from '@/components/RepoSelector';
 import { BranchSelector } from '@/components/BranchSelector';
 import { IssueSelector } from '@/components/IssueSelector';
+import { ModelOverrideField } from '@/components/settings/shared/ModelOverrideField';
+import { Cpu } from 'lucide-react';
 import type { Repo } from '@/components/RepoSelector';
 import type { Issue } from '@/lib/types';
 import { SESSION_NAME_MAX_LENGTH } from '@/lib/types';
@@ -53,6 +55,10 @@ function NewSessionForm() {
 
   const isNoRepo = form.selectedRepo?.fullName === NO_REPO_SENTINEL;
   const hasRepo = form.selectedRepo && !isNoRepo;
+
+  const { data: globalSettings } = trpc.globalSettings.get.useQuery();
+  const fallbackModel =
+    globalSettings?.claudeModel ?? globalSettings?.defaultClaudeModel ?? 'opus[1m]';
 
   const createMutation = trpc.sessions.create.useMutation({
     onSuccess: (data) => {
@@ -125,6 +131,7 @@ function NewSessionForm() {
       repoFullName: isNoRepo ? undefined : form.selectedRepo.fullName,
       branch: isNoRepo ? undefined : form.selectedBranch,
       initialPrompt: form.initialPrompt.trim() || undefined,
+      claudeModel: form.claudeModel ?? undefined,
     });
   };
 
@@ -185,6 +192,29 @@ function NewSessionForm() {
             />
             <p className="text-xs text-muted-foreground">
               If provided, this prompt will be sent to Claude automatically when the session starts.
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label className="flex items-center gap-1.5">
+              <Cpu className="h-4 w-4 text-muted-foreground" />
+              Claude model (optional)
+            </Label>
+            <ModelOverrideField
+              currentModel={form.claudeModel}
+              defaultModel={fallbackModel}
+              onSave={(model, onSuccess) => {
+                dispatch({ type: 'editModel', claudeModel: model });
+                onSuccess();
+              }}
+              isPending={false}
+              error={null}
+              setButtonLabel="Set Model"
+              emptyHint="(default)"
+            />
+            <p className="text-xs text-muted-foreground">
+              Overrides the model for this session only. You can change it later from the session
+              header.
             </p>
           </div>
         </>

--- a/src/components/SessionHeader.tsx
+++ b/src/components/SessionHeader.tsx
@@ -8,6 +8,7 @@ import { SessionActionButton } from '@/components/SessionActionButton';
 import { EditableSessionName } from '@/components/EditableSessionName';
 import { VoiceAutoReadToggle } from '@/components/voice/VoiceAutoReadToggle';
 import { OpenInEditorButton } from '@/components/OpenInEditorButton';
+import { SessionModelButton } from '@/components/SessionModelButton';
 
 interface SessionHeaderProps {
   session: {
@@ -18,6 +19,7 @@ interface SessionHeaderProps {
     status: string;
     statusMessage?: string | null;
     initialPrompt?: string | null;
+    claudeModel?: string | null;
   };
   onStart: () => void;
   onStop: () => void;
@@ -80,6 +82,12 @@ export function SessionHeader({
 
         <div className="flex flex-col items-end gap-1 shrink-0">
           <div className="flex items-center gap-1">
+            {session.status !== 'archived' && (
+              <SessionModelButton
+                sessionId={session.id}
+                claudeModel={session.claudeModel ?? null}
+              />
+            )}
             <OpenInEditorButton sessionId={session.id} />
             {voiceEnabled && onToggleVoiceMode && (
               <Button

--- a/src/components/SessionModelButton.tsx
+++ b/src/components/SessionModelButton.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useState } from 'react';
+import { Settings, Cpu } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import { ModelOverrideField } from '@/components/settings/shared/ModelOverrideField';
+import { trpc } from '@/lib/trpc';
+
+interface SessionModelButtonProps {
+  sessionId: string;
+  /** The session's current per-session model override, or null when none is set. */
+  claudeModel: string | null;
+}
+
+/**
+ * Per-session gear button in the session header. Opens a panel to view/change the
+ * session's Claude model override, which takes precedence over the repo/global/env
+ * model (see resolveClaudeModel) and persists on the session row.
+ */
+export function SessionModelButton({ sessionId, claudeModel }: SessionModelButtonProps) {
+  const [open, setOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const utils = trpc.useUtils();
+  const { data: globalSettings } = trpc.globalSettings.get.useQuery();
+
+  const mutation = trpc.sessions.setModel.useMutation({
+    onSuccess: () => {
+      void utils.sessions.get.invalidate({ sessionId });
+    },
+    onError: (err) => setError(err.message),
+  });
+
+  const fallbackModel =
+    globalSettings?.claudeModel ?? globalSettings?.defaultClaudeModel ?? 'opus[1m]';
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={() => setOpen(true)}
+        title="Session settings"
+        className="shrink-0 h-8 w-8"
+      >
+        <Settings className="h-4 w-4" />
+      </Button>
+
+      <Sheet open={open} onOpenChange={setOpen}>
+        <SheetContent className="w-full sm:max-w-lg overflow-y-auto">
+          <SheetHeader>
+            <SheetTitle>Session Settings</SheetTitle>
+            <SheetDescription>Settings that apply only to this session.</SheetDescription>
+          </SheetHeader>
+
+          <div className="mt-6 space-y-4">
+            <div className="flex items-center gap-2">
+              <Cpu className="h-4 w-4 text-muted-foreground" />
+              <h3 className="font-medium">Claude Model</h3>
+            </div>
+
+            <p className="text-sm text-muted-foreground">
+              Overrides the model for this session only. Takes precedence over the repo and global
+              models. Applies to the next turn.
+            </p>
+
+            <ModelOverrideField
+              currentModel={claudeModel}
+              defaultModel={fallbackModel}
+              onSave={(model, onSuccess) => {
+                setError(null);
+                mutation.mutate({ sessionId, claudeModel: model }, { onSuccess });
+              }}
+              isPending={mutation.isPending}
+              error={error}
+              setButtonLabel="Set Model"
+            />
+          </div>
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+}

--- a/src/server/routers/sessions.integration.test.ts
+++ b/src/server/routers/sessions.integration.test.ts
@@ -14,12 +14,15 @@ vi.mock('../services/worktree-manager', () => ({
 }));
 
 // Mock claude-runner
+const mockRefreshSessionSettings = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
 vi.mock('../services/claude-runner', () => ({
   sendUserMessage: vi.fn().mockResolvedValue(undefined),
   stopSession: vi.fn(),
   cleanupSession: vi.fn(),
   isClaudeRunning: vi.fn().mockReturnValue(false),
   isSessionBackgroundActive: vi.fn().mockReturnValue(false),
+  refreshSessionSettings: mockRefreshSessionSettings,
 }));
 
 // Mock settings-merger
@@ -130,6 +133,30 @@ describe('sessionsRouter integration', () => {
         where: { id: result.session.id },
       });
       expect(dbSession!.initialPrompt).toBe('Fix the bug in issue #123');
+    });
+
+    it('should store a per-session model override, trimmed', async () => {
+      const caller = createCaller('auth-session-id');
+      const result = await caller.sessions.create({
+        name: 'Model Session',
+        claudeModel: '  sonnet  ',
+      });
+
+      expect(result.session.claudeModel).toBe('sonnet');
+
+      const dbSession = await testPrisma.session.findUnique({
+        where: { id: result.session.id },
+      });
+      expect(dbSession!.claudeModel).toBe('sonnet');
+    });
+
+    it('should store null claudeModel when omitted or blank', async () => {
+      const caller = createCaller('auth-session-id');
+      const omitted = await caller.sessions.create({ name: 'No Model' });
+      const blank = await caller.sessions.create({ name: 'Blank Model', claudeModel: '   ' });
+
+      expect(omitted.session.claudeModel).toBeNull();
+      expect(blank.session.claudeModel).toBeNull();
     });
 
     it('should require authentication', async () => {
@@ -678,6 +705,123 @@ describe('sessionsRouter integration', () => {
         caller.sessions.rename({
           sessionId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
           name: 'New Name',
+        })
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('setModel', () => {
+    const createRunningSession = (claudeModel: string | null = null) =>
+      testPrisma.session.create({
+        data: {
+          name: 'Model Session',
+          workspacePath: '/workspace/test',
+          status: 'running',
+          claudeModel,
+        },
+      });
+
+    it('should set the per-session model override', async () => {
+      const session = await createRunningSession();
+
+      const caller = createCaller('auth-session-id');
+      const result = await caller.sessions.setModel({
+        sessionId: session.id,
+        claudeModel: 'sonnet',
+      });
+
+      expect(result.session.claudeModel).toBe('sonnet');
+
+      const dbSession = await testPrisma.session.findUnique({ where: { id: session.id } });
+      expect(dbSession!.claudeModel).toBe('sonnet');
+    });
+
+    it('should trim the model and collapse blank to null', async () => {
+      const session = await createRunningSession('opus');
+
+      const caller = createCaller('auth-session-id');
+      const trimmed = await caller.sessions.setModel({
+        sessionId: session.id,
+        claudeModel: '  haiku  ',
+      });
+      expect(trimmed.session.claudeModel).toBe('haiku');
+
+      const cleared = await caller.sessions.setModel({
+        sessionId: session.id,
+        claudeModel: '   ',
+      });
+      expect(cleared.session.claudeModel).toBeNull();
+    });
+
+    it('should clear the override with null', async () => {
+      const session = await createRunningSession('opus');
+
+      const caller = createCaller('auth-session-id');
+      const result = await caller.sessions.setModel({
+        sessionId: session.id,
+        claudeModel: null,
+      });
+
+      expect(result.session.claudeModel).toBeNull();
+    });
+
+    it('should apply the change to the live query', async () => {
+      const session = await createRunningSession();
+      mockRefreshSessionSettings.mockClear();
+
+      const caller = createCaller('auth-session-id');
+      await caller.sessions.setModel({ sessionId: session.id, claudeModel: 'sonnet' });
+
+      expect(mockRefreshSessionSettings).toHaveBeenCalledWith(session.id);
+    });
+
+    it('should emit a session update event', async () => {
+      const session = await createRunningSession();
+      mockSseEvents.emitSessionUpdate.mockClear();
+
+      const caller = createCaller('auth-session-id');
+      await caller.sessions.setModel({ sessionId: session.id, claudeModel: 'sonnet' });
+
+      expect(mockSseEvents.emitSessionUpdate).toHaveBeenCalledWith(
+        session.id,
+        expect.objectContaining({ claudeModel: 'sonnet' })
+      );
+    });
+
+    it('should reject changing the model of an archived session', async () => {
+      const session = await testPrisma.session.create({
+        data: {
+          name: 'Archived',
+          workspacePath: '/workspace/test',
+          status: 'archived',
+          archivedAt: new Date(),
+        },
+      });
+
+      const caller = createCaller('auth-session-id');
+      await expect(
+        caller.sessions.setModel({ sessionId: session.id, claudeModel: 'sonnet' })
+      ).rejects.toMatchObject({ code: 'PRECONDITION_FAILED' });
+    });
+
+    it('should throw NOT_FOUND for non-existent session', async () => {
+      const caller = createCaller('auth-session-id');
+
+      await expect(
+        caller.sessions.setModel({
+          sessionId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+          claudeModel: 'sonnet',
+        })
+      ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    });
+
+    it('should require authentication', async () => {
+      const caller = createCaller(null);
+
+      await expect(
+        caller.sessions.setModel({
+          sessionId: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+          claudeModel: 'sonnet',
         })
       ).rejects.toThrow();
     });

--- a/src/server/routers/sessions.ts
+++ b/src/server/routers/sessions.ts
@@ -317,6 +317,14 @@ export const sessionsRouter = router({
         });
       }
 
+      // Archived sessions are read-only (workspace removed, no live query).
+      if (session.status === 'archived') {
+        throw new TRPCError({
+          code: 'PRECONDITION_FAILED',
+          message: 'Cannot change the model of an archived session',
+        });
+      }
+
       const model = input.claudeModel?.trim() || null;
 
       const updatedSession = await prisma.session.update({

--- a/src/server/routers/sessions.ts
+++ b/src/server/routers/sessions.ts
@@ -15,6 +15,7 @@ import {
   cleanupSession,
   isClaudeRunning,
   isSessionBackgroundActive,
+  refreshSessionSettings,
 } from '../services/claude-runner';
 import { sseEvents } from '../services/events';
 import { createLogger, toError } from '@/lib/logger';
@@ -110,6 +111,7 @@ export const sessionsRouter = router({
           .optional(),
         branch: z.string().min(1).optional(),
         initialPrompt: z.string().max(100000).optional(),
+        claudeModel: z.string().max(200).optional(),
       })
     )
     .mutation(async ({ input }) => {
@@ -125,6 +127,7 @@ export const sessionsRouter = router({
           status: 'creating',
           statusMessage: hasRepo ? 'Cloning repository...' : 'Creating workspace...',
           initialPrompt: input.initialPrompt,
+          claudeModel: input.claudeModel?.trim() || null,
         },
       });
 
@@ -286,6 +289,43 @@ export const sessionsRouter = router({
         where: { id: session.id },
         data: { name: input.name },
       });
+
+      sseEvents.emitSessionUpdate(input.sessionId, updatedSession);
+      return { session: updatedSession };
+    }),
+
+  // Set the per-session Claude model override (highest precedence — see
+  // resolveClaudeModel). Pass null/empty to clear (reverts to repo/global/env
+  // model). Persisted, so it survives restarts; applied live to a running query
+  // on the next turn (refreshSessionSettings applies it now if idle).
+  setModel: protectedProcedure
+    .input(
+      z.object({
+        sessionId: z.string().uuid(),
+        claudeModel: z.string().max(200).nullable(),
+      })
+    )
+    .mutation(async ({ input }) => {
+      const session = await prisma.session.findUnique({
+        where: { id: input.sessionId },
+      });
+
+      if (!session) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Session not found',
+        });
+      }
+
+      const model = input.claudeModel?.trim() || null;
+
+      const updatedSession = await prisma.session.update({
+        where: { id: session.id },
+        data: { claudeModel: model },
+      });
+
+      // Apply to the live query now (no-op if the session isn't running).
+      await refreshSessionSettings(input.sessionId);
 
       sseEvents.emitSessionUpdate(input.sessionId, updatedSession);
       return { session: updatedSession };

--- a/src/server/services/claude-runner.ts
+++ b/src/server/services/claude-runner.ts
@@ -1089,7 +1089,7 @@ async function establishSessionQuery(
 ): Promise<SessionState> {
   const session = await prisma.session.findUnique({
     where: { id: sessionId },
-    select: { repoUrl: true, repoPath: true },
+    select: { repoUrl: true, repoPath: true, claudeModel: true },
   });
   if (!session) {
     throw new Error('Session not found');
@@ -1097,7 +1097,7 @@ async function establishSessionQuery(
 
   const repoFullName = session.repoUrl ? extractRepoFullName(session.repoUrl) : null;
   const settingsKey = repoFullName ?? '__no_repo__';
-  const settings = await loadMergedSessionSettings(settingsKey);
+  const settings = await loadMergedSessionSettings(settingsKey, session.claudeModel);
   const workingDir = getSessionWorkingDir(sessionId, session.repoPath);
 
   const shouldResume = (await prisma.message.count({ where: { sessionId } })) > 0;
@@ -1176,7 +1176,13 @@ async function applyLiveSettings(sessionId: string, state: SessionState): Promis
   if (!state.query || !state.boundSettings) return;
   let settings: MergedSessionSettings;
   try {
-    settings = await loadMergedSessionSettings(state.settingsKey);
+    // Re-read the per-session model override too, so changing it (via
+    // sessions.setModel) applies live on the next turn like repo/global changes.
+    const session = await prisma.session.findUnique({
+      where: { id: sessionId },
+      select: { claudeModel: true },
+    });
+    settings = await loadMergedSessionSettings(state.settingsKey, session?.claudeModel);
   } catch (err) {
     log.debug('applyLiveSettings: failed to load settings', {
       sessionId,
@@ -1499,6 +1505,18 @@ export async function stopBackgroundTask(sessionId: string, taskId: string): Pro
 /** Whether a main-agent turn is active for a session (in-memory check). */
 export function isClaudeRunning(sessionId: string): boolean {
   return sessions.get(sessionId)?.status.turnActive ?? false;
+}
+
+/**
+ * Apply live settings (model / MCP servers) to a session's running query now, if
+ * one exists. Used after persisting a per-session model change so it takes effect
+ * without waiting for the next send. A no-op when the session has no live query —
+ * the change is picked up on the next establish/send anyway. Best-effort.
+ */
+export async function refreshSessionSettings(sessionId: string): Promise<void> {
+  const state = sessions.get(sessionId);
+  if (!state?.query) return;
+  await applyLiveSettings(sessionId, state);
 }
 
 /**

--- a/src/server/services/settings-merger.test.ts
+++ b/src/server/services/settings-merger.test.ts
@@ -9,21 +9,29 @@ import {
 import type { ContainerEnvVar, ContainerMcpServer } from './repo-settings';
 
 describe('resolveClaudeModel', () => {
-  it('prefers the per-repo model over global and env', () => {
-    expect(resolveClaudeModel('repo-model', 'global-model', 'env-model')).toBe('repo-model');
+  it('prefers the per-session model over repo, global, and env', () => {
+    expect(resolveClaudeModel('session-model', 'repo-model', 'global-model', 'env-model')).toBe(
+      'session-model'
+    );
   });
 
-  it('falls back to the global model when no repo override', () => {
-    expect(resolveClaudeModel(null, 'global-model', 'env-model')).toBe('global-model');
-    expect(resolveClaudeModel(undefined, 'global-model', 'env-model')).toBe('global-model');
+  it('falls back to the per-repo model when no session override', () => {
+    expect(resolveClaudeModel(null, 'repo-model', 'global-model', 'env-model')).toBe('repo-model');
+    expect(resolveClaudeModel(undefined, 'repo-model', 'global-model', 'env-model')).toBe(
+      'repo-model'
+    );
   });
 
-  it('falls back to the env model when neither repo nor global is set', () => {
-    expect(resolveClaudeModel(null, null, 'env-model')).toBe('env-model');
+  it('falls back to the global model when no session or repo override', () => {
+    expect(resolveClaudeModel(null, null, 'global-model', 'env-model')).toBe('global-model');
+  });
+
+  it('falls back to the env model when neither session, repo, nor global is set', () => {
+    expect(resolveClaudeModel(null, null, null, 'env-model')).toBe('env-model');
   });
 
   it('returns undefined when nothing is set', () => {
-    expect(resolveClaudeModel(null, null, undefined)).toBeUndefined();
+    expect(resolveClaudeModel(null, null, null, undefined)).toBeUndefined();
   });
 });
 

--- a/src/server/services/settings-merger.ts
+++ b/src/server/services/settings-merger.ts
@@ -28,7 +28,8 @@ export interface MergedSessionSettings {
  * and merges env vars and MCP servers.
  */
 export async function loadMergedSessionSettings(
-  repoFullName: string | null | undefined
+  repoFullName: string | null | undefined,
+  sessionModel?: string | null | undefined
 ): Promise<MergedSessionSettings> {
   const [repoSettings, globalSettings] = await Promise.all([
     repoFullName ? getRepoSettingsForContainer(repoFullName) : null,
@@ -48,6 +49,7 @@ export async function loadMergedSessionSettings(
     envVars,
     mcpServers,
     claudeModel: resolveClaudeModel(
+      sessionModel,
       repoSettings?.claudeModel,
       globalSettings.claudeModel,
       env.CLAUDE_MODEL
@@ -62,14 +64,15 @@ export async function loadMergedSessionSettings(
 
 /**
  * Resolve the effective Claude model, in precedence order:
- * per-repo override → global override → CLAUDE_MODEL env var.
+ * per-session override → per-repo override → global override → CLAUDE_MODEL env var.
  */
 export function resolveClaudeModel(
+  sessionModel: string | null | undefined,
   repoModel: string | null | undefined,
   globalModel: string | null | undefined,
   envModel: string | undefined
 ): string | undefined {
-  return repoModel ?? globalModel ?? envModel;
+  return sessionModel ?? repoModel ?? globalModel ?? envModel;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds a **per-session Claude model override**, stored in the database, so each session starts with the default model but can be persistently changed to another. It's settable at session creation and changeable later from a new per-session gear button in the session header (next to the "Open in VS Code" link).

## How it works

- New nullable `Session.claudeModel` column (+ migration).
- `resolveClaudeModel` gains a top-precedence `sessionModel` arg: **session → repo → global → env**. `loadMergedSessionSettings(repoFullName, sessionModel)` threads it through.
- `establishSessionQuery` selects `claudeModel` and passes it in; `applyLiveSettings` re-reads it on each send, so a change applies **live on the next turn** via `query.setModel` (no Stop→Start needed). `sessions.setModel` also calls a new `refreshSessionSettings` to apply immediately to an idle live query.
- API: `sessions.create` accepts an optional `claudeModel`; new `sessions.setModel({ sessionId, claudeModel })` sets/clears it.
- UI: the New Session form gains an optional model field (reusing `ModelOverrideField`); a new `SessionModelButton` (gear icon) in the header opens a panel to view/change/clear the override.

## Tests

- Updated `resolveClaudeModel` unit tests for the new signature + session-precedence cases.
- Added `editModel` reducer tests; updated form-reducer state fixtures.
- Full suite (unit + component + integration) passes.

DESIGN.md updated throughout (data model, API, settings resolution, new "Per-Session Model Override" section, UI screens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)