### PR TITLE
Disable single-tilde strikethrough in markdown rendering

### DIFF
--- a/src/components/MarkdownContent.test.tsx
+++ b/src/components/MarkdownContent.test.tsx
@@ -30,14 +30,17 @@ describe('MarkdownContent', () => {
     expect(screen.getByText('italic')).toBeInTheDocument();
   });
 
-  it('does not render strikethrough, keeping tildes literal', () => {
-    // Claude uses `~` to mean "approximately", so `~5` and `~~x~~` must not
-    // become strikethrough.
-    const { container } = render(<MarkdownContent content="It takes ~5 minutes and ~~10~~." />);
+  it('keeps single tildes literal (Claude uses `~` to mean "approximately")', () => {
+    const { container } = render(<MarkdownContent content="It takes ~5 minutes." />);
     expect(container.querySelector('del')).toBeNull();
-    expect(container.querySelector('s')).toBeNull();
     expect(container.textContent).toContain('~5 minutes');
-    expect(container.textContent).toContain('~~10~~');
+  });
+
+  it('still renders double-tilde strikethrough', () => {
+    const { container } = render(<MarkdownContent content="This is ~~struck~~." />);
+    const del = container.querySelector('del');
+    expect(del).not.toBeNull();
+    expect(del?.textContent).toBe('struck');
   });
 
   it('renders code blocks', () => {

--- a/src/components/MarkdownContent.test.tsx
+++ b/src/components/MarkdownContent.test.tsx
@@ -30,6 +30,16 @@ describe('MarkdownContent', () => {
     expect(screen.getByText('italic')).toBeInTheDocument();
   });
 
+  it('does not render strikethrough, keeping tildes literal', () => {
+    // Claude uses `~` to mean "approximately", so `~5` and `~~x~~` must not
+    // become strikethrough.
+    const { container } = render(<MarkdownContent content="It takes ~5 minutes and ~~10~~." />);
+    expect(container.querySelector('del')).toBeNull();
+    expect(container.querySelector('s')).toBeNull();
+    expect(container.textContent).toContain('~5 minutes');
+    expect(container.textContent).toContain('~~10~~');
+  });
+
   it('renders code blocks', () => {
     render(<MarkdownContent content={'```js\nconst x = 1;\n```'} />);
     // Code blocks contain the language identifier and code

--- a/src/components/MarkdownContent.tsx
+++ b/src/components/MarkdownContent.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMemo } from 'react';
-import { marked, Renderer } from 'marked';
+import { marked, Renderer, type Tokens } from 'marked';
 import DOMPurify from 'dompurify';
 
 interface MarkdownContentProps {
@@ -23,13 +23,21 @@ marked.setOptions({
   renderer,
 });
 
-// Disable strikethrough (`~text~` / `~~text~~`). Claude uses `~` to mean
-// "approximately" far more often than for strikethrough, so we treat tildes as
-// literal text by having the `del` inline tokenizer never match.
+// Only allow double-tilde strikethrough (`~~text~~`). Claude uses a single `~`
+// to mean "approximately" (e.g. `~5 minutes`) far more often than for
+// strikethrough, so override the `del` inline tokenizer to match `~~…~~` only
+// and leave single tildes as literal text.
 marked.use({
   tokenizer: {
-    del(): undefined {
-      return undefined;
+    del(src: string): Tokens.Del | undefined {
+      const match = /^~~(?=\S)([\s\S]*?\S)~~/.exec(src);
+      if (!match) return undefined;
+      return {
+        type: 'del',
+        raw: match[0],
+        text: match[1],
+        tokens: this.lexer.inlineTokens(match[1]),
+      };
     },
   },
 });

--- a/src/components/MarkdownContent.tsx
+++ b/src/components/MarkdownContent.tsx
@@ -23,6 +23,17 @@ marked.setOptions({
   renderer,
 });
 
+// Disable strikethrough (`~text~` / `~~text~~`). Claude uses `~` to mean
+// "approximately" far more often than for strikethrough, so we treat tildes as
+// literal text by having the `del` inline tokenizer never match.
+marked.use({
+  tokenizer: {
+    del(): undefined {
+      return undefined;
+    },
+  },
+});
+
 export function MarkdownContent({ content, className = '' }: MarkdownContentProps) {
   const html = useMemo(() => {
     try {


### PR DESCRIPTION
## Summary

Claude uses a single `~` to mean "approximately" (e.g. `~5 minutes`) far more often than it uses it for strikethrough, but marked's GFM strikethrough was rendering `~text~` as struck-through.

This overrides marked's `del` inline tokenizer to match **only** double-tilde strikethrough (`~~text~~`). Single tildes are now left as literal text, while intentional `~~strikethrough~~` still works. All other GFM features are unaffected.

## Testing

- `~5 minutes` renders literally with no `<del>`.
- `~~struck~~` still renders as `<del>struck</del>`.
- `pnpm test:component MarkdownContent` passes (9 tests); typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)